### PR TITLE
Center camera in 3D Tetris board

### DIFF
--- a/tetris_3d.html
+++ b/tetris_3d.html
@@ -186,8 +186,8 @@
 
             init() {
                 // Setup camera
-                this.camera.position.set(0, 10, 15);
-                this.camera.lookAt(0, 0, 0);
+                this.camera.position.set(0, this.boardHeight / 2, 15);
+                this.camera.lookAt(0, this.boardHeight / 2, 0);
 
                 // Add lighting
                 const ambientLight = new THREE.AmbientLight(0x404040, 0.4);


### PR DESCRIPTION
## Summary
- adjust camera `lookAt` to the middle of the board so newly spawned pieces are visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68863b11e8cc83228930fcc0f1bd382c