### PR TITLE
Move rating UI to index and prevent duplicate votes

### DIFF
--- a/functions/api/rate.ts
+++ b/functions/api/rate.ts
@@ -7,6 +7,15 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
 
   const ip = request.headers.get("CF-Connecting-IP") ?? "0.0.0.0";
 
+  const existing = await env.DB
+    .prepare("SELECT 1 FROM ratings WHERE game_id = ?1 AND ip = ?2;")
+    .bind(gameId, ip)
+    .first();
+
+  if (existing) {
+    return new Response("Already rated", { status: 409 });
+  }
+
   await env.DB
     .prepare("INSERT INTO ratings (game_id, stars, ip) VALUES (?1, ?2, ?3);")
     .bind(gameId, stars, ip)

--- a/functions/api/ratings/[id].ts
+++ b/functions/api/ratings/[id].ts
@@ -1,13 +1,21 @@
-export const onRequestGet: PagesFunction = async ({ params, env }) => {
+export const onRequestGet: PagesFunction = async ({ params, env, request }) => {
   const gameId = params!.id as string;
+
+  const ip = request.headers.get("CF-Connecting-IP") ?? "0.0.0.0";
 
   const { count, avg } = await env.DB
     .prepare("SELECT COUNT(*) count, AVG(stars) avg FROM ratings WHERE game_id = ?1;")
     .bind(gameId)
     .first() as { count: number; avg: number };
 
+  const mineRow = await env.DB
+    .prepare("SELECT stars FROM ratings WHERE game_id = ?1 AND ip = ?2;")
+    .bind(gameId, ip)
+    .first<{ stars: number }>();
+
   return Response.json({
     votes: count ?? 0,
     average: avg ? Number(avg).toFixed(2) : 0,
+    mine: mineRow?.stars ?? null,
   });
 };

--- a/index.html
+++ b/index.html
@@ -78,6 +78,16 @@
             text-decoration: underline;
             color: #ffffff;
         }
+        .rate span {
+            cursor: pointer;
+            color: gold;
+        }
+        .rate span.selected {
+            color: orange;
+        }
+        .score {
+            margin-left: 8px;
+        }
     </style>
 </head>
 <body>
@@ -88,6 +98,14 @@
             <h2>Featured Game: 🧩 Physics Puzzle Platformer</h2>
             <p>Navigate through challenging levels using realistic physics! Collect gems, jump on moving platforms, and solve puzzles to reach the exit portal. A brain-teasing adventure awaits!</p>
             <a href="physics_puzzle.html" class="play-btn">Play Now!</a>
+            <div class="rate" data-id="physics-puzzle">
+                <span data-star="1">★</span>
+                <span data-star="2">★</span>
+                <span data-star="3">★</span>
+                <span data-star="4">★</span>
+                <span data-star="5">★</span>
+            </div>
+            <span class="score"></span>
         </div>
         
         <!-- Advertisement -->
@@ -106,16 +124,108 @@
         </div>
         
         <h2>More Games</h2>
-        <ul>
-            <li><a href="snake_game.html">Snake Game</a></li>
-            <li><a href="tetris_3d.html">3D Tetris</a></li>
-            <li><a href="space_shooter.html">Space Shooter</a></li>
-            <li><a href="word_scramble.html">Word Scramble Adventure</a></li>
-            <li><a href="memory_match.html">Memory Match Game</a></li>
-            <li><a href="number_guessing.html">Number Guessing Game</a></li>
-            <li><a href="rock_paper_scissors.html">Rock Paper Scissors</a></li>
+        <ul id="games">
+            <li data-id="snake-game"><a href="snake_game.html">Snake Game</a>
+                <div class="rate">
+                    <span data-star="1">★</span>
+                    <span data-star="2">★</span>
+                    <span data-star="3">★</span>
+                    <span data-star="4">★</span>
+                    <span data-star="5">★</span>
+                </div>
+                <span class="score"></span>
+            </li>
+            <li data-id="tetris-3d"><a href="tetris_3d.html">3D Tetris</a>
+                <div class="rate">
+                    <span data-star="1">★</span>
+                    <span data-star="2">★</span>
+                    <span data-star="3">★</span>
+                    <span data-star="4">★</span>
+                    <span data-star="5">★</span>
+                </div>
+                <span class="score"></span>
+            </li>
+            <li data-id="space-shooter"><a href="space_shooter.html">Space Shooter</a>
+                <div class="rate">
+                    <span data-star="1">★</span>
+                    <span data-star="2">★</span>
+                    <span data-star="3">★</span>
+                    <span data-star="4">★</span>
+                    <span data-star="5">★</span>
+                </div>
+                <span class="score"></span>
+            </li>
+            <li data-id="word-scramble"><a href="word_scramble.html">Word Scramble Adventure</a>
+                <div class="rate">
+                    <span data-star="1">★</span>
+                    <span data-star="2">★</span>
+                    <span data-star="3">★</span>
+                    <span data-star="4">★</span>
+                    <span data-star="5">★</span>
+                </div>
+                <span class="score"></span>
+            </li>
+            <li data-id="memory-match"><a href="memory_match.html">Memory Match Game</a>
+                <div class="rate">
+                    <span data-star="1">★</span>
+                    <span data-star="2">★</span>
+                    <span data-star="3">★</span>
+                    <span data-star="4">★</span>
+                    <span data-star="5">★</span>
+                </div>
+                <span class="score"></span>
+            </li>
+            <li data-id="number-guessing"><a href="number_guessing.html">Number Guessing Game</a>
+                <div class="rate">
+                    <span data-star="1">★</span>
+                    <span data-star="2">★</span>
+                    <span data-star="3">★</span>
+                    <span data-star="4">★</span>
+                    <span data-star="5">★</span>
+                </div>
+                <span class="score"></span>
+            </li>
+            <li data-id="rock-paper-scissors"><a href="rock_paper_scissors.html">Rock Paper Scissors</a>
+                <div class="rate">
+                    <span data-star="1">★</span>
+                    <span data-star="2">★</span>
+                    <span data-star="3">★</span>
+                    <span data-star="4">★</span>
+                    <span data-star="5">★</span>
+                </div>
+                <span class="score"></span>
+            </li>
         </ul>
     </div>
+    <script>
+        document.querySelectorAll('.rate').forEach(rateEl => {
+            const gameId = rateEl.dataset.id;
+            const li = rateEl.closest('li') || rateEl.parentElement;
+            const scoreEl = li.querySelector('.score');
+            rateEl.querySelectorAll('span').forEach(span => {
+                span.addEventListener('click', async () => {
+                    const res = await fetch('/api/rate', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ gameId, stars: +span.dataset.star })
+                    });
+                    if (res.status === 409) {
+                        alert('You already rated this game.');
+                    }
+                    load(gameId, rateEl, scoreEl);
+                });
+            });
+            load(gameId, rateEl, scoreEl);
+        });
+
+        async function load(gameId, rateEl, scoreEl) {
+            const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
+            scoreEl.textContent = `${r.average} ★ from ${r.votes} votes` + (r.mine ? ` - You rated ${r.mine}` : '');
+            rateEl.querySelectorAll('span').forEach(span => {
+                span.classList.toggle('selected', r.mine && +span.dataset.star <= r.mine);
+            });
+        }
+    </script>
 </body>
 </html>
 

--- a/memory_match.html
+++ b/memory_match.html
@@ -408,34 +408,6 @@
             new MemoryGame();
         });
     </script>
-<div id="rate">
-  <span data-star="1">★</span>
-  <span data-star="2">★</span>
-  <span data-star="3">★</span>
-  <span data-star="4">★</span>
-  <span data-star="5">★</span>
-</div>
-<p id="score"></p>
-<script>
-const gameId = "memory-match";
-
-document.querySelectorAll('#rate span').forEach(el =>
-  el.onclick = async () => {
-    await fetch('/api/rate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gameId, stars: +el.dataset.star })
-    });
-    load();
-  });
-
-async function load() {
-  const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
-  document.getElementById('score').textContent =
-    `${r.average} ★ from ${r.votes} votes`;
-}
-load();
-</script>
 </body>
 </html>
 

--- a/number_guessing.html
+++ b/number_guessing.html
@@ -78,33 +78,5 @@
             initGame();
         });
     </script>
-<div id="rate">
-  <span data-star="1">★</span>
-  <span data-star="2">★</span>
-  <span data-star="3">★</span>
-  <span data-star="4">★</span>
-  <span data-star="5">★</span>
-</div>
-<p id="score"></p>
-<script>
-const gameId = "number-guessing";
-
-document.querySelectorAll('#rate span').forEach(el =>
-  el.onclick = async () => {
-    await fetch('/api/rate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gameId, stars: +el.dataset.star })
-    });
-    load();
-  });
-
-async function load() {
-  const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
-  document.getElementById('score').textContent =
-    `${r.average} ★ from ${r.votes} votes`;
-}
-load();
-</script>
 </body>
 </html>

--- a/rock_paper_scissors.html
+++ b/rock_paper_scissors.html
@@ -67,33 +67,5 @@ function getResult(user, computer) {
   return 'You lose!';
 }
 </script>
-<div id="rate">
-  <span data-star="1">★</span>
-  <span data-star="2">★</span>
-  <span data-star="3">★</span>
-  <span data-star="4">★</span>
-  <span data-star="5">★</span>
-</div>
-<p id="score"></p>
-<script>
-const gameId = "rock-paper-scissors";
-
-document.querySelectorAll('#rate span').forEach(el =>
-  el.onclick = async () => {
-    await fetch('/api/rate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gameId, stars: +el.dataset.star })
-    });
-    load();
-  });
-
-async function load() {
-  const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
-  document.getElementById('score').textContent =
-    `${r.average} ★ from ${r.votes} votes`;
-}
-load();
-</script>
 </body>
 </html>

--- a/snake_game.html
+++ b/snake_game.html
@@ -347,34 +347,6 @@
         // Start the game
         startGame();
     </script>
-<div id="rate">
-  <span data-star="1">★</span>
-  <span data-star="2">★</span>
-  <span data-star="3">★</span>
-  <span data-star="4">★</span>
-  <span data-star="5">★</span>
-</div>
-<p id="score"></p>
-<script>
-const gameId = "snake-game";
-
-document.querySelectorAll('#rate span').forEach(el =>
-  el.onclick = async () => {
-    await fetch('/api/rate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gameId, stars: +el.dataset.star })
-    });
-    load();
-  });
-
-async function load() {
-  const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
-  document.getElementById('score').textContent =
-    `${r.average} ★ from ${r.votes} votes`;
-}
-load();
-</script>
 </body>
 </html>
 

--- a/space_shooter.html
+++ b/space_shooter.html
@@ -471,34 +471,6 @@
         updateUI();
         gameLoop();
     </script>
-<div id="rate">
-  <span data-star="1">★</span>
-  <span data-star="2">★</span>
-  <span data-star="3">★</span>
-  <span data-star="4">★</span>
-  <span data-star="5">★</span>
-</div>
-<p id="score"></p>
-<script>
-const gameId = "space-shooter";
-
-document.querySelectorAll('#rate span').forEach(el =>
-  el.onclick = async () => {
-    await fetch('/api/rate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gameId, stars: +el.dataset.star })
-    });
-    load();
-  });
-
-async function load() {
-  const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
-  document.getElementById('score').textContent =
-    `${r.average} ★ from ${r.votes} votes`;
-}
-load();
-</script>
 </body>
 </html>
 

--- a/tetris_3d.html
+++ b/tetris_3d.html
@@ -505,33 +505,6 @@
         // Start the game
         window.game = new Tetris3D();
     </script>
-<div id="rate">
-  <span data-star="1">★</span>
-  <span data-star="2">★</span>
-  <span data-star="3">★</span>
-  <span data-star="4">★</span>
-  <span data-star="5">★</span>
-</div>
-<p id="score"></p>
-<script>
-const gameId = "tetris-3d";
-
-document.querySelectorAll('#rate span').forEach(el =>
-  el.onclick = async () => {
-    await fetch('/api/rate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gameId, stars: +el.dataset.star })
-    });
-    load();
-  });
-
-async function load() {
-  const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
-  document.getElementById('score').textContent =
-    `${r.average} ★ from ${r.votes} votes`;
-}
-load();
 </script>
 </body>
 </html>

--- a/word_scramble.html
+++ b/word_scramble.html
@@ -118,33 +118,5 @@
 
         window.onload = newWord;
     </script>
-<div id="rate">
-  <span data-star="1">★</span>
-  <span data-star="2">★</span>
-  <span data-star="3">★</span>
-  <span data-star="4">★</span>
-  <span data-star="5">★</span>
-</div>
-<p id="score"></p>
-<script>
-const gameId = "word-scramble";
-
-document.querySelectorAll('#rate span').forEach(el =>
-  el.onclick = async () => {
-    await fetch('/api/rate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ gameId, stars: +el.dataset.star })
-    });
-    load();
-  });
-
-async function load() {
-  const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
-  document.getElementById('score').textContent =
-    `${r.average} ★ from ${r.votes} votes`;
-}
-load();
-</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize rating UI on index page
- track user's rating and highlight selected stars
- block duplicate ratings by IP on the API
- include user's rating in rating fetch response
- remove old rating snippets from game pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68898bb5abe883229b4f9dbf7979115d