### PR TITLE
Fix rating system

### DIFF
--- a/functions/api/rate.ts
+++ b/functions/api/rate.ts
@@ -7,17 +7,11 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
 
   const ip = request.headers.get("CF-Connecting-IP") ?? "0.0.0.0";
 
-  const existing = await env.DB
-    .prepare("SELECT 1 FROM ratings WHERE game_id = ?1 AND ip = ?2;")
-    .bind(gameId, ip)
-    .first();
-
-  if (existing) {
-    return new Response("Already rated", { status: 409 });
-  }
-
   await env.DB
-    .prepare("INSERT INTO ratings (game_id, stars, ip) VALUES (?1, ?2, ?3);")
+    .prepare(
+      "INSERT INTO ratings (game_id, stars, ip) VALUES (?1, ?2, ?3) " +
+        "ON CONFLICT(game_id, ip) DO UPDATE SET stars = excluded.stars;"
+    )
     .bind(gameId, stars, ip)
     .run();
 

--- a/index.html
+++ b/index.html
@@ -199,8 +199,8 @@
     </div>
     <script>
         document.querySelectorAll('.rate').forEach(rateEl => {
-            const gameId = rateEl.dataset.id;
             const li = rateEl.closest('li') || rateEl.parentElement;
+            const gameId = rateEl.dataset.id || li.dataset.id;
             const scoreEl = li.querySelector('.score');
             rateEl.querySelectorAll('span').forEach(span => {
                 span.addEventListener('click', async () => {
@@ -209,9 +209,6 @@
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ gameId, stars: +span.dataset.star })
                     });
-                    if (res.status === 409) {
-                        alert('You already rated this game.');
-                    }
                     load(gameId, rateEl, scoreEl);
                 });
             });

--- a/physics_puzzle.html
+++ b/physics_puzzle.html
@@ -132,6 +132,13 @@
                 font-size: 2em;
             }
         }
+        #rate {
+            margin-top: 10px;
+            font-size: 24px;
+        }
+        #rate span.selected {
+            color: orange;
+        }
     </style>
 </head>
 <body>
@@ -575,7 +582,10 @@ document.querySelectorAll('#rate span').forEach(el =>
 async function load() {
   const r = await fetch(`/api/ratings/${gameId}`).then(r => r.json());
   document.getElementById('score').textContent =
-    `${r.average} ★ from ${r.votes} votes`;
+    `${r.average} ★ from ${r.votes} votes` + (r.mine ? ` - You rated ${r.mine}` : '');
+  document.querySelectorAll('#rate span').forEach(span => {
+    span.classList.toggle('selected', r.mine && +span.dataset.star <= r.mine);
+  });
 }
 load();
 </script>


### PR DESCRIPTION
## Summary
- make the rate API update existing votes instead of blocking
- fix `index.html` so all games have an id for rating
- show current rating on `physics_puzzle.html`

## Testing
- `npx tsc --noEmit functions/api/rate.ts` *(fails: Cannot find name 'PagesFunction')*

------
https://chatgpt.com/codex/tasks/task_e_6889a0856d988322aa852d6597e85d5f