### PR TITLE
style: add arcade theme and fix star overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,29 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>Bot Built Arcade</title>
-	<style>
-		body {
-			margin: 0;
-			padding: 0;
-			background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
-			font-family: 'Arial', sans-serif;
-			display: flex;
-			justify-content: center;
-			align-items: center;
-			min-height: 100vh;
-			color: white;
-		}
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Bot Built Arcade</title>
+        <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+        <style>
+                body {
+                        margin: 0;
+                        padding: 0;
+                        background: linear-gradient(135deg, #ff0080 0%, #7e2eff 50%, #00e6ff 100%);
+                        font-family: 'Press Start 2P', cursive;
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;
+                        min-height: 100vh;
+                        color: white;
+                }
 
-		#container {
-			text-align: center;
-			background: rgba(0, 0, 0, 0.8);
-			padding: 20px;
-			border-radius: 15px;
-			box-shadow: 0 0 30px rgba(0, 255, 255, 0.3);
-		}
+                #container {
+                        text-align: center;
+                        background: rgba(0, 0, 0, 0.8);
+                        padding: 20px;
+                        border-radius: 15px;
+                        border: 3px solid #ff00ff;
+                        box-shadow: 0 0 30px rgba(255, 0, 255, 0.5);
+                }
 
 		#gameCanvas {
 			border: 3px solid #00ffff;
@@ -32,25 +34,25 @@
 			box-shadow: 0 0 20px rgba(0, 255, 255, 0.5);
 		}
 
-		h1 {
-			margin-top: 0;
-			color: #ffff00;
-			font-size: 29px;
-			margin-bottom: 10px;
-			text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
-			background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
-			-webkit-background-clip: text;
-			-webkit-text-fill-color: transparent;
-			background-clip: text;
-		}
+                h1 {
+                        margin-top: 0;
+                        color: #ffff00;
+                        font-size: 29px;
+                        margin-bottom: 10px;
+                        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+                        background: linear-gradient(45deg, #ff00ff, #00ff88);
+                        -webkit-background-clip: text;
+                        -webkit-text-fill-color: transparent;
+                        background-clip: text;
+                }
 
-		.featured {
-			background: rgba(255, 255, 255, 0.1);
-			padding: 20px;
-			border-radius: 8px;
-			margin-bottom: 30px;
-			box-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
-		}
+                .featured {
+                        background: rgba(255, 255, 255, 0.1);
+                        padding: 20px;
+                        border-radius: 8px;
+                        margin-bottom: 30px;
+                        box-shadow: 0 0 15px rgba(255, 0, 255, 0.4);
+                }
 
 		.featured h2 {
 			margin-top: 0;
@@ -64,21 +66,30 @@
 			font-size: 16px;
 		}
 
-		.play-btn {
-			background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
-			color: #000;
-			text-decoration: none;
-			padding: 10px 20px;
-			border-radius: 5px;
-			font-size: 16px;
-			font-weight: bold;
-			box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
-		}
+                .play-btn {
+                        background: linear-gradient(45deg, #ff00ff, #00ff88);
+                        color: #000;
+                        text-decoration: none;
+                        padding: 10px 20px;
+                        border-radius: 5px;
+                        font-size: 16px;
+                        font-weight: bold;
+                        box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
+                        display: inline-block;
+                        margin-bottom: 10px;
+                }
 
-		.play-btn:hover {
-			transform: translateY(-2px);
-			box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
-		}
+                .play-btn:hover {
+                        transform: translateY(-2px);
+                        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+                }
+
+                .rate {
+                        display: flex;
+                        justify-content: center;
+                        gap: 5px;
+                        margin-top: 10px;
+                }
 
 		ul {
 			list-style: none;
@@ -89,17 +100,16 @@
 			margin: 12px 0;
 		}
 
-		li a {
-			font-size: 18px;
-			color: #ffff8f;
-			text-decoration: underline;
-			color: #ffffff;
-		}
+                li a {
+                        font-size: 18px;
+                        color: #00ffff;
+                        text-decoration: underline;
+                }
 
-		li a:hover {
-			text-decoration: underline;
-			color: #ffffef;
-		}
+                li a:hover {
+                        text-decoration: underline;
+                        color: #ffea00;
+                }
 
 		.rate span {
 			cursor: pointer;
@@ -115,10 +125,12 @@
 			box-shadow: 0 0 12px #1affff;
 		}
 
-		.score {
-			margin-left: 8px;
-		}
-	</style>
+                .score {
+                        display: block;
+                        margin-top: 5px;
+                        color: #ffea00;
+                }
+        </style>
 </head>
 <body>
 	<div id="container">


### PR DESCRIPTION
## Summary
- adopt bright arcade aesthetic with a neon gradient background, retro font, and vibrant link colors
- add spacing to the featured game's rating stars to stop overlap with the Play Now button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68902bf1b0b08322875809b6344b9063