### PR TITLE
Add ads.txt and site icon

### DIFF
--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,2 @@
+google.com, ca-pub-5140771119439935, DIRECT, f08c47fec0942fa0
+

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
         <title>Bot Built Arcade</title>
         <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140771119439935" crossorigin="anonymous"></script>
         <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+        <link rel="icon" type="image/png" href="images/botbuiltarcade-icon-face.png">
         <style>
                 body {
                         margin: 0;


### PR DESCRIPTION
## Summary
- Authorize Google AdSense via `ads.txt`
- Add favicon using existing botbuilt arcade image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896d08063d88322a7ad9ca9bd89cf27