### PR TITLE
Return JSON errors for rating API

### DIFF
--- a/functions/api/rate.ts
+++ b/functions/api/rate.ts
@@ -3,14 +3,14 @@ type PagesFunction = any;
 export const onRequestPost: PagesFunction = async ({ request, env }) => {
   try {
     if (!env.DB) {
-      return new Response("Database not configured", { status: 500 });
+      return Response.json({ error: "Database not configured" }, { status: 500 });
     }
 
     const { gameId, stars } = await request.json() as any;
     const rating = parseInt(stars, 10);
 
     if (!gameId || isNaN(rating) || rating < 1 || rating > 5) {
-      return new Response("Bad request", { status: 400 });
+      return Response.json({ error: "Bad request" }, { status: 400 });
     }
 
     const ip = request.headers.get("CF-Connecting-IP") ?? "0.0.0.0";
@@ -29,11 +29,11 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
         .run();
 
       if (!insertResult.success) {
-        return new Response("Database error", { status: 500 });
+        return Response.json({ error: "Database error" }, { status: 500 });
       }
     } catch (dbError) {
       console.error('Database operation failed:', dbError);
-      return new Response("Database operation failed", { status: 500 });
+      return Response.json({ error: "Database operation failed" }, { status: 500 });
     }
 
     // Get updated stats
@@ -48,6 +48,6 @@ export const onRequestPost: PagesFunction = async ({ request, env }) => {
     });
   } catch (error) {
     console.error('Rate endpoint error:', error);
-    return new Response("Internal server error", { status: 500 });
+    return Response.json({ error: "Internal server error" }, { status: 500 });
   }
 };

--- a/functions/api/ratings/[id].ts
+++ b/functions/api/ratings/[id].ts
@@ -5,7 +5,7 @@ export const onRequestGet: PagesFunction = async ({ params, env, request }) => {
     const gameId = params!.id as string;
 
     if (!gameId) {
-      return new Response("Game ID required", { status: 400 });
+      return Response.json({ error: "Game ID required" }, { status: 400 });
     }
 
     const ip = request.headers.get("CF-Connecting-IP") ?? "0.0.0.0";
@@ -27,6 +27,6 @@ export const onRequestGet: PagesFunction = async ({ params, env, request }) => {
     });
   } catch (error) {
     console.error('Ratings endpoint error:', error);
-    return new Response("Internal server error", { status: 500 });
+    return Response.json({ error: "Internal server error" }, { status: 500 });
   }
 };


### PR DESCRIPTION
## Summary
- Ensure rating submission endpoint consistently returns JSON error responses
- Align rating retrieval endpoint with JSON error format for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b04a64d48322adac9528c6d2a48f