### PR TITLE
Add armored enemy and pierce tower to Aurora Tower Defense

### DIFF
--- a/aurora_tower_defense.html
+++ b/aurora_tower_defense.html
@@ -137,6 +137,10 @@
       <img src="images/td_tower_slow.svg" alt="slow">
       <div>Frost 35</div>
     </div>
+    <div class="tool" data-type="pierce" data-cost="50">
+      <img src="images/td_tower_pierce.svg" alt="pierce">
+      <div>Pierce 50</div>
+    </div>
   </div>
 
   <script>
@@ -169,8 +173,10 @@
       path: 'images/td_tile_path.svg',
       tower_basic: 'images/td_tower_basic.svg',
       tower_slow: 'images/td_tower_slow.svg',
+      tower_pierce: 'images/td_tower_pierce.svg',
       enemy: 'images/td_enemy_bug.svg',
       enemy_fast: 'images/td_enemy_fast.svg',
+      enemy_armored: 'images/td_enemy_armored.svg',
       bullet: 'images/td_bullet.svg',
       portal: 'images/td_portal.svg',
     };
@@ -195,13 +201,14 @@
     };
 
     const towers = []; // {gx, gy, type, cd}
-    const bullets = []; // {x,y,vx,vy,spd, dmg, slow, slowDur, targetId}
+    const bullets = []; // {x,y,vx,vy,spd, dmg, slow, slowDur, targetId, bonus}
     let enemies = []; // {id, x,y, seg, t, spd, hp, maxHp, slow, slowTimer}
     let nextEnemyId = 1;
 
     const TOWER_CONF = {
       basic: { range: 2.6, rof: 0.8, dmg: 16, spd: 420, cost: 25 },
       slow:  { range: 2.2, rof: 1.2, dmg: 8,  spd: 380, slow: 0.55, slowDur: 1.4, cost: 35 },
+      pierce:{ range: 2.4, rof: 0.6, dmg: 32, spd: 450, cost: 50, bonus: { armored: 24 } },
     };
 
     const INITIAL_WAVE_SPEED = 50;
@@ -209,8 +216,9 @@
     const MAX_WAVE_SPEED = 130;
     const ENEMY_CONF = { hp: 36, hpInc: 16 };
     const ENEMY_TYPES = {
-      bug:  { img: 'enemy', spdMul: 1,   hpMul: 1 },
-      fast: { img: 'enemy_fast', spdMul: 1.8, hpMul: 0.6 },
+      bug:    { img: 'enemy',         spdMul: 1,   hpMul: 1 },
+      fast:   { img: 'enemy_fast',    spdMul: 1.8, hpMul: 0.6 },
+      armored:{ img: 'enemy_armored', spdMul: 0.8, hpMul: 2.2 },
     };
 
     // UI selection
@@ -255,7 +263,10 @@
       // Track outstanding spawns so we don't advance the wave before enemies actually appear
       pendingSpawns = count;
       const iv = setInterval(()=>{
-        const type = (state.wave > 2 && Math.random() < 0.3) ? 'fast' : 'bug';
+        const r = Math.random();
+        let type = 'bug';
+        if(state.wave > 4 && r < 0.2) type = 'armored';
+        else if(state.wave > 2 && r < 0.5) type = 'fast';
         addEnemy(type);
         i++;
         pendingSpawns = Math.max(0, pendingSpawns - 1);
@@ -330,7 +341,7 @@
         }
         if(best){
           const spd = conf.spd; const dx = best.x - tx, dy = best.y - ty; const d = Math.hypot(dx,dy)||1;
-          bullets.push({ x: tx, y: ty, vx: dx/d, vy: dy/d, spd, dmg: conf.dmg, slow: conf.slow||0, slowDur: conf.slowDur||0, targetId: best.id });
+          bullets.push({ x: tx, y: ty, vx: dx/d, vy: dy/d, spd, dmg: conf.dmg, slow: conf.slow||0, slowDur: conf.slowDur||0, targetId: best.id, bonus: conf.bonus||{} });
           t.cd = 1/conf.rof; // cooldown seconds
         }
       }
@@ -345,7 +356,8 @@
           if(Math.hypot(e.x-b.x, e.y-b.y) < tile*0.45){ hit = e; break; }
         }
         if(hit){
-          hit.hp -= b.dmg;
+          let extra = 0; if(b.bonus && b.bonus[hit.type]) extra = b.bonus[hit.type];
+          hit.hp -= b.dmg + extra;
           if(b.slow){ hit.slow = Math.min(hit.slow, b.slow); hit.slowTimer = Math.max(hit.slowTimer, b.slowDur); }
           b.dead = true;
         }
@@ -422,7 +434,7 @@
     function drawTowers(){
       for(const t of towers){
         const x = t.gx*tile, y = t.gy*tile;
-        const img = t.type==='basic' ? Images.tower_basic : Images.tower_slow;
+        const img = Images['tower_'+t.type];
         ctx.drawImage(img, x, y, tile, tile);
       }
     }

--- a/images/td_enemy_armored.svg
+++ b/images/td_enemy_armored.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="shell" cx="0.5" cy="0.4" r="0.7">
+      <stop offset="0" stop-color="#f2ff9a"/>
+      <stop offset="1" stop-color="#6ba500"/>
+    </radialGradient>
+  </defs>
+  <ellipse cx="48" cy="72" rx="22" ry="8" fill="#190a16" opacity="0.5"/>
+  <g stroke="#d9ffb7" stroke-width="3" stroke-linecap="round">
+    <line x1="22" y1="56" x2="10" y2="66"/>
+    <line x1="74" y1="56" x2="86" y2="66"/>
+    <line x1="22" y1="66" x2="10" y2="76"/>
+    <line x1="74" y1="66" x2="86" y2="76"/>
+  </g>
+  <ellipse cx="48" cy="50" rx="28" ry="22" fill="url(#shell)" stroke="#d9ffb7" stroke-width="2"/>
+  <path d="M28 50 L68 50" stroke="#d9ffb7" stroke-width="4"/>
+  <circle cx="36" cy="44" r="4" fill="#f7ffe7"/>
+  <circle cx="60" cy="44" r="4" fill="#f7ffe7"/>
+  <path d="M36 62 C44 54, 52 54, 60 62" stroke="#f7ffe7" stroke-width="2" fill="none"/>
+</svg>

--- a/images/td_tower_pierce.svg
+++ b/images/td_tower_pierce.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="shaft" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#402815"/>
+      <stop offset="1" stop-color="#27160b"/>
+    </linearGradient>
+    <radialGradient id="tip" cx="0.5" cy="0.3" r="0.7">
+      <stop offset="0" stop-color="#ffe0b3"/>
+      <stop offset="1" stop-color="#ff7b00"/>
+    </radialGradient>
+  </defs>
+  <ellipse cx="64" cy="100" rx="34" ry="12" fill="#051018" opacity="0.7"/>
+  <path d="M52 96 L76 96 L72 60 L56 60 Z" fill="url(#shaft)" stroke="#ffb347" stroke-width="2"/>
+  <polygon points="64,28 80,60 48,60" fill="url(#tip)" stroke="#ffd6a1" stroke-width="2"/>
+  <line x1="64" y1="60" x2="64" y2="96" stroke="#ffd6a1" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
## Summary
- add armored enemy type with high health
- introduce pierce tower that deals bonus damage against armored enemies
- spawn armored foes in later waves and load new SVG assets

## Testing
- `npm test`

Closes #40
Closes #41

------
https://chatgpt.com/codex/tasks/task_e_689aca6c5624832291e5e9a75ae6f743