### PR TITLE
Limit Aurora Tower Defense to 8 waves

### DIFF
--- a/aurora_tower_defense.html
+++ b/aurora_tower_defense.html
@@ -189,7 +189,7 @@
 
     let COLS = 12, ROWS = 8, tile = 48; // computed on resize
     let pixelRatio = Math.max(1, Math.floor(window.devicePixelRatio || 1));
-    const TOTAL_WAVES = 20;
+    const TOTAL_WAVES = 8;
 
     // Assets
     const assets = {


### PR DESCRIPTION
## Summary
- End Aurora Tower Defense after wave 8 by reducing TOTAL_WAVES constant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c19a5708883228077f76318caa54c