### PR TITLE
fix: improve leaderboard mobile layout

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -22,6 +22,7 @@
       background: linear-gradient(135deg, var(--bg1) 0%, var(--bg2) 50%, var(--bg3) 100%);
       font-family: 'Press Start 2P', cursive;
       line-height: 1.45;
+      font-size: 14px;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -62,14 +63,14 @@
     }
     h1 {
       margin: 0;
-      font-size: 28px;
+      font-size: 24px;
       background: linear-gradient(45deg, var(--gold), #FFA500);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;
     }
     .titles { display:flex; flex-direction:column; }
-    .subtitle { margin-top: 2px; font-size: 14px; color: var(--teal); }
+    .subtitle { margin-top: 2px; font-size: 12px; color: var(--teal); }
     .btn {
       display: inline-block;
       text-decoration: none;
@@ -79,7 +80,7 @@
       padding: 10px 14px;
       border-radius: 10px;
       box-shadow: 0 4px 15px rgba(95,158,160,0.4);
-      font-size: 12px;
+      font-size: 10px;
       white-space: nowrap;
     }
     .btn:hover { filter: brightness(1.05); }
@@ -89,7 +90,7 @@
     }
     .controls input[type="text"] {
       font-family: inherit;
-      font-size: 14px;
+      font-size: 12px;
       padding: 10px 12px;
       border-radius: 10px;
       border: 2px solid var(--gold);
@@ -98,7 +99,7 @@
     }
     .controls button {
       font-family: inherit;
-      font-size: 14px;
+      font-size: 12px;
       padding: 10px 14px;
       border-radius: 10px;
       border: 2px solid var(--gold);
@@ -116,7 +117,7 @@
     }
     .submit-row input[type="text"], .submit-row input[type="number"] {
       font-family: inherit;
-      font-size: 14px;
+      font-size: 12px;
       padding: 10px 12px;
       border-radius: 10px;
       border: 2px solid var(--gold);
@@ -125,7 +126,7 @@
     }
     .submit-row button {
       font-family: inherit;
-      font-size: 14px;
+      font-size: 12px;
       padding: 10px 14px;
       border-radius: 10px;
       border: 2px solid var(--gold);
@@ -145,7 +146,7 @@
     }
     thead th {
       text-align: left;
-      font-size: 12px;
+      font-size: 10px;
       color: var(--gold);
       padding: 10px 12px;
       line-height: 1.35;
@@ -153,22 +154,32 @@
     }
     tbody td {
       padding: 10px 12px;
-      font-size: 14px;
+      font-size: 12px;
       line-height: 1.35;
       border-top: 1px solid rgba(255, 215, 0, 0.15);
       color: var(--ink);
+      word-break: break-word;
+    }
+    .col-rank { width:64px; }
+    .col-score { width:120px; }
+    .col-when { width:220px; }
+    @media (max-width: 480px) {
+      .col-rank, .col-score, .col-when { width:auto; }
+      thead th, tbody td { font-size:10px; padding:8px; }
+      header { flex-direction: column; align-items: center; justify-content: center; text-align: center; }
+      .btn-group { width:100%; justify-content:center; flex-wrap:wrap; }
     }
     tbody tr:hover { background: rgba(255, 215, 0, 0.08); }
 
     .footer {
       margin-top: 20px;
-      font-size: 12px;
+      font-size: 10px;
       color: var(--teal);
     }
     a { color: var(--gold); text-decoration: none; }
     a:hover { color: #FFA500; }
-    .error { color: #ff9999; margin-top: 8px; font-size: 12px; }
-    .success { color: #90EE90; margin-top: 8px; font-size: 12px; }
+    .error { color: #ff9999; margin-top: 8px; font-size: 10px; }
+    .success { color: #90EE90; margin-top: 8px; font-size: 10px; }
   </style>
 </head>
 <body>
@@ -193,10 +204,10 @@
     <table aria-label="Leaderboard table">
       <thead>
         <tr>
-          <th style="width:64px;">Rank</th>
-          <th>Name</th>
-          <th style="width:120px;">Score</th>
-          <th style="width:220px;">When</th>
+          <th class="col-rank">Rank</th>
+          <th class="col-name">Name</th>
+          <th class="col-score">Score</th>
+          <th class="col-when">When</th>
         </tr>
       </thead>
       <tbody id="tbody">


### PR DESCRIPTION
## Summary
- make leaderboard table responsive with classes instead of fixed widths
- add mobile media query to reduce padding and font size
- allow cell text to wrap for small screens
- shrink fonts across leaderboard so title fits on mobile
- stack header buttons on mobile to prevent horizontal scrolling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c1d7e9ea08322988380d83125d68b