### PR TITLE
Toughen final waves in Aurora Tower Defense

### DIFF
--- a/aurora_tower_defense.html
+++ b/aurora_tower_defense.html
@@ -418,8 +418,8 @@
       const baseSpd = Math.min(
         INITIAL_WAVE_SPEED + (waveNumber-1)*WAVE_SPEED_INCREMENT + (level-1)*3,
         MAX_WAVE_SPEED
-      ) * (hardWave ? 1.05 : 1);
-      const baseHp  = (ENEMY_CONF.hp + (waveNumber-1)*ENEMY_CONF.hpInc + (level-1)*25) * (hardWave ? 1.1 : 1);
+      ) * (hardWave ? 1.1 : 1);
+      const baseHp  = (ENEMY_CONF.hp + (waveNumber-1)*ENEMY_CONF.hpInc + (level-1)*25) * (hardWave ? 1.2 : 1);
       const conf = ENEMY_TYPES[type] || ENEMY_TYPES.bug;
       const hp = baseHp * conf.hpMul;
       enemies.push({ id: nextEnemyId++, type, ...gridToPx(path[0].x, path[0].y), seg:0, t:0, spd: baseSpd * conf.spdMul, hp, maxHp: hp, slow:1, slowTimer:0 });
@@ -431,7 +431,7 @@
       const hardWave = waveNumber >= 9;
       // Easier Wave 1, progressively harder later (quadratic term)
       let count = 4 + Math.floor(((level-1)*2 + waveNumber)*1.2) + Math.floor((waveNumber-1)*(waveNumber-1)*0.3);
-      if(hardWave) count = Math.floor(count * 1.25);
+      if(hardWave) count = Math.floor(count * 1.35);
       let i = 0;
       // Track outstanding spawns so we don't advance the wave before enemies actually appear
       pendingSpawns = count;
@@ -439,15 +439,16 @@
       const iv = setInterval(()=>{
         const r = Math.random();
         let type = 'bug';
-        if(level > 1 && r < 0.15) type = 'brute';
-        else if(hardWave && r < 0.3) type = 'armored';
+        if(level > 1 && r < (hardWave ? 0.2 : 0.15)) type = 'brute';
+        else if(hardWave && r < 0.45) type = 'armored';
+        else if(hardWave && r < 0.65) type = 'fast';
         else if(waveNumber + (level-1)*WAVES_PER_LEVEL > 8 && r < 0.2) type = 'armored';
         else if(waveNumber + (level-1)*WAVES_PER_LEVEL > 4 && r < 0.5) type = 'fast';
         addEnemy(type);
         i++;
         pendingSpawns = Math.max(0, pendingSpawns - 1);
         if(i>=count){ clearInterval(iv); pendingSpawns = 0; }
-      }, hardWave ? Math.max(200, baseInterval * 0.8) : baseInterval);
+      }, hardWave ? Math.max(180, baseInterval * 0.75) : baseInterval);
     }
 
     function placeValid(gx, gy){


### PR DESCRIPTION
## Summary
- Boost enemy speed and health on hard waves
- Increase enemy counts and tougher spawns for waves 9 and 10
- Accelerate spawn rates to intensify final waves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f3f19b62883229ee6ee87bb08153d