### PR TITLE
Enable long press placement after dragging

### DIFF
--- a/rampart/index.html
+++ b/rampart/index.html
@@ -586,7 +586,14 @@
         touchMoved = true; // finalize once animation completes
       } else if(Math.abs(t.clientX - touchStartX) > 10 || Math.abs(t.clientY - touchStartY) > 10){
         touchMoved = true;
-        if(longPressTimeout){ clearTimeout(longPressTimeout); longPressTimeout=null; }
+        if(longPressTimeout){ clearTimeout(longPressTimeout); }
+        longPressTimeout = null;
+        if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+          longPressTimeout = setTimeout(()=>{
+            longPressTimeout = null;
+            startLongPressAnimation();
+          }, LONG_PRESS_DELAY);
+        }
       }
       e.preventDefault();
     }, {passive:false});


### PR DESCRIPTION
## Summary
- allow restarting long press timer on finger moves so walls can be placed after dragging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a807900fd88322984ecac747c036e5