### PR TITLE
Enable long press placement after dragging

### DIFF
--- a/rampart/index.html
+++ b/rampart/index.html
@@ -500,6 +500,7 @@
     }
 
     function startLongPressAnimation(){
+      touchMoved = false;
       longPressAnimating = true;
       longPressAnimStart = performance.now();
       longPressAnimProgress = 0;
@@ -513,10 +514,9 @@
         longPressAnimating = false;
         longPressAnimProgress = 1;
         longPressReady = true;
-        if(touchMoved || longPressAfterRelease){
+        if(longPressAfterRelease){
           finalizePlacement();
           longPressReady = false;
-          touchMoved = true;
           longPressAfterRelease = false;
         }
         draw();
@@ -577,16 +577,47 @@
       const r = canvas.getBoundingClientRect();
       updateHover(t.clientX - r.left, t.clientY - r.top);
       if(longPressReady){
-        finalizePlacement();
         longPressReady = false;
         longPressAnimating = false;
         longPressAfterRelease = false;
         touchMoved = true;
+        if(longPressTimeout){ clearTimeout(longPressTimeout); }
+        longPressTimeout = null;
+        touchStartX = t.clientX;
+        touchStartY = t.clientY;
+        if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+          longPressTimeout = setTimeout(()=>{
+            longPressTimeout = null;
+            startLongPressAnimation();
+          }, LONG_PRESS_DELAY);
+        }
       } else if(longPressAnimating){
-        touchMoved = true; // finalize once animation completes
+        touchMoved = true;
+        longPressAnimating = false;
+        longPressReady = false;
+        longPressAfterRelease = false;
+        if(longPressTimeout){ clearTimeout(longPressTimeout); }
+        longPressTimeout = null;
+        touchStartX = t.clientX;
+        touchStartY = t.clientY;
+        if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+          longPressTimeout = setTimeout(()=>{
+            longPressTimeout = null;
+            startLongPressAnimation();
+          }, LONG_PRESS_DELAY);
+        }
       } else if(Math.abs(t.clientX - touchStartX) > 10 || Math.abs(t.clientY - touchStartY) > 10){
         touchMoved = true;
-        if(longPressTimeout){ clearTimeout(longPressTimeout); longPressTimeout=null; }
+        if(longPressTimeout){ clearTimeout(longPressTimeout); }
+        longPressTimeout = null;
+        touchStartX = t.clientX;
+        touchStartY = t.clientY;
+        if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+          longPressTimeout = setTimeout(()=>{
+            longPressTimeout = null;
+            startLongPressAnimation();
+          }, LONG_PRESS_DELAY);
+        }
       }
       e.preventDefault();
     }, {passive:false});


### PR DESCRIPTION
## Summary
- allow restarting long press timer on finger moves so walls can be placed after dragging
- restore ability to cancel placement by dragging after a long press

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a807900fd88322984ecac747c036e5