### PR TITLE
Remove rotate/place buttons and update rampart controls

### DIFF
--- a/rampart/index.html
+++ b/rampart/index.html
@@ -73,6 +73,15 @@
     .tool.selected { outline: 3px solid #7fffd4; }
     .tool img { width: 28px; height: 28px; }
 
+    .instructions {
+      color: var(--teal);
+      font-size: 10px;
+      line-height: 1.4;
+      text-align: center;
+      max-width: 220px;
+      user-select: none;
+    }
+
     .overlay { position: absolute; inset: 0; display: none; align-items: center; justify-content: center; flex-direction: column;
       background: radial-gradient(800px 400px at 50% 40%, rgba(0,0,0,0.6), rgba(0,0,0,0.9)); z-index: 18; text-align: center; padding: 24px; gap: 14px; }
     .overlay.show { display: flex; }
@@ -112,7 +121,8 @@
     <canvas id="game"></canvas>
     <div class="overlay show" id="overlay">
       <h2>Rebuild the Bastion</h2>
-      <p>Tap to place walls and cannons during the build phase. Defend the keep against incoming ships.</p>
+      <p>Defend the keep against incoming ships.</p>
+      <p>Mobile: tap to rotate, long press to place. Desktop: click to place, press R to rotate.</p>
       <p class="tap">Tap to start · Pinch zoom is disabled</p>
     </div>
     <div class="overlay" id="howTo">
@@ -125,8 +135,7 @@
   <div class="toolbar" id="toolbar">
     <div class="tool selected" data-type="wall" data-cost="1"><img src="assets/wall.svg" alt="wall"><div>Wall 1</div></div>
     <div class="tool" data-type="cannon" data-cost="6"><img src="assets/cannon.svg" alt="cannon"><div>Cannon 6</div></div>
-    <div class="tool action" id="rotateBtn"><div>Rotate</div></div>
-    <div class="tool action" id="placeBtn"><div>Place</div></div>
+    <div class="instructions">Mobile: tap to rotate, long press to place<br>Desktop: click to place, press R to rotate</div>
   </div>
 
   <script>
@@ -148,8 +157,6 @@
     const hudEl = document.getElementById('hud');
     const currentPreviewCanvas = document.getElementById('currentPreview');
     const currentPreviewCtx = currentPreviewCanvas.getContext('2d');
-    const rotateBtn = document.getElementById('rotateBtn');
-    const placeBtn = document.getElementById('placeBtn');
 
     // Leaderboard integration
     const GAME_ID = 'rampart';
@@ -296,7 +303,7 @@
           <li><strong>Defend:</strong> Ships sail in and fire at your defenses. Cannons auto-fire at ships.</li>
         </ul>
         <p>Score points by destroying ships and surviving waves. The game ends when the keep is destroyed, or you clear all ${MAX_WAVES} waves.</p>
-        <p>Tips: Place cannons behind walls. Repair damage during the next build phase. Rotate wall pieces with <kbd>R</kbd>, space, or the rotate button. Move a piece then press <kbd>Enter</kbd> or the place button to set it. The current piece is shown in the HUD.</p>
+        <p>Tips: Place cannons behind walls. Repair damage during the next build phase. On desktop, click to place pieces and press <kbd>R</kbd> to rotate them. On mobile, long press to place and tap to rotate. The current piece is shown in the HUD.</p>
       `;
     }
 
@@ -637,27 +644,11 @@
     overlay.addEventListener('click', start);
     overlay.addEventListener('touchstart', (e)=>{ e.preventDefault(); start(); }, {passive:false});
 
-    rotateBtn.addEventListener('click', ()=>{
-      if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+    window.addEventListener('keydown', (e)=>{
+      if(state.phase==='build' && selectedTool==='wall' && e.key==='r'){
         currentPiece = rotatePiece(currentPiece);
         draw();
         drawCurrentPreview();
-      }
-    });
-    rotateBtn.addEventListener('touchstart', (e)=>{ e.preventDefault(); rotateBtn.click(); });
-    placeBtn.addEventListener('click', finalizePlacement);
-    placeBtn.addEventListener('touchstart', (e)=>{ e.preventDefault(); finalizePlacement(); });
-
-    window.addEventListener('keydown', (e)=>{
-      if(state.phase==='build'){
-        if(selectedTool==='wall' && (e.key==='r' || e.key===' ')){
-          currentPiece = rotatePiece(currentPiece);
-          draw();
-          drawCurrentPreview();
-        }
-        if(e.key==='Enter'){
-          finalizePlacement();
-        }
       }
     });
 


### PR DESCRIPTION
## Summary
- Remove rotate and place buttons from Bastion Builder's toolbar
- Add textual instructions for placing and rotating on mobile and desktop
- Update how-to panel and keyboard handling to match new controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81d52b22c8322adddfb3a94168d4b