### PR TITLE
Remove rotate/place buttons and update rampart controls

### DIFF
--- a/rampart/index.html
+++ b/rampart/index.html
@@ -73,6 +73,15 @@
     .tool.selected { outline: 3px solid #7fffd4; }
     .tool img { width: 28px; height: 28px; }
 
+    .instructions {
+      color: var(--teal);
+      font-size: 10px;
+      line-height: 1.4;
+      text-align: center;
+      max-width: 220px;
+      user-select: none;
+    }
+
     .overlay { position: absolute; inset: 0; display: none; align-items: center; justify-content: center; flex-direction: column;
       background: radial-gradient(800px 400px at 50% 40%, rgba(0,0,0,0.6), rgba(0,0,0,0.9)); z-index: 18; text-align: center; padding: 24px; gap: 14px; }
     .overlay.show { display: flex; }
@@ -112,7 +121,8 @@
     <canvas id="game"></canvas>
     <div class="overlay show" id="overlay">
       <h2>Rebuild the Bastion</h2>
-      <p>Tap to place walls and cannons during the build phase. Defend the keep against incoming ships.</p>
+      <p>Defend the keep against incoming ships.</p>
+      <p>Mobile: tap to rotate, long press to place. Desktop: click to place, press R to rotate.</p>
       <p class="tap">Tap to start · Pinch zoom is disabled</p>
     </div>
     <div class="overlay" id="howTo">
@@ -125,8 +135,7 @@
   <div class="toolbar" id="toolbar">
     <div class="tool selected" data-type="wall" data-cost="1"><img src="assets/wall.svg" alt="wall"><div>Wall 1</div></div>
     <div class="tool" data-type="cannon" data-cost="6"><img src="assets/cannon.svg" alt="cannon"><div>Cannon 6</div></div>
-    <div class="tool action" id="rotateBtn"><div>Rotate</div></div>
-    <div class="tool action" id="placeBtn"><div>Place</div></div>
+    <div class="instructions">Mobile: tap to rotate, long press to place<br>Desktop: click to place, press R to rotate</div>
   </div>
 
   <script>
@@ -148,8 +157,6 @@
     const hudEl = document.getElementById('hud');
     const currentPreviewCanvas = document.getElementById('currentPreview');
     const currentPreviewCtx = currentPreviewCanvas.getContext('2d');
-    const rotateBtn = document.getElementById('rotateBtn');
-    const placeBtn = document.getElementById('placeBtn');
 
     // Leaderboard integration
     const GAME_ID = 'rampart';
@@ -228,6 +235,10 @@
     const LONG_PRESS_DELAY = 600;
     const LONG_PRESS_ANIM_MS = 200;
 
+    function canLongPress(){
+      return state.phase==='build' && ((selectedTool==='wall' && currentPiece) || selectedTool==='cannon');
+    }
+
     function genPiece(bricks){
       if(bricks<=0) return null;
       let piece, attempts=0;
@@ -296,7 +307,7 @@
           <li><strong>Defend:</strong> Ships sail in and fire at your defenses. Cannons auto-fire at ships.</li>
         </ul>
         <p>Score points by destroying ships and surviving waves. The game ends when the keep is destroyed, or you clear all ${MAX_WAVES} waves.</p>
-        <p>Tips: Place cannons behind walls. Repair damage during the next build phase. Rotate wall pieces with <kbd>R</kbd>, space, or the rotate button. Move a piece then press <kbd>Enter</kbd> or the place button to set it. The current piece is shown in the HUD.</p>
+        <p>Tips: Place cannons behind walls. Repair damage during the next build phase. On desktop, click to place pieces and press <kbd>R</kbd> to rotate them. On mobile, long press to place and tap to rotate. The current piece is shown in the HUD.</p>
       `;
     }
 
@@ -557,7 +568,7 @@
       longPressAnimating = false;
       longPressAnimProgress = 0;
       if(longPressTimeout){ clearTimeout(longPressTimeout); longPressTimeout=null; }
-      if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+      if(canLongPress()){
         longPressTimeout = setTimeout(()=>{
           longPressTimeout = null;
           startLongPressAnimation();
@@ -577,7 +588,7 @@
         longPressTimeout = null;
         touchStartX = t.clientX;
         touchStartY = t.clientY;
-        if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+        if(canLongPress()){
           longPressTimeout = setTimeout(()=>{
             longPressTimeout = null;
             startLongPressAnimation();
@@ -591,7 +602,7 @@
         longPressTimeout = null;
         touchStartX = t.clientX;
         touchStartY = t.clientY;
-        if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+        if(canLongPress()){
           longPressTimeout = setTimeout(()=>{
             longPressTimeout = null;
             startLongPressAnimation();
@@ -603,7 +614,7 @@
         longPressTimeout = null;
         touchStartX = t.clientX;
         touchStartY = t.clientY;
-        if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+        if(canLongPress()){
           longPressTimeout = setTimeout(()=>{
             longPressTimeout = null;
             startLongPressAnimation();
@@ -618,15 +629,21 @@
           longPressAnimating = false;
           longPressReady = false;
           longPressAnimProgress = 0;
-        } else if(state.phase==='build' && selectedTool==='wall' && currentPiece){
-        if(longPressReady && !touchMoved){
+        } else if(state.phase==='build'){ 
+        if(selectedTool==='wall' && currentPiece){
+          if(longPressReady && !touchMoved){
+            finalizePlacement();
+            longPressReady = false;
+            longPressAnimating = false;
+          }else if(!longPressReady && !touchMoved){
+            currentPiece = rotatePiece(currentPiece);
+            draw();
+            drawCurrentPreview();
+          }
+        } else if(selectedTool==='cannon' && longPressReady && !touchMoved){
           finalizePlacement();
           longPressReady = false;
           longPressAnimating = false;
-        }else if(!longPressReady && !touchMoved){
-          currentPiece = rotatePiece(currentPiece);
-          draw();
-          drawCurrentPreview();
         }
       }
       e.preventDefault();
@@ -637,27 +654,11 @@
     overlay.addEventListener('click', start);
     overlay.addEventListener('touchstart', (e)=>{ e.preventDefault(); start(); }, {passive:false});
 
-    rotateBtn.addEventListener('click', ()=>{
-      if(state.phase==='build' && selectedTool==='wall' && currentPiece){
+    window.addEventListener('keydown', (e)=>{
+      if(state.phase==='build' && selectedTool==='wall' && e.key==='r'){
         currentPiece = rotatePiece(currentPiece);
         draw();
         drawCurrentPreview();
-      }
-    });
-    rotateBtn.addEventListener('touchstart', (e)=>{ e.preventDefault(); rotateBtn.click(); });
-    placeBtn.addEventListener('click', finalizePlacement);
-    placeBtn.addEventListener('touchstart', (e)=>{ e.preventDefault(); finalizePlacement(); });
-
-    window.addEventListener('keydown', (e)=>{
-      if(state.phase==='build'){
-        if(selectedTool==='wall' && (e.key==='r' || e.key===' ')){
-          currentPiece = rotatePiece(currentPiece);
-          draw();
-          drawCurrentPreview();
-        }
-        if(e.key==='Enter'){
-          finalizePlacement();
-        }
       }
     });
 
@@ -806,9 +807,30 @@
         }
       } else if(selectedTool==='cannon'){
         const valid = canPlaceCannon(hoverCell.gx, hoverCell.gy);
+        const x = hoverCell.gx * tile;
+        const y = hoverCell.gy * tile;
+        const ringCx = x + tile;
+        const ringCy = y + tile;
+        const ringR = tile * (Math.SQRT2 + longPressAnimProgress);
+        const scale = longPressAnimating ? 1.6 - 0.6*longPressAnimProgress : 1;
+        ctx.save();
+        ctx.translate(ringCx, ringCy);
+        ctx.scale(scale, scale);
+        ctx.translate(-ringCx, -ringCy);
         ctx.globalAlpha = valid ? 0.7 : 0.3;
-        ctx.drawImage(Images.cannon, hoverCell.gx*tile, hoverCell.gy*tile, tile*2, tile*2);
+        ctx.drawImage(Images.cannon, x, y, tile*2, tile*2);
+        ctx.restore();
         ctx.globalAlpha = 1;
+        if(longPressAnimating){
+          ctx.save();
+          ctx.globalAlpha = 1 - longPressAnimProgress;
+          ctx.strokeStyle = '#FFD700';
+          ctx.lineWidth = Math.max(2, tile * 0.08);
+          ctx.beginPath();
+          ctx.arc(ringCx, ringCy, ringR, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.restore();
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Remove rotate and place buttons from Bastion Builder's toolbar
- Add textual instructions for placing and rotating on mobile and desktop
- Update how-to panel and keyboard handling to match new controls
- Enable long-press placement for cannons, matching wall behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81d52b22c8322adddfb3a94168d4b