### PR TITLE
Move Nova Striker final boss to wave 10

### DIFF
--- a/nova-striker/index.html
+++ b/nova-striker/index.html
@@ -348,7 +348,7 @@
       }
     }
 
-    // Final Boss (Wave 12, type X4): randomly switches between multiple patterns
+    // Final Boss (Wave 10, type X4): randomly switches between multiple patterns
     function bossShootFinal(e, dt) {
       // Initialize mode duration on first run
       if (!e.modeDur || e.modeDur <= 0) {
@@ -446,7 +446,7 @@
         currentMusic.play().catch(console.error);
         let label;
         if (isBossWave(wave)) {
-          label = (wave === 12) ? 'Final Boss' : ('Boss Wave ' + Math.floor(wave/3));
+          label = (wave === 10) ? 'Final Boss' : ('Boss Wave ' + Math.floor(wave/3));
         } else {
           label = 'Wave ' + wave;
         }
@@ -455,7 +455,7 @@
       }
     }
 
-    function isBossWave(n) { return n % 3 === 0; }
+    function isBossWave(n) { return n === 3 || n === 6 || n === 9 || n === 10; }
 
     function setupWave(n) {
       wave = n; waveEl.textContent = wave;
@@ -476,8 +476,8 @@
         if (running && !paused && !muted) currentMusic.play().catch(console.error);
       }
       if (isBossWave(n)) {
-        // Create a unique boss for waves 3, 6, 9
-        const idx = Math.floor(n / 3); // 1,2,3,(4 for final)
+        // Create a unique boss for waves 3, 6, 9, 10
+        const idx = (n === 10) ? 4 : Math.floor(n / 3); // 1,2,3,(4 for final)
         const bossHP = (idx === 1) ? 37 : (idx === 2) ? 180 : (idx === 3) ? 390 : 750;
         const bossW  = (idx === 1) ? 140 : (idx === 2) ? 160 : (idx === 3) ? 180 : 196;
         const bossH  = (idx === 1) ? 120 : (idx === 2) ? 135 : (idx === 3) ? 150 : 168;
@@ -532,27 +532,7 @@
           enemies.push({ x: 60 + Math.random()*(W-120), y: -200 - i*100, w: 52, h: 34, hp: 2 + Math.floor(n/3), type: 'W', t: Math.random()*6.28,
             pat: { amp: 90, freq: 1.5, vy: 1.2 + n*0.10 }, score: 180 });
         }
-        // Extra pressure on late non-boss waves 10 and 11
-        if (n === 10 || n === 11) {
-          // Add an additional fighter row
-          for (let c=0; c<cols; c++) {
-            enemies.push({
-              x: startX + c*gapX, y: -120 - rows*gapY,
-              w: 48, h: 46, hp: 1 + Math.floor((n-1)/3), type: 'F', t: Math.random()*6.28,
-              pat: { amp: 30 + 8*rows, freq: 1.1 + rows*0.15, vy: 1.4 + n*0.1 }
-            });
-          }
-          // Add a couple more bombers
-          for (let i=0; i<2; i++) {
-            enemies.push({ x: Math.random()*W, y: -300 - (bombers + i)*120, w: 56, h: 54, hp: 2 + Math.floor(n/2), type: 'B', t: Math.random()*6.28,
-              pat: { amp: 60, freq: 0.7, vy: 1.0 + n*0.12 } });
-          }
-          // Add one extra sniper and weaver
-          enemies.push({ x: 60 + Math.random()*(W-120), y: -350 - snipers*160, w: 40, h: 44, hp: 2 + Math.floor((n-1)/3), type: 'S', t: Math.random()*6.28,
-            pat: { amp: 18, freq: 0.7, vy: 0.9 + n*0.09 }, score: 350 });
-          enemies.push({ x: 60 + Math.random()*(W-120), y: -200 - weavers*100, w: 52, h: 34, hp: 2 + Math.floor(n/3), type: 'W', t: Math.random()*6.28,
-            pat: { amp: 90, freq: 1.5, vy: 1.2 + n*0.10 }, score: 180 });
-        }
+        // Extra pressure on late non-boss waves (none after wave 9)
       }
     }
 
@@ -1218,11 +1198,11 @@
         if (!endWaveTimeout) {
           endWaveTimeout = setTimeout(() => {
             endWaveTimeout = null;
-            if (wave >= 12) {
+            if (wave >= 10) {
               victory();
             } else {
               setupWave(wave + 1);
-              const label = isBossWave(wave) ? ((wave === 12) ? 'Final Boss' : ('Boss Wave ' + Math.floor(wave/3))) : ('Wave ' + wave);
+              const label = isBossWave(wave) ? ((wave === 10) ? 'Final Boss' : ('Boss Wave ' + Math.floor(wave/3))) : ('Wave ' + wave);
               showWaveBanner(label);
             }
           }, 2000);


### PR DESCRIPTION
## Summary
- Remove wave 11 and 12 progression
- Trigger the final boss and victory sequence on wave 10

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1002fda7483229865888b09530912