### PR TITLE
fix: unlock boss music on mobile

### DIFF
--- a/nova-striker/index.html
+++ b/nova-striker/index.html
@@ -484,6 +484,22 @@
         hideOverlay();
         running = true;
         currentMusic.play().catch(console.error);
+        // iOS Safari requires a user gesture to allow audio playback. Since the
+        // boss track has not been played yet when the game launches, attempting
+        // to switch to it later (e.g. when a boss wave begins) will fail unless
+        // it has been "unlocked" here. Pre-play all other music tracks muted
+        // so they are authorized for playback on mobile browsers.
+        for (const k in MUSIC) {
+          const m = MUSIC[k];
+          if (m === currentMusic) continue;
+          const prevVol = m.volume;
+          m.volume = 0;
+          m.play().then(() => {
+            m.pause();
+            m.currentTime = 0;
+            m.volume = prevVol;
+          }).catch(() => { m.volume = prevVol; });
+        }
         let label;
         if (isBossWave(wave)) {
           label = (wave === 10) ? 'Final Boss' : ('Boss Wave ' + Math.floor(wave/3));


### PR DESCRIPTION
## Summary
- prevent boss wave music from being blocked on iOS by pre-playing other tracks after user gesture

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a9886b248329be78a2e89f92e552