### PR TITLE
Enable off-canvas touch controls in Nova Striker

### DIFF
--- a/nova-striker/index.html
+++ b/nova-striker/index.html
@@ -331,6 +331,7 @@
     }
 
     function attachControls() {
+      const stageEl = document.querySelector('.stage');
       window.addEventListener('keydown', (e) => {
         if (e.code === 'ArrowLeft' || e.code === 'KeyA') input.left = true;
         if (e.code === 'ArrowRight' || e.code === 'KeyD') input.right = true;
@@ -344,7 +345,7 @@
       });
       // Clickable audio icon
       if (audioIcon) audioIcon.addEventListener('click', toggleAudio);
-      // Pointer controls: keep tracking even when leaving the canvas while dragging
+      // Pointer controls: allow starting outside the stage and keep tracking even when leaving the canvas while dragging
       let dragging = false;
       let activePointerId = null;
       function moveToPointer(e) {
@@ -378,6 +379,10 @@
         el.addEventListener('pointermove', onPointerMove);
         // In case capture is lost (e.g., OS gesture), stop dragging
         el.addEventListener('lostpointercapture', () => { dragging = false; activePointerId = null; });
+      });
+      // Start drag even if pointerdown happens outside the play area
+      window.addEventListener('pointerdown', (e) => {
+        if (!stageEl.contains(e.target)) onPointerDown(e);
       });
       // Continue tracking while outside the play area
       window.addEventListener('pointermove', onPointerMove);


### PR DESCRIPTION
## Summary
- Allow touch and drag inputs outside the play area to move the player ship
- Keep pointer tracking active even when dragging starts away from the stage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3368518a48322833b1607081ad81b