### PR TITLE
Add contextual sound effects to Nova Striker

### DIFF
--- a/nova-striker/index.html
+++ b/nova-striker/index.html
@@ -279,9 +279,35 @@
     let muted = false;
     const LS_MUTE_KEY = 'nova-striker:muted';
 
+    // Sound effects
+    const SFX = {
+      alienExplodeLarge: new Audio('assets/ns_sfx_alien_exploding_large.wav'),
+      alienExplodeSmall: new Audio('assets/ns_sfx_alien_exploding_small.wav'),
+      alienHit: new Audio('assets/ns_sfx_alien_hit.wav'),
+      alienLaser: new Audio('assets/ns_sfx_alien_laser.wav'),
+      playerLaser: new Audio('assets/ns_sfx_player_laser.wav'),
+      playerLaserBeam: new Audio('assets/ns_sfx_player_laserbeam.wav'),
+      playerMissile: new Audio('assets/ns_sfx_player_missile.wav'),
+      playerElectric: new Audio('assets/ns_sfx_player_electricity.wav'),
+      playerShield: new Audio('assets/ns_sfx_player_shield.wav'),
+      playerHit: new Audio('assets/ns_sfx_player_hit.wav'),
+      playerExplode: new Audio('assets/ns_sfx_player_exploding.wav')
+    };
+
+    function playSfx(name) {
+      if (muted) return;
+      const a = SFX[name];
+      if (a) {
+        const s = a.cloneNode();
+        s.muted = muted;
+        s.play().catch(() => {});
+      }
+    }
+
     function setMuted(m) {
       muted = !!m;
       currentMusic.muted = muted;
+      for (const a of Object.values(SFX)) a.muted = muted;
       if (muted) {
         try { currentMusic.pause(); } catch (e) {}
       } else {
@@ -428,6 +454,7 @@
           const ang = e.phase + i * (Math.PI*2/N);
           bullets.push({ x: e.x, y: e.y + e.h*0.25, vx: Math.cos(ang)*3.4, vy: Math.sin(ang)*3.4, good: false });
         }
+        playSfx('alienLaser');
       }
 
       // Active mode pattern
@@ -444,6 +471,7 @@
               const ang = base + i*0.28;
               bullets.push({ x: e.x, y: e.y + e.h*0.22, vx: Math.cos(ang)*speeds[i], vy: Math.sin(ang)*speeds[i], good: false });
             }
+            playSfx('alienLaser');
           }
           break;
         case 1:
@@ -456,6 +484,7 @@
               const ang = base + k * 0.09;
               bullets.push({ x: e.x, y: e.y + e.h*0.28, vx: Math.cos(ang)*7.4, vy: Math.sin(ang)*7.4, good: false });
             }
+            playSfx('alienLaser');
           }
           break;
         case 2:
@@ -468,6 +497,7 @@
               const ang = base + i*0.1;
               bullets.push({ x: e.x, y: e.y + e.h*0.3, vx: Math.cos(ang)*7.0, vy: Math.sin(ang)*7.0, good: false });
             }
+            playSfx('alienLaser');
           }
           e.spawnT = (e.spawnT || 0) + dt;
           if (e.spawnT >= 2.8) {
@@ -651,6 +681,7 @@
       } else if (d.type === 'S') {
         shieldActive = true; shieldPulse = 0;
         pickupMsgs.push({ text: 'SHIELD!', color: '#00e5ff', t: 0, dur: 1.8 });
+        playSfx('playerShield');
       } else {
         const kind = d.kind || pickUpgrade();
         applyUpgrade(kind);
@@ -686,6 +717,7 @@
               hit: new Set()
             });
           }
+          playSfx('playerLaserBeam');
         }
       }
 
@@ -703,12 +735,14 @@
             bullets.push({ x: P.x + off, y: P.y - P.h/2 - 4, vx, vy, good: true, kind: 'normal', dmg: 1 });
           }
         }
+        playSfx('playerLaser');
       }
     }
 
     function spawnMissile() {
       // Spawn from the ship center; initial upward velocity; will home in update
       bullets.push({ x: P.x, y: P.y - P.h/2 - 6, vx: 0, vy: -MISS.speed, good: true, kind: 'missile', dmg: 2, spd: MISS.speed });
+      playSfx('playerMissile');
     }
 
     function enemyShoot(e, chance=0.006, dt) {
@@ -717,6 +751,7 @@
       if (Math.random() < p) {
         const vx = (P.x - e.x) * 0.006; // slight aim
         bullets.push({ x: e.x, y: e.y + e.h/2, vx, vy: EB.speed, good: false });
+        playSfx('alienLaser');
       }
     }
 
@@ -736,6 +771,7 @@
         ang = base + delta;
         const spd = 10.5;
         bullets.push({ x: e.x, y: e.y + e.h/2, vx: Math.cos(ang)*spd, vy: Math.sin(ang)*spd, good: false });
+        playSfx('alienLaser');
       }
     }
 
@@ -751,6 +787,7 @@
           const ang = base + off;
           bullets.push({ x: e.x, y: e.y + e.h/2, vx: Math.cos(ang)*spd, vy: Math.sin(ang)*spd, good: false });
         }
+        playSfx('alienLaser');
       }
     }
 
@@ -767,6 +804,7 @@
           const ang = base + offsets[i];
           bullets.push({ x: e.x, y: e.y + e.h*0.3, vx: Math.cos(ang)*speeds[i], vy: Math.sin(ang)*speeds[i], good: false });
         }
+        playSfx('alienLaser');
       }
     }
 
@@ -780,6 +818,7 @@
           const ang = e.phase + (i * (Math.PI*2/N));
           bullets.push({ x: e.x, y: e.y + e.h*0.25, vx: Math.cos(ang)*4.2, vy: Math.sin(ang)*4.2, good: false });
         }
+        playSfx('alienLaser');
       }
     }
 
@@ -794,6 +833,7 @@
           const ang = base + i*0.12;
           bullets.push({ x: e.x, y: e.y + e.h*0.3, vx: Math.cos(ang)*6.5, vy: Math.sin(ang)*6.5, good: false });
         }
+        playSfx('alienLaser');
       }
       // Spawn fighters from top edges, up to a cap
       if (e.spawnT >= 3.5) {
@@ -907,6 +947,7 @@
                 spawnDrop(p.target);
                 // explosion on electro kill
                 spawnExplosion(tx, ty, (p.target && p.target.boss) ? 50 : 20, 'electric');
+                playSfx((p.target && p.target.boss) ? 'alienExplodeLarge' : 'alienExplodeSmall');
               }
             }
             // impact sparks at current destination
@@ -984,10 +1025,12 @@
       cand.sort((a,b) => a.d2 - b.d2);
       const maxChains = 2; // reduced overall damage by limiting number of chained targets
       const dmg = 1; // per-target shock damage upon arrival
-      for (let i=0; i<Math.min(maxChains, cand.length); i++) {
+      const chains = Math.min(maxChains, cand.length);
+      for (let i=0; i<chains; i++) {
         const e2 = cand[i].e;
         spawnElectricArc(hx, hy, e2.x, e2.y, { target: e2, damage: dmg });
       }
+      if (chains > 0) playSfx('playerElectric');
     }
 
     function update(dt) {
@@ -1087,9 +1130,12 @@
               if (e.hp <= 0) {
                 // explosion on laser kill
                 spawnExplosion(hitX, hitY, e.boss ? 50 : 22, 'orange');
+                playSfx(e.boss ? 'alienExplodeLarge' : 'alienExplodeSmall');
                 const add = (e.type === 'F') ? 100 : (e.type === 'B' ? 250 : (e.score || 2000));
                 if (!cheatInvuln) { score += add; scoreEl.textContent = score; }
                 spawnDrop(e);
+              } else {
+                playSfx('alienHit');
               }
             }
           }
@@ -1171,9 +1217,12 @@
             if (e.hp <= 0) {
               // explosion on bullet kill
               spawnExplosion(e.x, e.y, e.boss ? 50 : 22, 'orange');
+              playSfx(e.boss ? 'alienExplodeLarge' : 'alienExplodeSmall');
               const add = (e.type === 'F') ? 100 : (e.type === 'B' ? 250 : (e.score || 2000));
               if (!cheatInvuln) { score += add; scoreEl.textContent = score; }
               spawnDrop(e);
+            } else {
+              playSfx('alienHit');
             }
             break;
           }
@@ -1188,6 +1237,7 @@
             b.y = H + 999; // remove bullet
             if (shieldActive) {
               shieldActive = false;
+              playSfx('playerShield');
             } else {
               // explosion on player hit by bullet
               spawnExplosion(P.x, P.y, 26, 'orange');
@@ -1206,6 +1256,7 @@
             m.y = H + 999; // remove
             if (shieldActive) {
               shieldActive = false;
+              playSfx('playerShield');
             } else {
               hitPlayer();
             }
@@ -1223,10 +1274,13 @@
               e.hp = 0; shieldActive = false; spawnDrop(e);
               // explosion on enemy destroyed by shield
               spawnExplosion(e.x, e.y, e.boss ? 50 : 22, 'orange');
+              playSfx(e.boss ? 'alienExplodeLarge' : 'alienExplodeSmall');
+              playSfx('playerShield');
             } else {
               e.hp = 0;
               // explosions on collision: enemy and player
               spawnExplosion(e.x, e.y, e.boss ? 50 : 22, 'orange');
+              playSfx(e.boss ? 'alienExplodeLarge' : 'alienExplodeSmall');
               spawnExplosion(P.x, P.y, 26, 'orange');
               hitPlayer();
             }
@@ -1279,6 +1333,7 @@
       lives = Math.max(0, lives - 1);
       livesEl.textContent = lives;
       if (lives <= 0) {
+        playSfx('playerExplode');
         // Player destroyed: keep the world running for 2s so effects/enemies continue
         playerDead = true;
         invulnT = 999; // block further hits
@@ -1292,6 +1347,7 @@
           }, 2000);
         }
       } else {
+        playSfx('playerHit');
         // Brief invulnerability after being hit
         invulnT = 2.5; // seconds
         // Only show the "INVULNERABLE!" popup if the invulnerability cheat is enabled.


### PR DESCRIPTION
## Summary
- load all Nova Striker sound effect assets and helper to play them
- hook sound effects into player weapons, shield, enemy hits, and explosions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3c64a73b48329b6ba9beca5d8828f