### PR TITLE
Fix mobile HUD overlap in Core Crisis

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -12,7 +12,11 @@
       --ink: #F5F5DC;
       --ui: rgba(0,0,0,0.75);
     }
-    * { box-sizing: border-box; }
+    * {
+      box-sizing: border-box;
+      -webkit-user-select: none;
+      user-select: none;
+    }
     html, body { height: 100%; }
     body {
       margin: 0;
@@ -21,7 +25,6 @@
       font-family: 'Press Start 2P', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
       overflow: hidden;
       touch-action: manipulation;
-      user-select: none;
     }
     .wrap {
       position: relative;
@@ -163,12 +166,17 @@
     const ctx = canvas.getContext('2d');
     let W = canvas.width, H = canvas.height;
 
+    const topbar = document.querySelector('.topbar');
+    const isTouch = window.matchMedia('(pointer: coarse)').matches;
     function resize() {
       const ratio = 16/9;
-      let w = window.innerWidth, h = window.innerHeight;
+      let w = window.innerWidth;
+      const topOffset = isTouch ? topbar.offsetHeight : 0;
+      let h = window.innerHeight - topOffset;
       if (w/h > ratio) { w = h * ratio; } else { h = w / ratio; }
       canvas.style.width = w + 'px';
       canvas.style.height = h + 'px';
+      canvas.style.top = topOffset + 'px';
     }
     window.addEventListener('resize', resize); resize();
 


### PR DESCRIPTION
## Summary
- Offset game canvas by top bar height on touch devices to prevent HUD overlap
- Disable text selection on mobile to avoid drag selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b66db523dc8322886560bc86f37bc5