### PR TITLE
Handle missing images in Aurora Tower Defense

### DIFF
--- a/aurora-tower-defense/index.html
+++ b/aurora-tower-defense/index.html
@@ -256,7 +256,24 @@
       portal: 'assets/td_portal.svg',
     };
     const Images = {};
-    function loadImg(src) { return new Promise((res, rej) => { const i = new Image(); i.onload = () => res(i); i.onerror = rej; i.src = src; }); }
+    function loadImg(src) {
+      return new Promise((res) => {
+        const i = new Image();
+        i.onload = () => res(i);
+        i.onerror = () => {
+          console.warn('Failed to load image', src);
+          const canvas = document.createElement('canvas');
+          canvas.width = canvas.height = 32;
+          const ctx2 = canvas.getContext('2d');
+          ctx2.fillStyle = '#f0f';
+          ctx2.fillRect(0, 0, 32, 32);
+          const fallback = new Image();
+          fallback.src = canvas.toDataURL();
+          fallback.onload = () => res(fallback);
+        };
+        i.src = src;
+      });
+    }
 
     // Path definitions (grid points)
     const MAPS = [


### PR DESCRIPTION
## Summary
- prevent image load errors from breaking Aurora Tower Defense
- add visible placeholder sprite when an asset fails to load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cc3e7a708329b2ade491faa2758b