### PR TITLE
Use PNG art for Core Crisis pickups

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -189,13 +189,13 @@
       p2: 'assets/player-run-2.svg',
       p3: 'assets/player-run-3.svg',
       p4: 'assets/player-run-4.svg',
-      spike: 'assets/spike.svg',
-      orb: 'assets/orb.svg',
-      gem: 'assets/gem.svg',
-      jetpack: 'assets/jetpack.svg',
+      spike: 'assets/rr_smasher.png',
+      orb: 'assets/rr_pickup_coolant_small.png',
+      gem: 'assets/rr_pickup_coolant_large.png',
+      jetpack: 'assets/rr_pickup_jetpack.png',
       glider: 'assets/glider.svg',
       gun: 'assets/gun.svg',
-      shield: 'assets/shield.svg',
+      shield: 'assets/rr_pickup_shield.png',
     };
 
     const IMG = {};


### PR DESCRIPTION
## Summary
- Switch Core Crisis pickups from old SVG assets to new PNG art

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf2ed4b48329a4bdc189a4d722c6