### PR TITLE
Replace Core Crisis spikes with flame animation

### DIFF
--- a/core-crisis/assets/spike.svg
+++ b/core-crisis/assets/spike.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" fill="none"/>
-  <g transform="translate(32,38)">
-    <polygon points="-20,20 0,-16 20,20" fill="#4b1f2a" stroke="#ff6a88" stroke-width="3"/>
-    <polygon points="-16,20 0,-6 16,20" fill="#6b2a3a" opacity="0.6"/>
-  </g>
-</svg>
-

--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -189,7 +189,7 @@
       p2: 'assets/player-run-2.svg',
       p3: 'assets/player-run-3.svg',
       p4: 'assets/player-run-4.svg',
-      spike: 'assets/spike.svg',
+      flame: 'assets/Bot_animation_Flame_up.png',
       orb: 'assets/orb.svg',
       gem: 'assets/gem.svg',
       jetpack: 'assets/jetpack.svg',
@@ -203,6 +203,9 @@
     };
 
     const IMG = {};
+    const FLAME_FRAME_W = 64;
+    const FLAME_FRAME_H = 128;
+    const FLAME_FRAMES = 12;
     function loadImage(path) { return new Promise(res=>{ const i=new Image(); i.src=path; i.onload=()=>res(i); i.onerror=()=>res(i); }); }
     Promise.all(Object.entries(ASSETS).map(async ([k,p])=> IMG[k] = await loadImage(p))).then(()=>{
       init();
@@ -275,7 +278,7 @@
     const P = { x: 200, y: GROUND_Y, vx: 0, vy: 0, w: 64, h: 64, onGround: true, glide: false, hitX: 0.48, hitY: 0.56, hitOffsetY: -8, isJumping: false, jumpT: 0 };
 
     // Entities
-    const spikes=[]; // ground obstacles
+    const spikes=[]; // ground flame obstacles
     const platforms=[]; // floating platforms the player can land on
     const orbs=[];   // floating hazards
     const gems=[];   // collectibles
@@ -319,8 +322,8 @@
 
     // Grid-based placement to align items and prevent overlaps at spawn
     // Choose a grid cell size large enough to fit the largest item entirely
-    // spike=54, orb=48, jetpack=44, glider=44, shield=44, gem=34, coolant small=28, coolant large=44
-    const GRID_CELL = Math.max(54, 48, 44, 44, 44, 34, 28);
+    // flame=64, orb=48, jetpack=44, glider=44, shield=44, gem=34, coolant small=28, coolant large=44
+    const GRID_CELL = Math.max(64, 48, 44, 44, 44, 34, 28);
     // Occupied spawn-column rows with expiry times (seconds since start)
     const gridOccupied = new Map(); // rowIndex -> expiresAtTime
     // Convert between row index and Y center. Row 0 is at ground, grows upward.
@@ -614,11 +617,11 @@
         const nowSec = time;
         const x = gridSpawnX();
         if (Math.random() < 0.55) {
-          // Spike at ground: reserve row 0 if free; otherwise skip this cycle
+          // Flame at ground: reserve row 0 if free; otherwise skip this cycle
           const row = tryReserveRow(0, 0, nowSec);
           if (row !== null) {
             const y = yForRow(row);
-            spikes.push({ x, y, w: 54, h: 54, img: IMG.spike, hitX: 0.42, hitY: 0.30, hitOffsetY: -12 });
+            spikes.push({ x, y, w: 64, h: 64, img: IMG.flame, frame: 0, t: 0, hitX: 0.42, hitY: 0.30, hitOffsetY: -12 });
           }
         } else {
           // Floating orb: allow rows safely above ground (row >= 2)
@@ -797,7 +800,11 @@
 
       // Move hazards + gems
       const move = v => v - RUN_SPEED * scrollMul * dt;
-      for (const s of spikes) s.x = move(s.x);
+      for (const s of spikes) {
+        s.x = move(s.x);
+        s.t += dt;
+        if (s.t > 0.08) { s.t = 0; s.frame = (s.frame + 1) % FLAME_FRAMES; }
+      }
       for (const pl of platforms) pl.x = move(pl.x);
       for (const o of orbs) { o.x = move(o.x); o.t += dt; o.y = (o.baseY ?? o.y) + Math.sin(o.t * 4.3) * 18; }
       for (const gobj of gems) { gobj.x = move(gobj.x); gobj.t += dt; gobj.y = (gobj.baseY ?? gobj.y) + Math.sin(gobj.t * 6.1) * 14; }
@@ -1126,7 +1133,7 @@
       }
 
       // Draw hazards
-      for (const s of spikes) drawImg(s.img, s.x, s.y, s.w, s.h);
+      for (const s of spikes) drawSprite(s.img, s.frame, FLAME_FRAME_W, FLAME_FRAME_H, s.x, s.y, s.w, s.h);
       // Draw platforms
       for (const pl of platforms) drawPlatform(pl.x, pl.y, pl.w, pl.h);
       for (const o of orbs) drawImg(o.img, o.x, o.y, o.w, o.h);
@@ -1174,6 +1181,10 @@
 
     function drawLayer(img, x, y, w, h){ ctx.drawImage(img, x - 2, y, w + 4, h); }
     function drawImg(img, x, y, w, h){ ctx.drawImage(img, Math.round(x - w/2), Math.round(y - h/2), w, h); }
+    function drawSprite(img, frame, fw, fh, x, y, w, h){
+      const sx = frame * fw;
+      ctx.drawImage(img, sx, 0, fw, fh, Math.round(x - w/2), Math.round(y - h/2), w, h);
+    }
     function drawPlatform(x, y, w, h){
       const left = Math.round(x - w/2), top = Math.round(y - h/2);
       ctx.save();

--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -620,8 +620,9 @@
           // Flame at ground: reserve row 0 if free; otherwise skip this cycle
           const row = tryReserveRow(0, 0, nowSec);
           if (row !== null) {
-            const y = yForRow(row);
-            spikes.push({ x, y, w: 64, h: 64, img: IMG.flame, frame: 0, t: 0, hitX: 0.42, hitY: 0.30, hitOffsetY: -12 });
+            // offset so the flame rests on the ground instead of being centered on it
+            const y = yForRow(row) - 32;
+            spikes.push({ x, y, w: 64, h: 64, img: IMG.flame, frame: 0, t: 0, hitX: 0.42, hitY: 0.30, hitOffsetY: 20 });
           }
         } else {
           // Floating orb: allow rows safely above ground (row >= 2)


### PR DESCRIPTION
## Summary
- Swap static spike obstacle for animated Bot_animation_Flame_up flame
- Animate flame frames during movement and rendering
- Remove unused spike asset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b89d3d39088329a8fe487ae9a1a71b