### PR TITLE
Use sprite sheet for running animation in Core Crisis

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -185,10 +185,7 @@
       sky: 'assets/parallax-sky.svg',
       hills: 'assets/parallax-mountains.svg',
       fg: 'assets/parallax-foreground.svg',
-      p1: 'assets/player-run-1.svg',
-      p2: 'assets/player-run-2.svg',
-      p3: 'assets/player-run-3.svg',
-      p4: 'assets/player-run-4.svg',
+      botRun: 'assets/Bot_animation_running.png',
       spike: 'assets/spike.svg',
       orb: 'assets/orb.svg',
       gem: 'assets/gem.svg',
@@ -1205,8 +1202,11 @@
       for (const pb of pshots) drawPlayerBullet(pb.x, pb.y, pb.w, pb.h);
 
       // Player
-      const pf = animFrame===0?IMG.p1:animFrame===1?IMG.p2:animFrame===2?IMG.p3:IMG.p4;
-      drawImg(pf, P.x, P.y, P.w, P.h);
+      const runFrames = 4;
+      const fw = IMG.botRun.width / runFrames;
+      const fh = IMG.botRun.height;
+      ctx.drawImage(IMG.botRun, animFrame * fw, 0, fw, fh,
+        Math.round(P.x - P.w/2), Math.round(P.y - P.h/2), P.w, P.h);
       if (hasShield) drawImg(IMG.shieldImg, P.x, P.y, P.w * 1.5, P.h * 1.5);
 
       // End shake transform


### PR DESCRIPTION
## Summary
- Replace four separate player running frames with `Bot_animation_running.png` sprite sheet
- Draw player by cropping appropriate frame from the sprite sheet

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b98fe719608329a85a15e4d37aed3e