### PR TITLE
Switch player to gun-running animation after pickup

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -187,6 +187,8 @@
       fg: 'assets/parallax-foreground.svg',
       // Player running spritesheet (4 frames)
       playerRun: 'assets/Bot_animation_running.png',
+      // Player running spritesheet when holding the gun (4 frames)
+      playerRunGun: 'assets/bot_animation_running_gun.png',
       spike: 'assets/spike.svg',
       orb: 'assets/orb.svg',
       gem: 'assets/gem.svg',
@@ -1235,7 +1237,7 @@
     function drawLayer(img, x, y, w, h){ ctx.drawImage(img, x - 2, y, w + 4, h); }
     function drawImg(img, x, y, w, h){ ctx.drawImage(img, Math.round(x - w/2), Math.round(y - h/2), w, h); }
     function drawPlayer(x, y, w, h, frame){
-      const img = IMG.playerRun;
+      const img = (hasGun && IMG.playerRunGun && IMG.playerRunGun.width) ? IMG.playerRunGun : IMG.playerRun;
       if (!img || !img.width) { return; }
       const frames = 4;
       const fw = Math.floor(img.width / frames);


### PR DESCRIPTION
## Summary
- Load dedicated playerRunGun sprite for Core Crisis
- Swap to gun-running animation when gun upgrade is active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e833eb6c8329b4dba446b7e87c60