### PR TITLE
Play Core Crisis soundtracks sequentially

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -299,7 +299,10 @@
     const pshots=[];   // player bullets (from gun)
 
     // Soundtrack playback
-    const TRACKS = ['cc_soundtrack01.mp3', 'cc_soundtrack02.mp3'].filter(t => t.includes('soundtrack'));
+    const TRACKS = [
+      'assets/cc_soundtrack01.mp3',
+      'assets/cc_soundtrack02.mp3'
+    ].filter(t => t.includes('soundtrack'));
     let trackIndex = 0;
     let musicStarted = false;
     const music = new Audio();
@@ -310,10 +313,10 @@
       music.play();
     });
     function startMusic(){
-    //   if (musicStarted || !TRACKS.length) return;
-    //   musicStarted = true;
-    //   music.src = TRACKS[trackIndex];
-    //   music.play();
+      if (musicStarted || !TRACKS.length) return;
+      musicStarted = true;
+      music.src = TRACKS[trackIndex];
+      music.play();
     }
 
     // Parallax layers positions


### PR DESCRIPTION
## Summary
- Add soundtrack playlist to Core Crisis and implement continuous sequential playback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f4eadb108329bc5852e07829e276