### PR TITLE
Remove floating bubble hazards from core crisis

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -195,7 +195,6 @@
       playerFlyHit: 'assets/bot_animation_flying_hit.png',
       playerFlyGun: 'assets/bot_animation_flying_gun.png',
       spike: 'assets/spike.svg',
-      orb: 'assets/orb.svg',
       gem: 'assets/gem.svg',
       jetpack: 'assets/rr_pickup_jetpack.png',
       glider: 'assets/rr_glider.png',
@@ -293,7 +292,6 @@
       { key: 'platformMedium', w: 240, h: 48 },
       { key: 'platformLong', w: 336, h: 48 },
     ];
-    const orbs=[];   // floating hazards
     const gems=[];   // collectibles
     const jetpacks=[]; // jetpack pickup(s)
     const gliders=[];  // glider pickup(s)
@@ -365,7 +363,7 @@
       frameTimer=0; animFrame=0; spawnTimer=0; gemTimer=0; coolantTimer = rand(2.5, 4.5);
       heat = 0;
       worldFreeze = 0; hitFlash = 0; shake = 0; hitGrace = 0;
-      spikes.length=0; platforms.length=0; orbs.length=0; gems.length=0; jetpacks.length=0; gliders.length=0; guns.length=0; coolants.length=0; cogs.length=0; smashers.length=0; flyers.length=0; shots.length=0; pshots.length=0;
+      spikes.length=0; platforms.length=0; gems.length=0; jetpacks.length=0; gliders.length=0; guns.length=0; coolants.length=0; cogs.length=0; smashers.length=0; flyers.length=0; shots.length=0; pshots.length=0;
       P.x = 200; P.y = GROUND_Y; P.vx = 0; P.vy = 0; P.onGround = true; P.glide=false; P.isJumping=false; P.jumpT=0;
       Object.assign(L, { sky1:0, sky2:W, h1:0, h2:W, f1:0, f2:W });
       // Clear any lingering input so the new run doesn't start with stuck keys
@@ -386,8 +384,8 @@
 
     // Grid-based placement to align items and prevent overlaps at spawn
     // Choose a grid cell size large enough to fit the largest item entirely
-    // spike=54, orb=48, jetpack=44, glider=44, shield=44, gem=34, coolant small=28, coolant large=44
-    const GRID_CELL = Math.max(54, 48, 44, 44, 44, 34, 28);
+    // spike=54, jetpack=44, glider=44, shield=44, gem=34, coolant small=28, coolant large=44
+    const GRID_CELL = Math.max(54, 44, 44, 44, 34, 28);
     // Small visual nudge so drawn sprites look centered between vertical borders
     const GRID_ITEM_X_OFFSET = 2; // pixels to the right; platforms excluded
     // Occupied spawn-column rows with expiry times (seconds since start)
@@ -685,21 +683,11 @@
         spawnTimer = rand(0.9, 1.6);
         const nowSec = time;
         const x = gridSpawnX() + GRID_ITEM_X_OFFSET;
-        if (Math.random() < 0.55) {
-          // Spike at ground: reserve row 0 if free; otherwise skip this cycle
-          const row = tryReserveRow(0, 0, nowSec);
-          if (row !== null) {
-            const y = yForRow(row);
-            spikes.push({ x, y, w: 54, h: 54, img: IMG.spike, hitX: 0.42, hitY: 0.30, hitOffsetY: -12 });
-          }
-        } else {
-          // Floating orb: allow rows safely above ground (row >= 2)
-          const maxRow = Math.max(0, Math.floor((GROUND_Y - 48/2) / GRID_CELL));
-          const row = tryReserveRow(Math.min(2, maxRow), maxRow, nowSec);
-          if (row !== null) {
-            const y = yForRow(row);
-            orbs.push({ x, y, baseY: y, w: 48, h: 48, img: IMG.orb, t: 0, hitX: 0.56, hitY: 0.56 });
-          }
+        // Spike at ground: reserve row 0 if free; otherwise skip this cycle
+        const row = tryReserveRow(0, 0, nowSec);
+        if (row !== null) {
+          const y = yForRow(row);
+          spikes.push({ x, y, w: 54, h: 54, img: IMG.spike, hitX: 0.42, hitY: 0.30, hitOffsetY: -12 });
         }
       }
 
@@ -894,7 +882,6 @@
       const move = v => v - RUN_SPEED * scrollMul * dt;
       for (const s of spikes) s.x = move(s.x);
       for (const pl of platforms) pl.x = move(pl.x);
-      for (const o of orbs) { o.x = move(o.x); o.t += dt; o.y = (o.baseY ?? o.y) + Math.sin(o.t * 4.3) * 18; }
       for (const gobj of gems) { gobj.x = move(gobj.x); gobj.t += dt; gobj.y = (gobj.baseY ?? gobj.y) + Math.sin(gobj.t * 6.1) * 14; }
       for (const jp of jetpacks) { jp.x = move(jp.x); jp.t += dt; jp.y = (jp.baseY ?? jp.y) + Math.sin(jp.t * 3.7) * 10; }
       for (const gl of gliders) { gl.x = move(gl.x); gl.t += dt; gl.y = (gl.baseY ?? gl.y) + Math.sin(gl.t * 3.9) * 10; }
@@ -989,7 +976,6 @@
       // Remove offscreen
       while (spikes.length && spikes[0].x + spikes[0].w < 0) spikes.shift();
       while (platforms.length && platforms[0].x + platforms[0].w/2 < 0) platforms.shift();
-      while (orbs.length && orbs[0].x + orbs[0].w < 0) orbs.shift();
       while (gems.length && gems[0].x + gems[0].w < 0) gems.shift();
       while (jetpacks.length && jetpacks[0].x + jetpacks[0].w < 0) jetpacks.shift();
       while (gliders.length && gliders[0].x + gliders[0].w < 0) gliders.shift();
@@ -1046,18 +1032,6 @@
             loseRandomItem();
           }
           // Bounce up to escape overlap and start grace window
-          P.vy = Math.min(P.vy, -350);
-          P.onGround = false;
-          P.y = Math.max(P.h/2, P.y - 10);
-          hitGrace = 0.6; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
-          return; // process one hazard hit per frame
-        }
-        for (const o of orbs) if (hit(P, o)) {
-          if (!consumeShieldOnHit()) {
-            heat = clamp(heat + (hasJetpack ? HEAT_HIT_PENALTY : HEAT_HIT_PENALTY_NO_JET), 0, HEAT_MAX);
-            loseRandomItem();
-          }
-          // Bounce away and grace
           P.vy = Math.min(P.vy, -350);
           P.onGround = false;
           P.y = Math.max(P.h/2, P.y - 10);
@@ -1271,7 +1245,6 @@
       for (const s of spikes) drawImg(s.img, s.x, s.y, s.w, s.h);
       // Draw platforms
       for (const pl of platforms) drawPlatform(pl.x, pl.y, pl.w, pl.h, pl.img);
-      for (const o of orbs) drawImg(o.img, o.x, o.y, o.w, o.h);
       for (const g of gems) drawImg(g.img, g.x, g.y, g.w, g.h);
       for (const jp of jetpacks) drawImg(jp.img, jp.x, jp.y, jp.w, jp.h);
       for (const gl of gliders) drawImg(gl.img, gl.x, gl.y, gl.w, gl.h);


### PR DESCRIPTION
## Summary
- remove orb asset and related logic from core crisis
- simplify hazard spawning to ground spikes only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba4a93b41c8329aa2fef5e3829ae9c