### PR TITLE
Increase spacing between flame hazards

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -680,7 +680,8 @@
       // Spawning hazards
       spawnTimer -= dt;
       if (spawnTimer <= 0) {
-        spawnTimer = rand(0.9, 1.6);
+        // longer delay so ground flames appear farther apart
+        spawnTimer = rand(1.8, 3.2);
         const nowSec = time;
         const x = gridSpawnX() + GRID_ITEM_X_OFFSET;
         // Spike at ground: reserve row 0 if free; otherwise skip this cycle


### PR DESCRIPTION
## Summary
- Extend hazard spawn interval so ground flames appear farther apart in Core Crisis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba5556b9a08329b0440aed4cae2c14