### PR TITLE
Add post-hit invincibility with blinking

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -272,7 +272,7 @@
     let spawnTimer=0, gemTimer=0;
     let platformTimer=0;
     let coolantTimer=0;
-    let hitGrace = 0;            // short invulnerability after taking a hit
+    let hitGrace = 0;            // 1s invulnerability after taking a hit (player blinks)
     let worldFreeze = 0;         // halt forward scroll briefly after impact
     let hitFlash = 0;            // red flash overlay intensity timer
     let shake = 0;               // camera shake magnitude (pixels)
@@ -1068,7 +1068,7 @@
           P.vy = Math.min(P.vy, -350);
           P.onGround = false;
           P.y = Math.max(P.h/2, P.y - 10);
-          hitGrace = 0.6; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
+          hitGrace = 1; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
           return; // process one hazard hit per frame
         }
         for (const cg of cogs) if (hit(P, cg)) {
@@ -1079,7 +1079,7 @@
           P.vy = Math.min(P.vy, -350);
           P.onGround = false;
           P.y = Math.max(P.h/2, P.y - 10);
-          hitGrace = 0.6; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
+          hitGrace = 1; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
           return;
         }
         for (const sm of smashers) if (sm.state !== 'peek' && hit(P, sm)) {
@@ -1090,7 +1090,7 @@
           P.vy = Math.min(P.vy, -350);
           P.onGround = false;
           P.y = Math.max(P.h/2, P.y - 10);
-          hitGrace = 0.6; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
+          hitGrace = 1; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
           return;
         }
         // Flyer body collision
@@ -1102,7 +1102,7 @@
           P.vy = Math.min(P.vy, -350);
           P.onGround = false;
           P.y = Math.max(P.h/2, P.y - 10);
-          hitGrace = 0.6; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
+          hitGrace = 1; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
           return;
         }
         // Enemy shots collision
@@ -1117,7 +1117,7 @@
             P.vy = Math.min(P.vy, -300);
             P.onGround = false;
             P.y = Math.max(P.h/2, P.y - 8);
-            hitGrace = 0.5; worldFreeze = Math.max(worldFreeze, 0.3); hitFlash = Math.max(hitFlash, 0.28); shake = Math.max(shake, 10);
+            hitGrace = 1; worldFreeze = Math.max(worldFreeze, 0.3); hitFlash = Math.max(hitFlash, 0.28); shake = Math.max(shake, 10);
             return;
           }
         }
@@ -1328,6 +1328,8 @@
     function drawLayer(img, x, y, w, h){ ctx.drawImage(img, x - 2, y, w + 4, h); }
     function drawImg(img, x, y, w, h){ ctx.drawImage(img, Math.round(x - w/2), Math.round(y - h/2), w, h); }
     function drawPlayer(x, y, w, h, frame){
+      // Blink while invincible
+      if (hitGrace > 0 && Math.floor(time * 10) % 2 === 0) return;
       let img;
       let frames = 4;
       if (P.glide && IMG.playerGlide) {


### PR DESCRIPTION
## Summary
- Add blinking effect to player while invulnerable
- Extend post-hit invulnerability to one second

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba64d79d9c8329abd2a4dbb9e2235e