### PR TITLE
Add first boss with beam attack

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -235,6 +235,8 @@
       platformMedium: 'assets/rr_conveyor_platform_medium.png',
       platformLong: 'assets/rr_conveyor_platform_long.png',
       smasher: 'assets/rr_smasher.png',
+      bossEyeShut: 'assets/boss_eyeball_shut.png',
+      bossEyeOpen: 'assets/boss_eyeball_open.png',
     };
 
     const IMG = {};
@@ -331,6 +333,8 @@
     const flyers=[];   // flying enemies that hover and shoot
     const shots=[];    // enemy bullets
     const pshots=[];   // player bullets (from gun)
+    let boss = null;   // first boss entity
+    let bossSpawned = false;
 
     // Soundtrack playback
     const TRACKS = [
@@ -392,6 +396,7 @@
       heat = 0;
       worldFreeze = 0; hitFlash = 0; shake = 0; hitGrace = 0;
       spikes.length=0; platforms.length=0; gems.length=0; jetpacks.length=0; gliders.length=0; guns.length=0; coolants.length=0; cogs.length=0; smashers.length=0; flyers.length=0; shots.length=0; pshots.length=0;
+      boss = null; bossSpawned = false;
       P.x = 200; P.y = GROUND_Y; P.vx = 0; P.vy = 0; P.onGround = true; P.glide=false; P.isJumping=false; P.jumpT=0;
       Object.assign(L, { sky1:0, sky2:W, h1:0, h2:W, f1:0, f2:W });
       // Clear any lingering input so the new run doesn't start with stuck keys
@@ -449,6 +454,54 @@
         return r;
       }
       return null;
+    }
+
+    function spawnBoss(){
+      const w = P.w * 2;
+      const h = P.h * 2;
+      const totalRows = Math.floor(GROUND_Y / GRID_CELL);
+      const midRow = Math.round(totalRows / 2);
+      const y = yForRow(midRow);
+      boss = {
+        x: W + w / 2,
+        y,
+        w,
+        h,
+        hp: 30,
+        maxHp: 30,
+        state: 'enter',
+        fireTimer: 3,
+        exposeTimer: 0,
+        beamActive: false,
+        targetRow: midRow,
+        hitX: 0.6,
+        hitY: 0.6,
+      };
+    }
+
+    function updateBoss(dt){
+      if (!boss) return;
+      const targetX = W - boss.w/2 - 40;
+      if (boss.state === 'enter') {
+        boss.x -= 80 * dt;
+        if (boss.x <= targetX) { boss.x = targetX; boss.state = 'closed'; boss.fireTimer = 2.5; }
+      } else if (boss.state === 'closed') {
+        boss.fireTimer -= dt;
+        if (boss.fireTimer <= 0) {
+          boss.state = 'open';
+          boss.exposeTimer = 2;
+          boss.beamActive = true;
+          const totalRows = Math.floor(GROUND_Y / GRID_CELL);
+          boss.targetRow = Math.floor(Math.random() * (totalRows + 1));
+        }
+      } else if (boss.state === 'open') {
+        boss.exposeTimer -= dt;
+        if (boss.exposeTimer <= 0) {
+          boss.state = 'closed';
+          boss.beamActive = false;
+          boss.fireTimer = rand(3,5);
+        }
+      }
     }
 
     // Heat system
@@ -560,6 +613,8 @@
 
     function update(dt){
       time += dt;
+      if (!boss && !bossSpawned && time >= 45) { spawnBoss(); bossSpawned = true; }
+      updateBoss(dt);
       if (hitGrace > 0) hitGrace -= dt;
       if (worldFreeze > 0) worldFreeze -= dt;
       if (hitFlash > 0) hitFlash -= dt;
@@ -1134,6 +1189,20 @@
             return;
           }
         }
+        if (boss && boss.beamActive) {
+          const beamRow = boss.targetRow;
+          if (rowForY(P.y) === beamRow && P.x < boss.x) {
+            if (!consumeShieldOnHit()) {
+              heat = clamp(heat + (hasJetpack ? HEAT_HIT_PENALTY : HEAT_HIT_PENALTY_NO_JET), 0, HEAT_MAX);
+              loseRandomItem();
+            }
+            P.vy = Math.min(P.vy, -350);
+            P.onGround = false;
+            P.y = Math.max(P.h/2, P.y - 10);
+            hitGrace = 2; worldFreeze = Math.max(worldFreeze, 0.4); hitFlash = Math.max(hitFlash, 0.35); shake = Math.max(shake, 14);
+            return;
+          }
+        }
       }
       // Gem pickups add score with multiplier based on current combo (applies AFTER 5/10 streak)
       for (let i=gems.length-1; i>=0; i--) {
@@ -1210,14 +1279,18 @@
         }
       }
 
-      // Player bullet collisions: only destroy flying enemies; +1 score
+      // Player bullet collisions: destroy flying enemies or boss; +1 score
       for (let i = pshots.length - 1; i >= 0; i--) {
         const b = pshots[i];
-        let hitFlyer = false;
+        let hitSomething = false;
         for (let j = flyers.length - 1; j >= 0; j--) {
-          if (hit(b, flyers[j])) { flyers.splice(j,1); hitFlyer = true; score += 1; break; }
+          if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; score += 1; break; }
         }
-        if (hitFlyer) { pshots.splice(i,1); }
+        if (!hitSomething && boss && boss.state === 'open' && hit(b, boss)) {
+          boss.hp -= 1; score += 1; hitSomething = true;
+          if (boss.hp <= 0) boss = null;
+        }
+        if (hitSomething) { pshots.splice(i,1); }
       }
     }
 
@@ -1304,6 +1377,26 @@
       for (const c of coolants) drawImg(c.img, c.x, c.y, c.w, c.h);
       for (const sm of smashers) drawImg(IMG.smasher, sm.x, sm.y, sm.w, sm.h);
       for (const cg of cogs) drawCog(cg.x, cg.y, cg.w, cg.h, cg.t);
+
+      if (boss) {
+        if (boss.beamActive) {
+          const y = yForRow(boss.targetRow);
+          ctx.fillStyle = 'rgba(255,0,0,0.6)';
+          ctx.fillRect(0, y - GRID_CELL/2, boss.x, GRID_CELL);
+        }
+        const img = boss.state === 'open' ? IMG.bossEyeOpen : IMG.bossEyeShut;
+        drawImg(img, boss.x, boss.y, boss.w, boss.h);
+        const barW = boss.w;
+        const barH = 12;
+        const barX = boss.x - barW/2;
+        const barY = boss.y - boss.h/2 - 20;
+        ctx.fillStyle = 'rgba(0,0,0,0.6)';
+        ctx.fillRect(barX, barY, barW, barH);
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(barX, barY, barW * (boss.hp / boss.maxHp), barH);
+        ctx.strokeStyle = '#fff';
+        ctx.strokeRect(barX, barY, barW, barH);
+      }
 
       // Draw flyers and shots
       for (const f of flyers) drawFlyer(f.x, f.y, f.w, f.h, f.state);


### PR DESCRIPTION
## Summary
- add eyeball boss assets and spawn logic
- implement boss beam attack and vulnerability cycles
- render boss with health bar and process beam and bullet collisions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baf8eb270c832998f3b9f9062efd5f