### PR TITLE
Double Core Crisis boss laser linger time

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -267,7 +267,7 @@
     const BOSS_OPEN_DURATION = 0.3;
     const BOSS_CLOSE_DURATION = 0.3;
     const BOSS_LASER_DURATION = 0.6;
-    const BOSS_EXPOSE_DURATION = 1.0;
+    const BOSS_EXPOSE_DURATION = 2.0;
     const BOSS_COOLDOWN_MAX = 6;
     const BOSS_COOLDOWN_MIN = 2;
     const BOSS_TELEGRAPH_MAX = 1.5;


### PR DESCRIPTION
## Summary
- Increase BOSS_EXPOSE_DURATION so the first boss's laser sprite stays on screen twice as long after firing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6ac912548329b4f1f1ba436919c5