### PR TITLE
Extend boss laser exposure in Core Crisis

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -267,7 +267,7 @@
     const BOSS_OPEN_DURATION = 0.3;
     const BOSS_CLOSE_DURATION = 0.3;
     const BOSS_LASER_DURATION = 0.6;
-    const BOSS_EXPOSE_DURATION = 1.0;
+    const BOSS_EXPOSE_DURATION = 3.0;
     const BOSS_COOLDOWN_MAX = 6;
     const BOSS_COOLDOWN_MIN = 2;
     const BOSS_TELEGRAPH_MAX = 1.5;


### PR DESCRIPTION
## Summary
- Lengthen Core Crisis boss laser exposure time so the boss keeps the laser sprite active for 3 seconds after firing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6d3be19c8329bda02ca3d08d3225