### PR TITLE
feat(core-crisis): add boss health bar and damage flash

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -71,7 +71,14 @@
     .heatbar-fill { position: absolute; left: 0; top: 0; bottom: 0; width: 0%; background: linear-gradient(90deg, #34d399 0%, #fbbf24 50%, #ef4444 100%); box-shadow: inset 0 0 6px rgba(255,255,255,0.2); }
     .heatbar-text { position: absolute; inset: 0; display: grid; place-items: center; font-size: 10px; color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,0.8); }
     /* Boss health bar */
-    #bossHud { min-width: 220px; }
+    #bossHud {
+      position: absolute;
+      top: 60px;
+      left: 50%;
+      transform: translateX(-50%);
+      min-width: 220px;
+      pointer-events: none;
+    }
     #bossHud:not(.hidden) { display: grid; gap: 6px; }
     .boss-label { font-size: 11px; color: #f87171; opacity: 0.95; }
     .bossbar { position: relative; height: 12px; width: 100%; background: rgba(255,255,255,0.08); border: 1px solid rgba(248,113,113,0.6); border-radius: 8px; overflow: hidden; }
@@ -152,11 +159,11 @@
       <div class="chip hidden" id="shieldHud">
         <div class="jet-label">Shield</div>
       </div>
-      <div class="chip hidden" id="bossHud">
-        <div class="boss-label">Boss</div>
-        <div class="bossbar"><div class="bossbar-fill" id="bossFill"></div><div class="bossbar-text" id="bossText">100%</div></div>
-      </div>
       <a href="../index.html" class="btn btn-primary back">← Back to Home</a>
+    </div>
+    <div id="bossHud" class="hidden">
+      <div class="boss-label">Boss</div>
+      <div class="bossbar"><div class="bossbar-fill" id="bossFill"></div><div class="bossbar-text" id="bossText">100%</div></div>
     </div>
     <div id="upgradeNotify" class="upgrade-notify"></div>
   </div>
@@ -659,7 +666,8 @@
           vulnerable: false,
           spawnedFlyer: false,
           hitX: 0.3,
-          hitY: 0.3
+          hitY: 0.3,
+          flashT: 0
         };
       }
       if (boss) {
@@ -669,6 +677,7 @@
           if (bossFill) bossFill.style.width = `${pct}%`;
           if (bossText) bossText.textContent = `${pct}%`;
         }
+        if (boss.flashT > 0) boss.flashT = Math.max(0, boss.flashT - dt);
         switch (boss.state) {
           case 'entry':
             boss.x -= 80 * dt;
@@ -1368,7 +1377,7 @@
           if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; score += 1; break; }
         }
         if (!hitSomething && boss && boss.vulnerable && hit(b, boss)) {
-          boss.hp--; hitSomething = true; playSfx(SFX.bossHit);
+          boss.hp--; boss.flashT = 0.2; hitSomething = true; playSfx(SFX.bossHit);
           if (boss.hp <= 0) { boss = null; if (bossHud) bossHud.classList.add('hidden'); }
         }
         if (hitSomething) { pshots.splice(i,1); }
@@ -1471,10 +1480,13 @@
         ctx.fillRect(0, beamY - beamH/2, beamLeft, beamH);
       }
       if (boss) {
+        ctx.save();
+        if (boss.flashT > 0) ctx.filter = 'brightness(1.8)';
         if (boss.state === 'open') drawBossOpen(boss);
         else if (boss.state === 'close') drawBossClose(boss);
         else if (boss.state === 'laser' || boss.state === 'post') drawImg(IMG.bossLaser, boss.x, boss.y, boss.w, boss.h);
         else drawImg(IMG.bossShut, boss.x, boss.y, boss.w, boss.h);
+        ctx.restore();
       }
 
       // Player (4-frame spritesheet)


### PR DESCRIPTION
## Summary
- Move boss health bar to the top-center HUD and style it as a slim bar
- Add flash effect when bosses take damage

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7019c81c83299ae0b58536519c6d