### PR TITLE
Display boss health bar in Core Crisis

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -71,12 +71,20 @@
     .heatbar-fill { position: absolute; left: 0; top: 0; bottom: 0; width: 0%; background: linear-gradient(90deg, #34d399 0%, #fbbf24 50%, #ef4444 100%); box-shadow: inset 0 0 6px rgba(255,255,255,0.2); }
     .heatbar-text { position: absolute; inset: 0; display: grid; place-items: center; font-size: 10px; color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,0.8); }
     /* Boss health bar */
-    #bossHud { min-width: 220px; }
-    #bossHud:not(.hidden) { display: grid; gap: 6px; }
-    .boss-label { font-size: 11px; color: #f87171; opacity: 0.95; }
-    .bossbar { position: relative; height: 12px; width: 100%; background: rgba(255,255,255,0.08); border: 1px solid rgba(248,113,113,0.6); border-radius: 8px; overflow: hidden; }
-    .bossbar-fill { position: absolute; left: 0; top: 0; bottom: 0; width: 100%; background: linear-gradient(90deg, #dc2626 0%, #ef4444 100%); box-shadow: inset 0 0 6px rgba(255,255,255,0.2); }
-    .bossbar-text { position: absolute; inset: 0; display: grid; place-items: center; font-size: 10px; color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,0.8); }
+    #bossHud {
+      position: absolute;
+      left: 50%; transform: translateX(-50%);
+      width: 200px; height: 6px;
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(248,113,113,0.6);
+      border-radius: 4px; overflow: hidden;
+    }
+    #bossHud.hidden { display: none; }
+    #bossFill {
+      position: absolute; left: 0; top: 0; bottom: 0; width: 100%;
+      background: linear-gradient(90deg, #dc2626 0%, #ef4444 100%);
+      box-shadow: inset 0 0 6px rgba(255,255,255,0.2);
+    }
     .btn { pointer-events: auto; text-decoration: none; cursor: pointer; }
     .btn-primary {
       background: linear-gradient(45deg, var(--teal), #4682B4);
@@ -152,14 +160,11 @@
       <div class="chip hidden" id="shieldHud">
         <div class="jet-label">Shield</div>
       </div>
-      <div class="chip hidden" id="bossHud">
-        <div class="boss-label">Boss</div>
-        <div class="bossbar"><div class="bossbar-fill" id="bossFill"></div><div class="bossbar-text" id="bossText">100%</div></div>
+        <a href="../index.html" class="btn btn-primary back">← Back to Home</a>
       </div>
-      <a href="../index.html" class="btn btn-primary back">← Back to Home</a>
+      <div id="bossHud" class="hidden"><div id="bossFill"></div></div>
+      <div id="upgradeNotify" class="upgrade-notify"></div>
     </div>
-    <div id="upgradeNotify" class="upgrade-notify"></div>
-  </div>
 
     <div class="center" id="startScreen">
       <div class="panel">
@@ -204,17 +209,19 @@
       }, 1000);
     }
     const isTouch = window.matchMedia('(pointer: coarse)').matches;
-    function resize() {
-      const ratio = 16/9;
-      let w = window.innerWidth;
-      const topOffset = isTouch ? topbar.offsetHeight : 0;
-      let h = window.innerHeight - topOffset;
-      if (w/h > ratio) { w = h * ratio; } else { h = w / ratio; }
-      canvas.style.width = w + 'px';
-      canvas.style.height = h + 'px';
-      canvas.style.top = topOffset + 'px';
-    }
-    window.addEventListener('resize', resize); resize();
+      function resize() {
+        const ratio = 16/9;
+        let w = window.innerWidth;
+        const topOffset = isTouch ? topbar.offsetHeight : 0;
+        let h = window.innerHeight - topOffset;
+        if (w/h > ratio) { w = h * ratio; } else { h = w / ratio; }
+        canvas.style.width = w + 'px';
+        canvas.style.height = h + 'px';
+        canvas.style.top = topOffset + 'px';
+        const b = document.getElementById('bossHud');
+        if (b) b.style.top = topbar.offsetHeight + 6 + 'px';
+      }
+      window.addEventListener('resize', resize); resize();
 
     // Asset loading
     const ASSETS = {
@@ -510,7 +517,6 @@
     const shieldText = shieldHud ? shieldHud.querySelector('.jet-label') : null;
     const bossHud = document.getElementById('bossHud');
     const bossFill = document.getElementById('bossFill');
-    const bossText = document.getElementById('bossText');
     const finalScore = document.getElementById('finalScore');
     const lbBtn = document.getElementById('lbBtn');
     const mobile = document.getElementById('mobileCtrls');
@@ -667,7 +673,6 @@
         if (bossHud) {
           bossHud.classList.remove('hidden');
           if (bossFill) bossFill.style.width = `${pct}%`;
-          if (bossText) bossText.textContent = `${pct}%`;
         }
         switch (boss.state) {
           case 'entry':


### PR DESCRIPTION
## Summary
- Add a thin boss health bar positioned below the HUD in Core Crisis
- Update resize logic to keep the bar centered under the top information panel
- Remove unused boss HUD label and percent text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb73c70be88329a0b3761834e5e740