### PR TITLE
Add bottom Overseer boss health bar

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -37,7 +37,7 @@
     }
     .hud {
       position: absolute; inset: 0; pointer-events: none;
-      padding: 10px;
+      padding: 10px 10px 0 10px;
     }
     .topbar {
       display: flex; gap: 12px; align-items: center; justify-content: flex-start;
@@ -70,13 +70,22 @@
     .heatbar { position: relative; height: 12px; width: 100%; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,99,71,0.6); border-radius: 8px; overflow: hidden; }
     .heatbar-fill { position: absolute; left: 0; top: 0; bottom: 0; width: 0%; background: linear-gradient(90deg, #34d399 0%, #fbbf24 50%, #ef4444 100%); box-shadow: inset 0 0 6px rgba(255,255,255,0.2); }
     .heatbar-text { position: absolute; inset: 0; display: grid; place-items: center; font-size: 10px; color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,0.8); }
-    /* Boss health bar */
-    #bossHud { min-width: 220px; }
-    #bossHud:not(.hidden) { display: grid; gap: 6px; }
-    .boss-label { font-size: 11px; color: #f87171; opacity: 0.95; }
-    .bossbar { position: relative; height: 12px; width: 100%; background: rgba(255,255,255,0.08); border: 1px solid rgba(248,113,113,0.6); border-radius: 8px; overflow: hidden; }
+    /* Boss health bar fixed to bottom */
+    #bossHud {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: none;
+      align-items: center;
+      gap: 8px;
+      padding: 4px 8px;
+      background: var(--ui);
+    }
+    #bossHud:not(.hidden) { display: flex; }
+    .boss-label { font-size: 12px; color: #f87171; white-space: nowrap; }
+    .bossbar { position: relative; flex: 1; height: 6px; background: rgba(255,255,255,0.08); border: 1px solid rgba(248,113,113,0.6); overflow: hidden; }
     .bossbar-fill { position: absolute; left: 0; top: 0; bottom: 0; width: 100%; background: linear-gradient(90deg, #dc2626 0%, #ef4444 100%); box-shadow: inset 0 0 6px rgba(255,255,255,0.2); }
-    .bossbar-text { position: absolute; inset: 0; display: grid; place-items: center; font-size: 10px; color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,0.8); }
     .btn { pointer-events: auto; text-decoration: none; cursor: pointer; }
     .btn-primary {
       background: linear-gradient(45deg, var(--teal), #4682B4);
@@ -149,17 +158,17 @@
       <div class="chip hidden" id="gunHud">
         <div class="jet-label">Gun</div>
       </div>
-      <div class="chip hidden" id="shieldHud">
-        <div class="jet-label">Shield</div>
+        <div class="chip hidden" id="shieldHud">
+          <div class="jet-label">Shield</div>
+        </div>
+        <a href="../index.html" class="btn btn-primary back">← Back to Home</a>
       </div>
-      <div class="chip hidden" id="bossHud">
-        <div class="boss-label">Boss</div>
-        <div class="bossbar"><div class="bossbar-fill" id="bossFill"></div><div class="bossbar-text" id="bossText">100%</div></div>
+      <div id="bossHud" class="hidden">
+        <span class="boss-label">Overseer:</span>
+        <div class="bossbar"><div class="bossbar-fill" id="bossFill"></div></div>
       </div>
-      <a href="../index.html" class="btn btn-primary back">← Back to Home</a>
+      <div id="upgradeNotify" class="upgrade-notify"></div>
     </div>
-    <div id="upgradeNotify" class="upgrade-notify"></div>
-  </div>
 
     <div class="center" id="startScreen">
       <div class="panel">


### PR DESCRIPTION
## Summary
- Move Core Crisis boss HP display to the bottom of the screen
- Style a thin red health bar labeled "Overseer:" that appears only while the boss lives

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb7a7ce8bc8329a8a404d5170b438a