### PR TITLE
Add soundtrack shuffling utility

### DIFF
--- a/__tests__/shuffleSoundtrack.test.js
+++ b/__tests__/shuffleSoundtrack.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { shuffleSoundtrack } = require('../src/shuffleSoundtrack');
+
+describe('shuffleSoundtrack', () => {
+  test('finds and shuffles soundtrack mp3 files', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'st-test-'));
+    try {
+      // create dummy files
+      fs.writeFileSync(path.join(tmpDir, 'intro.mp3'), '');
+      fs.writeFileSync(path.join(tmpDir, 'main_soundtrack.mp3'), '');
+      fs.writeFileSync(path.join(tmpDir, 'ending_soundtrack.mp3'), '');
+
+      const shuffled = shuffleSoundtrack(tmpDir);
+      expect(shuffled).toHaveLength(2);
+      expect(shuffled.every(p => p.includes('soundtrack'))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/shuffleSoundtrack.js
+++ b/src/shuffleSoundtrack.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function getSoundtracks(dir) {
+  return fs.readdirSync(dir)
+    .filter(f => f.toLowerCase().includes('soundtrack') && f.toLowerCase().endsWith('.mp3'))
+    .map(f => path.join(dir, f));
+}
+
+function shuffleSoundtrack(dir = '.') {
+  const tracks = getSoundtracks(dir);
+  shuffle(tracks);
+  return tracks;
+}
+
+if (require.main === module) {
+  const tracks = shuffleSoundtrack(process.argv[2] || '.');
+  if (!tracks.length) {
+    console.log('No soundtrack mp3 files found.');
+  } else {
+    tracks.forEach(t => console.log(t));
+  }
+}
+
+module.exports = { shuffleSoundtrack };


### PR DESCRIPTION
## Summary
- add `shuffleSoundtrack` helper to collect and shuffle soundtrack MP3s
- test soundtrack shuffling against temporary directory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bba0840cfc8329a9d51426ce040987