### PR TITLE
Play enemy hit sound across games

### DIFF
--- a/aurora-tower-defense/index.html
+++ b/aurora-tower-defense/index.html
@@ -292,6 +292,9 @@
     let enemies = []; // {id, x,y, seg, t, spd, hp, maxHp, slow, slowTimer}
     let nextEnemyId = 1;
 
+    const sfxEnemyHit = new Audio('assets/sfx_enemy_hit.wav');
+    function playEnemyHit(){ try{ sfxEnemyHit.cloneNode().play(); } catch{} }
+
     const TOWER_CONF = {
       basic: { range: 2.6, rof: 0.8, dmg: 16, spd: 420, cost: 25 },
       slow:  { range: 2.2, rof: 1.2, dmg: 8,  spd: 380, slow: 0.55, slowDur: 1.4, cost: 35 },
@@ -558,6 +561,7 @@
         if(hit){
           let extra = 0; if(b.bonus && b.bonus[hit.type]) extra = b.bonus[hit.type];
           hit.hp -= b.dmg + extra;
+          playEnemyHit();
           if(b.slow){ hit.slow = Math.min(hit.slow, b.slow); hit.slowTimer = Math.max(hit.slowTimer, b.slowDur); }
           b.dead = true;
         }

--- a/bastion-builder/index.html
+++ b/bastion-builder/index.html
@@ -230,6 +230,9 @@
     const bullets = []; // {x,y,vx,vy,spd,dmg,owner}
     const placementHistory = []; // stack of actions to support Undo during build
 
+    const sfxEnemyHit = new Audio('assets/sfx_enemy_hit.wav');
+    function playEnemyHit(){ try{ sfxEnemyHit.cloneNode().play(); } catch{} }
+
     // Enclosed area mask (computed at end of build phase)
     let enclosedMask = null; // Array[ROWS][COLS] of booleans
 
@@ -1118,7 +1121,7 @@
         // out of bounds
         if(b.x < -40 || b.y < -40 || b.x > COLS*tile+40 || b.y > ROWS*tile+40){ b.dead=true; continue; }
         if(b.owner==='cannon'){
-          for(const s of ships){ if(Math.hypot(s.x-b.x, s.y-b.y) < tile*0.5){ s.hp -= b.dmg; b.dead = true; if(s.hp<=0){ s.dead = true; state.kills++; } break; } }
+          for(const s of ships){ if(Math.hypot(s.x-b.x, s.y-b.y) < tile*0.5){ s.hp -= b.dmg; playEnemyHit(); b.dead = true; if(s.hp<=0){ s.dead = true; state.kills++; } break; } }
         } else { // ship bullet
           // walls
           for(const w of walls){ const p = gridToPx(w.gx, w.gy); if(Math.hypot(p.x-b.x, p.y-b.y) < tile*0.6){ w.hp -= b.dmg; b.dead=true; break; } }

--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -416,7 +416,8 @@
       cog: new Audio('assets/sfx_cog.wav'),
       upgrade: new Audio('assets/sfx_upgrade.wav'),
       bossLaser: new Audio('assets/sfx_boss_laser.wav'),
-      bossHit: new Audio('assets/sfx_boss_hit.wav')
+      bossHit: new Audio('assets/sfx_boss_hit.wav'),
+      enemyHit: new Audio('assets/sfx_enemy_hit.wav')
     };
     function playSfx(s) {
       try { s.cloneNode().play(); } catch {}
@@ -1413,7 +1414,7 @@
         const b = pshots[i];
         let hitSomething = false;
         for (let j = flyers.length - 1; j >= 0; j--) {
-          if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; if (!heatCheat) score += 1; break; }
+          if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; playSfx(SFX.enemyHit); if (!heatCheat) score += 1; break; }
         }
         if (!hitSomething && boss && boss.vulnerable && hit(b, boss)) {
           boss.hp--; boss.flash = 0.25; hitSomething = true; playSfx(SFX.bossHit);

--- a/neon-brick-breaker/index.html
+++ b/neon-brick-breaker/index.html
@@ -202,6 +202,9 @@
     let ballVX = 0, ballVY = 0;
     let bricks = [];
 
+    const sfxEnemyHit = new Audio('assets/sfx_enemy_hit.wav');
+    function playEnemyHit(){ try{ sfxEnemyHit.cloneNode().play(); } catch{} }
+
     const input = { left:false, right:false };
     // Leaderboard integration
     const GAME_ID = 'neon-brick-breaker';
@@ -362,6 +365,7 @@
             ballVX *= -1; // horizontal flip
           }
           br.hp -= 1;
+          playEnemyHit();
           if (br.hp <= 0) { br.alive = false; score += 50; }
           else { score += 20; }
           scoreEl.textContent = score;

--- a/nova-striker/index.html
+++ b/nova-striker/index.html
@@ -279,6 +279,9 @@
     let muted = false;
     const LS_MUTE_KEY = 'nova-striker:muted';
 
+    const sfxEnemyHit = new Audio('assets/sfx_enemy_hit.wav');
+    function playEnemyHit(){ if(!muted){ try{ sfxEnemyHit.cloneNode().play(); } catch{} } }
+
     function setMuted(m) {
       muted = !!m;
       currentMusic.muted = muted;
@@ -901,6 +904,7 @@
           if (!p.didDamage && p.progress >= 1) {
             if (p.target && p.target.hp > 0) {
               p.target.hp -= (p.damage || 1);
+              playEnemyHit();
               if (p.target.hp <= 0) {
                 const add = (p.target.type === 'F') ? 100 : (p.target.type === 'B' ? 250 : (p.target.score || 2000));
                 if (!cheatInvuln) { score += add; scoreEl.textContent = score; }
@@ -1082,6 +1086,7 @@
               // subtle hit sparks on laser contact
               spawnHitSparks(hitX, hitY, 8, 1.3);
               e.hp -= L.dmg;
+              playEnemyHit();
               // Electro chain from this laser hit
               triggerElectro(e, hitX, hitY);
               if (e.hp <= 0) {
@@ -1159,7 +1164,7 @@
           if (Math.abs(b.x - e.x) < (e.w/2) && Math.abs(b.y - e.y) < (e.h/2)) {
             // capture impact point BEFORE removing the bullet
             const hitX = b.x, hitY = b.y;
-            e.hp -= (b.dmg || 1); b.y = -9999; // remove
+            e.hp -= (b.dmg || 1); playEnemyHit(); b.y = -9999; // remove
             if (b.kind === 'missile') {
               // distinct smaller cyan burst for missile impacts
               spawnMissileBurst(hitX, hitY, 12);


### PR DESCRIPTION
## Summary
- play shared enemy hit sound when units take damage or are destroyed in Aurora Tower Defense, Bastion Builder, Core Crisis, Neon Brick Breaker and Nova Striker

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc21b88bcc8329a15b668ccfd5980f