### PR TITLE
feat(core-crisis): trigger enemy hit sound effect

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -416,7 +416,8 @@
       cog: new Audio('assets/sfx_cog.wav'),
       upgrade: new Audio('assets/sfx_upgrade.wav'),
       bossLaser: new Audio('assets/sfx_boss_laser.wav'),
-      bossHit: new Audio('assets/sfx_boss_hit.wav')
+      bossHit: new Audio('assets/sfx_boss_hit.wav'),
+      enemyHit: new Audio('assets/sfx_enemy_hit.wav')
     };
     function playSfx(s) {
       try { s.cloneNode().play(); } catch {}
@@ -1413,10 +1414,10 @@
         const b = pshots[i];
         let hitSomething = false;
         for (let j = flyers.length - 1; j >= 0; j--) {
-          if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; if (!heatCheat) score += 1; break; }
+          if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; if (!heatCheat) score += 1; playSfx(SFX.enemyHit); break; }
         }
         if (!hitSomething && boss && boss.vulnerable && hit(b, boss)) {
-          boss.hp--; boss.flash = 0.25; hitSomething = true; playSfx(SFX.bossHit);
+          boss.hp--; boss.flash = 0.25; hitSomething = true; playSfx(SFX.enemyHit); playSfx(SFX.bossHit);
             if (boss.hp <= 0) {
               boss = null;
               bossNextTime = time + 30;


### PR DESCRIPTION
## Summary
- play `sfx_enemy_hit.wav` when enemies take damage
- register enemy hit sound in the Core Crisis sound library

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc27429c308329abfb0b39e5f22a2c