### PR TITLE
feat(core-crisis): play enemy hit sound on damage

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -415,6 +415,7 @@
       jetpack: new Audio('assets/sfx_bot_jetpack.wav'),
       cog: new Audio('assets/sfx_cog.wav'),
       upgrade: new Audio('assets/sfx_upgrade.wav'),
+      enemyHit: new Audio('assets/sfx_enemy_hit.wav'),
       bossLaser: new Audio('assets/sfx_boss_laser.wav'),
       bossHit: new Audio('assets/sfx_boss_hit.wav')
     };
@@ -1413,10 +1414,10 @@
         const b = pshots[i];
         let hitSomething = false;
         for (let j = flyers.length - 1; j >= 0; j--) {
-          if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; if (!heatCheat) score += 1; break; }
+          if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; if (!heatCheat) score += 1; playSfx(SFX.enemyHit); break; }
         }
         if (!hitSomething && boss && boss.vulnerable && hit(b, boss)) {
-          boss.hp--; boss.flash = 0.25; hitSomething = true; playSfx(SFX.bossHit);
+          boss.hp--; boss.flash = 0.25; hitSomething = true; playSfx(SFX.enemyHit); playSfx(SFX.bossHit);
             if (boss.hp <= 0) {
               boss = null;
               bossNextTime = time + 30;


### PR DESCRIPTION
## Summary
- play enemy hit SFX when flyers are destroyed or boss is damaged
- add enemy hit sound effect asset to SFX library

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2975af60832998559f5373f5ba27