### PR TITLE
feat(core-crisis): add boss defeat sound and notification

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -173,6 +173,7 @@
       <div class="bossbar"><div class="bossbar-fill" id="bossFill"></div></div>
     </div>
     <div id="upgradeNotify" class="upgrade-notify"></div>
+    <div id="bossNotify" class="upgrade-notify"></div>
   </div>
 
     <div class="center" id="startScreen">
@@ -215,6 +216,15 @@
       clearTimeout(upgradeNotify._hide);
       upgradeNotify._hide = setTimeout(() => {
         upgradeNotify.style.opacity = 0;
+      }, 1000);
+    }
+    const bossNotify = document.getElementById('bossNotify');
+    function showBossDefeated() {
+      bossNotify.textContent = 'Boss Defeated!';
+      bossNotify.style.opacity = 1;
+      clearTimeout(bossNotify._hide);
+      bossNotify._hide = setTimeout(() => {
+        bossNotify.style.opacity = 0;
       }, 1000);
     }
     const isTouch = window.matchMedia('(pointer: coarse)').matches;
@@ -418,7 +428,8 @@
       upgrade: new Audio('assets/sfx_upgrade.wav'),
       enemyHit: new Audio('assets/sfx_enemy_hit.wav'),
       bossLaser: new Audio('assets/sfx_boss_laser.wav'),
-      bossHit: new Audio('assets/sfx_boss_hit.wav')
+      bossHit: new Audio('assets/sfx_boss_hit.wav'),
+      bossKilled: new Audio('assets/sfx_boss_killed.wav')
     };
     function playSfx(s) {
       try { s.cloneNode().play(); } catch {}
@@ -1420,6 +1431,8 @@
         if (!hitSomething && boss && boss.vulnerable && hit(b, boss)) {
           boss.hp -= GUN_DAMAGE; boss.flash = 0.25; hitSomething = true; playSfx(SFX.enemyHit); playSfx(SFX.bossHit);
             if (boss.hp <= 0) {
+              playSfx(SFX.bossKilled);
+              showBossDefeated();
               boss = null;
               bossNextTime = time + 30;
               difficulty++;


### PR DESCRIPTION
## Summary
- play `sfx_boss_killed.wav` when the boss is destroyed
- show a fading "Boss Defeated!" notice on screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3c0e5ed48329bc92211837c09c32