### PR TITLE
Double Core Crisis SFX volume

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -431,8 +431,18 @@
       bossHit: new Audio('assets/sfx_boss_hit.wav'),
       bossKill: new Audio('assets/sfx_boss_killed.wav')
     };
+    // Boost sound effect volume without altering music volume
+    for (const k in SFX) {
+      // double the original volume but cap at the maximum of 1
+      SFX[k].volume = Math.min(1, (SFX[k].volume || 1) * 2);
+    }
     function playSfx(s) {
-      try { s.cloneNode().play(); } catch {}
+      try {
+        const a = s.cloneNode();
+        // ensure the cloned audio uses the boosted volume
+        a.volume = s.volume;
+        a.play();
+      } catch {}
     }
 
     // Parallax layers positions


### PR DESCRIPTION
## Summary
- Boost sound effect volume in Core Crisis without affecting soundtrack

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc439b6cb48329b76979ffefebada7