### PR TITLE
Boost Core Crisis sound effects volume

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -393,6 +393,7 @@
     const START_TRACK = 'assets/cc_soundtrack02.mp3';
     let musicStarted = false;
     const music = new Audio();
+    music.volume = 1; // keep soundtrack volume unchanged
     let playOrder = [];
     function shuffle(arr) {
       for (let i = arr.length - 1; i > 0; i--) {
@@ -431,8 +432,27 @@
       bossHit: new Audio('assets/sfx_boss_hit.wav'),
       bossKill: new Audio('assets/sfx_boss_killed.wav')
     };
+    const SFX_VOLUME = 3;
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    const audioCtx = AudioCtx ? new AudioCtx() : null;
+    let sfxGain;
+    if (audioCtx) {
+      sfxGain = audioCtx.createGain();
+      sfxGain.gain.value = SFX_VOLUME;
+      sfxGain.connect(audioCtx.destination);
+    }
     function playSfx(s) {
-      try { s.cloneNode().play(); } catch {}
+      try {
+        const node = s.cloneNode();
+        if (audioCtx) {
+          const source = audioCtx.createMediaElementSource(node);
+          source.connect(sfxGain);
+          if (audioCtx.state === 'suspended') audioCtx.resume();
+        } else {
+          node.volume = 1;
+        }
+        node.play();
+      } catch {}
     }
 
     // Parallax layers positions


### PR DESCRIPTION
## Summary
- Triple Core Crisis sound effects using an `AudioContext` gain node
- Keep the soundtrack volume unchanged while restoring SFX playback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc44cc28d88329989c1349e512c333