### PR TITLE
Award points for defeating bosses in Core Crisis

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -1454,6 +1454,7 @@
           hitSomething = true;
           if (boss.hp <= 0) {
             playSfx(SFX.bossKill);
+            if (!heatCheat) score += 10;
             showBossDefeated();
             boss = null;
             bossNextTime = time + 30;


### PR DESCRIPTION
## Summary
- grant 10 points when a boss is defeated in Core Crisis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc51efadb48329bbfa80f7d32f396f