### PR TITLE
fix(core-crisis): shrink crane boss

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -763,12 +763,14 @@
           const frames = 4;
           const fw = moveImg.width / frames;
           const fh = moveImg.height;
+          const craneW = fw / 2;
+          const craneH = fh / 2;
           boss = {
             type: 'crane',
-            x: W + fw,
+            x: W + craneW,
             y: BOSS_LANES[1],
-            w: fw,
-            h: fh,
+            w: craneW,
+            h: craneH,
             state: 'entry',
             hp: BOSS_MAX_HP * difficulty,
             maxHp: BOSS_MAX_HP * difficulty,


### PR DESCRIPTION
## Summary
- make crane boss (second boss) spawn at half size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd0c57d6cc83299c0933d91a151196