### PR TITLE
Ensure enemy hit sound plays on boss damage

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -1611,6 +1611,7 @@
           boss.hp -= GUN_DAMAGE;
           boss.flash = 0.25;
           hitSomething = true;
+          playSfx(SFX.enemyHit);
           if (boss.hp <= 0) {
             playSfx(SFX.bossKill);
             if (!heatCheat) score += 10;
@@ -1627,7 +1628,6 @@
             runSpeed = RUN_SPEED * (1 + 0.1 * (difficulty - 1));
             if (bossHud) bossHud.classList.add('hidden');
           } else {
-            playSfx(SFX.enemyHit);
             playSfx(SFX.bossHit);
           }
         }


### PR DESCRIPTION
## Summary
- Always play the enemy hit sound whenever a boss takes damage in Core Crisis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bee6abcd9083299ecb1133651845d2