### PR TITLE
Shuffle Core Crisis soundtrack

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -406,9 +406,10 @@
     // Soundtrack playback
     const TRACKS = [
       'assets/cc_soundtrack01.mp3',
-      'assets/cc_soundtrack02.mp3'
+      'assets/cc_soundtrack02.mp3',
+      'assets/cc_soundtrack03.mp3',
+      'assets/cc_soundtrack04.mp3'
     ].filter(t => t.includes('soundtrack'));
-    const START_TRACK = 'assets/cc_soundtrack02.mp3';
     let musicStarted = false;
     const music = new Audio();
     music.volume = 1; // keep soundtrack volume unchanged
@@ -421,8 +422,7 @@
       return arr;
     }
     function preparePlaylist() {
-      const others = TRACKS.filter(t => t !== START_TRACK);
-      playOrder = shuffle(others.slice());
+      playOrder = shuffle(TRACKS.slice());
     }
     music.addEventListener('ended', () => {
       if (!playOrder.length) preparePlaylist();
@@ -434,7 +434,8 @@
       if (musicStarted || !TRACKS.length) return;
       musicStarted = true;
       preparePlaylist();
-      music.src = START_TRACK;
+      if (!playOrder.length) return;
+      music.src = playOrder.shift();
       music.play();
     }
 


### PR DESCRIPTION
## Summary
- Randomize Core Crisis soundtrack selection across all available tracks
- Shuffle playlist to vary background music each session

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bef8496dc48329868261b6868630ae