### PR TITLE
Use fighter image for Emberfall hero

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -191,7 +191,7 @@
       shadow: new Image(),
       spark: new Image(),
     };
-    IMG.hero.src = 'assets/eg_hero.svg';
+    IMG.hero.src = 'assets/EG_hero_fighter.png';
     IMG.slime.src = 'assets/eg_slime.svg';
     IMG.swift.src = 'assets/eg_swift.svg';
     IMG.brute.src = 'assets/eg_brute.svg';


### PR DESCRIPTION
## Summary
- Use `EG_hero_fighter.png` as the main hero sprite in Emberfall Gauntlet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfb8b19aa4832980e943ec1550882b