### PR TITLE
feat: add final boss overseer

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -277,6 +277,11 @@
       bossCraneMove: 'assets/boss_crane_moving.png',
       bossCraneAttackHigh: 'assets/boss_crane_attack_high.png',
       bossCraneAttackLow: 'assets/boss_crane_attack_low.png',
+      bossFinalClosed: 'assets/boss_final_closed.png',
+      bossFinalOpening: 'assets/boss_final_opening.png',
+      bossFinalOpen: 'assets/boss_final_open.png',
+      bossFinalClosing: 'assets/boss_final_closing.png',
+      bossFinalClawing: 'assets/boss_final_clawing.png',
     };
 
     const IMG = {};
@@ -315,6 +320,19 @@
     function craneTelegraphFor(b){ const pct=b.hp/b.maxHp; return CRANE_TELEGRAPH_MIN + (CRANE_TELEGRAPH_MAX-CRANE_TELEGRAPH_MIN)*pct; }
     function craneSpeedFor(b){ const pct=1 - b.hp/b.maxHp; return CRANE_SPEED_MIN + (CRANE_SPEED_MAX-CRANE_SPEED_MIN)*pct; }
     function craneChargeSpeedFor(b){ const pct=1 - b.hp/b.maxHp; return CRANE_CHARGE_SPEED_MIN + (CRANE_CHARGE_SPEED_MAX-CRANE_CHARGE_SPEED_MIN)*pct; }
+    const OVERSEER_HP = 1800;
+    const OVERSEER_MOVE_SPEED = 220;
+    const OVERSEER_GUN_CADENCE_BY_HP = { normal: 0.6, low: 0.45 };
+    const OVERSEER_LASER_COOLDOWN_BY_HP = { normal: [6.0, 8.0], low: [4.8, 6.4] };
+    const OVERSEER_VULNERABLE_WINDOW = { before: 1.0, during: 2.0, after: 1.0 };
+    const OVERSEER_CLAW_COOLDOWN_MIN = 3.5;
+    const OVERSEER_CLAW_COOLDOWN_MAX = 4.5;
+    const OVERSEER_HOVER_POINTS = [
+      { x: W - 180, y: 100 },
+      { x: W - 140, y: 180 },
+      { x: W - 200, y: 140 },
+      { x: W - 160, y: 220 }
+    ];
     const JUMP_V = 700;
     const QUICK_TAP_TIME = 0.1; // seconds; taps shorter than this trigger a half jump
     // Make gliding more pronounced: much lower gravity while gliding
@@ -739,7 +757,7 @@
       }
       // Boss spawn and HUD
       if (!boss && time >= bossNextTime) {
-        if (difficulty % 2 === 1) {
+        if (difficulty % 3 === 1) {
           boss = {
             type: 'eyeball',
             x: W + 200,
@@ -760,7 +778,7 @@
             hitX: 0.3,
             hitY: 0.3
           };
-        } else {
+        } else if (difficulty % 3 === 2) {
           const moveImg = IMG.bossCraneMove;
           const frames = 4;
           const fw = moveImg.width / frames;
@@ -785,6 +803,28 @@
             hitY: 0.7,
             moveT: 0,
             passes: 0
+          };
+        } else {
+          boss = {
+            type: 'overseer',
+            x: W + 200,
+            y: 120,
+            w: 320,
+            h: 320,
+            state: 'entry',
+            hp: OVERSEER_HP,
+            maxHp: OVERSEER_HP,
+            gunCadence: OVERSEER_GUN_CADENCE_BY_HP.normal,
+            gunCd: OVERSEER_GUN_CADENCE_BY_HP.normal,
+            laserCd: rand(OVERSEER_LASER_COOLDOWN_BY_HP.normal[0], OVERSEER_LASER_COOLDOWN_BY_HP.normal[1]),
+            clawCd: rand(OVERSEER_CLAW_COOLDOWN_MIN, OVERSEER_CLAW_COOLDOWN_MAX),
+            target: null,
+            vulnerable: false,
+            eyeActive: false,
+            clawActive: false,
+            flash: 0,
+            hitX: 0.7,
+            hitY: 0.7
           };
         }
       }
@@ -935,6 +975,97 @@
               boss.moveT += dt;
               boss.timer -= dt;
               if (boss.timer <= 0) boss.state = 'retreat';
+              break;
+          }
+        } else if (boss.type === 'overseer') {
+          if (!boss.low && boss.hp / boss.maxHp < 0.4) {
+            boss.low = true;
+            boss.gunCadence = OVERSEER_GUN_CADENCE_BY_HP.low;
+            boss.laserRange = OVERSEER_LASER_COOLDOWN_BY_HP.low;
+          }
+          if (boss.eyeActive) {
+            boss.eye = { x: boss.x - boss.w*0.15, y: boss.y - boss.h*0.15, w: boss.w*0.3, h: boss.h*0.3 };
+          }
+          switch (boss.state) {
+            case 'entry':
+              boss.x -= 120 * dt;
+              if (boss.x <= W - 150) { boss.x = W - 150; boss.state = 'idle'; }
+              break;
+            case 'idle':
+              boss.gunCd -= dt;
+              if (boss.gunCd <= 0) {
+                const sx = boss.x - boss.w * 0.3;
+                const sy = boss.y - boss.h * 0.1;
+                const dxs = P.x - sx, dys = P.y - sy;
+                const len = Math.hypot(dxs, dys) || 1;
+                const speed = 320;
+                const vx = (dxs / len) * speed;
+                const vy = (dys / len) * speed;
+                shots.push({ x: sx, y: sy, w: 12, h: 12, vx, vy, t: 0, hitX:0.75, hitY:0.75 });
+                boss.gunCd = boss.gunCadence;
+              }
+              boss.laserCd -= dt;
+              boss.clawCd -= dt;
+              if (boss.laserCd <= 0) {
+                boss.state = 'laserOpening';
+                boss.timer = OVERSEER_VULNERABLE_WINDOW.before;
+                boss.animT = 0;
+                boss.vulnerable = true;
+                boss.eyeActive = true;
+              } else if (boss.clawCd <= 0 && P.y > boss.y && Math.abs(P.x - boss.x) < boss.w) {
+                boss.state = 'claw';
+                boss.animT = 0;
+                boss.animFrame = 0;
+                boss.clawActive = false;
+              }
+              if (!boss.target || Math.hypot(boss.x - boss.target.x, boss.y - boss.target.y) < 4) {
+                boss.target = OVERSEER_HOVER_POINTS[Math.floor(Math.random()*OVERSEER_HOVER_POINTS.length)];
+              }
+              if (boss.target) {
+                const dx = boss.target.x - boss.x;
+                const dy = boss.target.y - boss.y;
+                const dist = Math.hypot(dx, dy) || 1;
+                const step = Math.min(OVERSEER_MOVE_SPEED * dt, dist);
+                boss.x += dx / dist * step;
+                boss.y += dy / dist * step;
+              }
+              break;
+            case 'laserOpening':
+              boss.animT += dt;
+              boss.timer -= dt;
+              if (boss.timer <= 0) { boss.state = 'laserFiring'; boss.timer = OVERSEER_VULNERABLE_WINDOW.during; }
+              break;
+            case 'laserFiring':
+              boss.timer -= dt;
+              if (boss.timer <= 0) { boss.state = 'laserClosing'; boss.timer = OVERSEER_VULNERABLE_WINDOW.after; boss.animT = 0; }
+              break;
+            case 'laserClosing':
+              boss.animT += dt;
+              boss.timer -= dt;
+              if (boss.timer <= 0) {
+                boss.state = 'recover';
+                boss.timer = 0.5;
+                boss.vulnerable = false;
+                boss.eyeActive = false;
+                const range = boss.laserRange || OVERSEER_LASER_COOLDOWN_BY_HP.normal;
+                boss.laserCd = rand(range[0], range[1]);
+              }
+              break;
+            case 'claw':
+              boss.animT += dt;
+              if (!boss.clawFrameDur) boss.clawFrameDur = 0.1;
+              if (boss.animT >= boss.clawFrameDur) { boss.animT -= boss.clawFrameDur; boss.animFrame++; }
+              boss.clawActive = boss.animFrame >=2 && boss.animFrame <=3;
+              if (boss.animFrame >=5) {
+                boss.state = 'recover';
+                boss.timer = 0.5;
+                boss.clawCd = rand(OVERSEER_CLAW_COOLDOWN_MIN, OVERSEER_CLAW_COOLDOWN_MAX);
+                boss.clawActive = false;
+              }
+              break;
+            case 'recover':
+              boss.timer -= dt;
+              if (boss.timer <= 0) boss.state = 'idle';
               break;
           }
         }
@@ -1461,6 +1592,44 @@
             return;
           }
         }
+        if (boss && boss.type === 'overseer') {
+          if (hit(P, boss)) {
+            if (!consumeShieldOnHit()) {
+              heat = clamp(heat + (hasJetpack ? HEAT_HIT_PENALTY : HEAT_HIT_PENALTY_NO_JET), 0, HEAT_MAX);
+              loseRandomItem();
+            }
+            P.vy = Math.min(P.vy, -350);
+            P.onGround = false;
+            hitGrace = 2; worldFreeze = Math.max(worldFreeze,0.4); hitFlash = Math.max(hitFlash,0.35); shake = Math.max(shake,14);
+            return;
+          }
+          if (boss.state === 'laserFiring') {
+            const beam = { x: (boss.x - boss.w/2)/2, y: boss.y, w: boss.x - boss.w/2, h: boss.h * 0.3 };
+            if (hit(P, beam)) {
+              if (!consumeShieldOnHit()) {
+                heat = clamp(heat + (hasJetpack ? HEAT_HIT_PENALTY : HEAT_HIT_PENALTY_NO_JET), 0, HEAT_MAX);
+                loseRandomItem();
+              }
+              P.vy = Math.min(P.vy, -350);
+              P.onGround = false;
+              hitGrace = 2; worldFreeze = Math.max(worldFreeze,0.4); hitFlash = Math.max(hitFlash,0.35); shake = Math.max(shake,14);
+              return;
+            }
+          }
+          if (boss.state === 'claw' && boss.clawActive) {
+            const claw = { x: boss.x, y: boss.y + boss.h*0.25, w: boss.w*0.5, h: boss.h*0.6 };
+            if (hit(P, claw)) {
+              if (!consumeShieldOnHit()) {
+                heat = clamp(heat + (hasJetpack ? HEAT_HIT_PENALTY : HEAT_HIT_PENALTY_NO_JET), 0, HEAT_MAX);
+                loseRandomItem();
+              }
+              P.vy = Math.min(P.vy, -350);
+              P.onGround = false;
+              hitGrace = 2; worldFreeze = Math.max(worldFreeze,0.4); hitFlash = Math.max(hitFlash,0.35); shake = Math.max(shake,14);
+              return;
+            }
+          }
+        }
         for (const s of spikes) if (hit(P, s)) {
           if (!consumeShieldOnHit()) {
             // Apply heat penalty based on whether a jetpack was owned at impact
@@ -1607,12 +1776,14 @@
         for (let j = flyers.length - 1; j >= 0; j--) {
           if (hit(b, flyers[j])) { flyers.splice(j,1); hitSomething = true; if (!heatCheat) score += 1; playSfx(SFX.enemyHit); break; }
         }
-        if (!hitSomething && boss && boss.vulnerable && hit(b, boss)) {
-          boss.hp -= GUN_DAMAGE;
-          boss.flash = 0.25;
-          hitSomething = true;
-          playSfx(SFX.enemyHit);
-          if (boss.hp <= 0) {
+        if (!hitSomething && boss && boss.vulnerable) {
+          const hitBoss = boss.type === 'overseer' ? (boss.eyeActive && boss.eye && hit(b, boss.eye)) : hit(b, boss);
+          if (hitBoss) {
+            boss.hp -= GUN_DAMAGE;
+            boss.flash = 0.25;
+            hitSomething = true;
+            playSfx(SFX.enemyHit);
+            if (boss.hp <= 0) {
             playSfx(SFX.bossKill);
             if (!heatCheat) score += 10;
             showBossDefeated();
@@ -1723,12 +1894,18 @@
       for (const f of flyers) drawFlyer(f.x, f.y, f.w, f.h, f.state);
       for (const b of shots) drawBullet(b.x, b.y, b.w, b.h);
       for (const pb of pshots) drawPlayerBullet(pb.x, pb.y, pb.w, pb.h);
-      if (boss && boss.state === 'laser') {
+      if (boss && boss.type === 'eyeball' && boss.state === 'laser') {
         const beamH = P.h * 0.5;
         const beamLeft = boss.x - BOSS_LASER_BEAM_OFFSET;
         const beamY = boss.y - (boss.lane === 0 ? BOSS_UPPER_LASER_SHIFT : 0);
         ctx.fillStyle = 'rgba(255,0,0,0.6)';
         ctx.fillRect(0, beamY - beamH/2, beamLeft, beamH);
+      }
+      if (boss && boss.type === 'overseer' && boss.state === 'laserFiring') {
+        const beamH = boss.h * 0.3;
+        const beamLeft = boss.x - boss.w/2;
+        ctx.fillStyle = 'rgba(255,0,0,0.6)';
+        ctx.fillRect(0, boss.y - beamH/2, beamLeft, beamH);
       }
       if (boss) {
         if (boss.type === 'eyeball') {
@@ -1736,8 +1913,10 @@
           else if (boss.state === 'close') drawBossClose(boss);
           else if (boss.state === 'laser' || boss.state === 'post') drawBossImage(IMG.bossLaser, boss);
           else drawBossImage(IMG.bossShut, boss);
-        } else {
+        } else if (boss.type === 'crane') {
           drawCrane(boss);
+        } else {
+          drawOverseer(boss);
         }
       }
 
@@ -1903,6 +2082,41 @@
       } else {
         frame = Math.floor(b.moveT * 10) % frames;
       }
+      const x = Math.round(b.x - b.w/2);
+      const y = Math.round(b.y - b.h/2);
+      ctx.save();
+      ctx.drawImage(img, frame * fw, 0, fw, fh, x, y, b.w, b.h);
+      if (b.flash > 0) {
+        const alpha = Math.min(1, b.flash * 4);
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.globalAlpha = alpha;
+        ctx.drawImage(img, frame * fw, 0, fw, fh, x, y, b.w, b.h);
+      }
+      ctx.restore();
+    }
+
+    function drawOverseer(b){
+      let img, frames = 1, frame = 0;
+      if (b.state === 'laserOpening') {
+        img = IMG.bossFinalOpening;
+        frames = 3;
+        frame = Math.min(frames - 1, Math.floor((b.animT / OVERSEER_VULNERABLE_WINDOW.before) * frames));
+      } else if (b.state === 'laserClosing') {
+        img = IMG.bossFinalClosing;
+        frames = 3;
+        frame = Math.min(frames - 1, Math.floor((b.animT / OVERSEER_VULNERABLE_WINDOW.after) * frames));
+      } else if (b.state === 'laserFiring') {
+        img = IMG.bossFinalOpen;
+      } else if (b.state === 'claw') {
+        img = IMG.bossFinalClawing;
+        frames = 5;
+        frame = Math.min(frames - 1, b.animFrame || 0);
+      } else {
+        img = IMG.bossFinalClosed;
+      }
+      if (!img || !img.width) return;
+      const fw = img.width / frames;
+      const fh = img.height;
       const x = Math.round(b.x - b.w/2);
       const y = Math.round(b.y - b.h/2);
       ctx.save();


### PR DESCRIPTION
## Summary
- add Overseer final boss sprites and tuning hooks
- rotate boss spawns to include Overseer and implement state machine, attacks, and drawing
- handle Overseer collisions and low health behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf282332a08329a391380a79a5c7c4