### PR TITLE
feat: add shuffled soundtrack to Emberfall Gauntlet

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -199,6 +199,39 @@
     const againBtn = document.getElementById('againBtn');
     const classBtns = document.querySelectorAll('.class-btn');
 
+    // Background music: shuffle all soundtrack mp3 files
+    const MUSIC = {
+      tracks: [
+        'assets/EG_soundtrack_01.mp3',
+        'assets/EG_soundtrack_02.mp3',
+        'assets/EG_soundtrack_03.mp3',
+        'assets/EG_soundtrack_04.mp3',
+      ],
+      index: 0,
+      audio: new Audio()
+    };
+
+    function shuffle(arr){
+      for (let i = arr.length - 1; i > 0; i--){
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+    }
+
+    function startMusic(){
+      if (!MUSIC.tracks.length) return;
+      shuffle(MUSIC.tracks);
+      MUSIC.audio.src = MUSIC.tracks[0];
+      MUSIC.audio.addEventListener('ended', () => {
+        MUSIC.index = (MUSIC.index + 1) % MUSIC.tracks.length;
+        if (MUSIC.index === 0) shuffle(MUSIC.tracks);
+        MUSIC.audio.src = MUSIC.tracks[MUSIC.index];
+        MUSIC.audio.play();
+      });
+      MUSIC.audio.play().catch(()=>{});
+    }
+    let musicStarted = false;
+
     // Assets (SVG/PNG art)
     const CLASS_IMG = {
       fighter: new Image(),
@@ -460,7 +493,14 @@
     function gameOver() {
       if (gameOverHandled) return; gameOverHandled = true; running = false; paused = true; finalScoreEl.textContent = SCORE.value; gameOverOverlay.classList.add('show'); maybeSubmitLeaderboard(); }
 
-    startBtn.addEventListener('click', () => { start(); gameOverHandled = false; });
+    startBtn.addEventListener('click', () => {
+      start();
+      gameOverHandled = false;
+      if (!musicStarted){
+        startMusic();
+        musicStarted = true;
+      }
+    });
     againBtn.addEventListener('click', () => { gameOverOverlay.classList.remove('show'); start(); gameOverHandled = false; });
 
     // Controls


### PR DESCRIPTION
## Summary
- add soundtrack playlist that shuffles all `EG_soundtrack_*.mp3` files
- start background music after the player hits Start

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d764a9608329b20e0251f29b0814