### PR TITLE
feat: add muck monster boss

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -332,18 +332,31 @@
     ORC_ANIM.left.src = 'assets/EG_enemy_orc_animation_walking_left_small.png';
     ORC_ANIM.right.src = 'assets/EG_enemy_orc_animation_walking_right_small.png';
 
+    const MUCK_ANIM = {
+      down: new Image(),
+      up: new Image(),
+      left: new Image(),
+      right: new Image(),
+    };
+    MUCK_ANIM.down.src = 'assets/EG_enemy_boss_mudMonster_animation_walking_down_small.png';
+    MUCK_ANIM.up.src = 'assets/EG_enemy_boss_mudMonster_animation_walking_up_small.png';
+    MUCK_ANIM.left.src = 'assets/EG_enemy_boss_mudMonster_animation_walking_left_small.png';
+    MUCK_ANIM.right.src = 'assets/EG_enemy_boss_mudMonster_animation_walking_right_small.png';
+
 
     const IMG = {
       coin: new Image(),
       heart: new Image(),
       shadow: new Image(),
       spark: new Image(),
+      mud: new Image(),
       hero: CLASS_IMG.fighter,
     };
     IMG.coin.src = 'assets/eg_coin.svg';
     IMG.heart.src = 'assets/eg_heart.svg';
     IMG.shadow.src = 'assets/eg_shadow.svg';
     IMG.spark.src = 'assets/eg_spark.svg';
+    IMG.mud.src = 'assets/eg_slime.svg';
 
     const MAP_FILES = [
       'assets/EG_map_mirewatch01.png',
@@ -355,7 +368,7 @@
     ];
     const MAPS = MAP_FILES.map(src => { const i = new Image(); i.src = src; return i; });
 
-    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length;
+    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length;
     for (const k in IMG) IMG[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const img of MAPS) img.addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in WIZ_ANIM) WIZ_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
@@ -364,6 +377,7 @@
     for (const k in GOBLIN_ANIM) GOBLIN_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in IMP_ANIM) IMP_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in ORC_ANIM) ORC_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in MUCK_ANIM) MUCK_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.rogue.addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.wizard.addEventListener('load', () => { if (++loaded === need) init(); });
 
@@ -426,6 +440,7 @@
       shardCount: 1,
     };
     let PROJECTILES = [];
+    let BOSS_PROJECTILES = [];
     let ORBS = [];
     const PARTICLES = [];
     let enemies = [];
@@ -507,7 +522,7 @@
       currentMap = MAPS[stage];
       ARENA.x = 0; ARENA.y = 0; ARENA.w = currentMap.width; ARENA.h = currentMap.height;
       DENSITY = Math.max(1, Math.round(Math.max(ARENA.w / W, ARENA.h / H) * 1.5));
-      enemies = []; drops = []; PARTICLES.length = 0;
+      enemies = []; drops = []; PARTICLES.length = 0; BOSS_PROJECTILES = [];
       Object.assign(P, { x: ARENA.x + ARENA.w/2, y: ARENA.y + ARENA.h/2, vx:0, vy:0, dir:0, aimDir:0, swingAim:0, iT:0, atkT:0, autoT:0 });
       Object.assign(SPAWN, { t:0, cd:2.2, wave:1, count:0 });
       waveEl.textContent = SPAWN.wave;
@@ -536,7 +551,7 @@
       // Reset upgrades and spell state
       Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:0, critChance:0, critMult:1.6, doubleCoinChance:0, orbs:0, orbDmg:1, orbRadius:60, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1 });
       if (stats.startOrbs) { UPGR.orbs = stats.startOrbs; }
-      PROJECTILES = []; ORBS = [];
+      PROJECTILES = []; BOSS_PROJECTILES = []; ORBS = [];
       stage = 0;
       loadStage();
       drawHearts();
@@ -646,13 +661,14 @@
     function spawnBoss(){
       const x = ARENA.x + ARENA.w/2;
       const y = ARENA.y + ARENA.h/2;
-      const b = { kind:'boss', x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp:60, spd:60, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0 };
+      const b = { kind:'boss', x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp:120, hpMax:120, spd:60, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0 };
       enemies.push(b);
       return b;
     }
 
     function handleBossDefeat(){
       boss = null;
+      BOSS_PROJECTILES = [];
       awaitingStage = true;
       let remaining = 10;
       stageTimerEl.textContent = `Next Stage in ${remaining} seconds`;
@@ -882,6 +898,15 @@
           e.y = clamp(e.y, ARENA.y + AI.wallPad, ARENA.y + ARENA.h - AI.wallPad);
         }
 
+        if (e.kind === 'boss'){
+          e.atkT += dt;
+          if (e.atkT >= 2.4){
+            e.atkT = 0;
+            const a = Math.atan2(dy, dx);
+            BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(a)*140, vy:Math.sin(a)*140, life:0, ttl:3 });
+          }
+        }
+
         // Walk animation for goblins, imps, orcs, and bosses
         if (e.kind === 'goblin' || e.kind === 'imp' || e.kind === 'orc' || e.kind === 'boss'){
           const spd = Math.hypot(e.vx, e.vy);
@@ -979,6 +1004,9 @@
       // Update projectiles
       for (let i=PROJECTILES.length-1;i>=0;i--){ const p=PROJECTILES[i]; p.life+=dt; p.x+=p.vx*dt; p.y+=p.vy*dt; if (p.life>p.ttl){ PROJECTILES.splice(i,1); continue; } for (const e of enemies){ if (e.hp<=0) continue; if (len(p.x-e.x,p.y-e.y)<16){ applyDamage(e, p.dmg, p.vx, p.vy, KNOCK.projectile); PROJECTILES.splice(i,1); break; } } }
 
+      // Update boss projectiles
+      for (let i=BOSS_PROJECTILES.length-1;i>=0;i--){ const p=BOSS_PROJECTILES[i]; p.life+=dt; p.x+=p.vx*dt; p.y+=p.vy*dt; if (p.life>p.ttl){ BOSS_PROJECTILES.splice(i,1); continue; } if (len(p.x-P.x,p.y-P.y)<20){ if (P.iT<=0){ if (CHEAT.active){ P.hitFlash=0.25; spark(P.x,P.y,'#ff8a8a'); } else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); if (P.hp<=0) return gameOver(); } } BOSS_PROJECTILES.splice(i,1); } }
+
       // Wave & spawns (scale with larger world)
       if (!boss && !awaitingStage) {
         SPAWN.t += dt;
@@ -1049,8 +1077,13 @@
           const fw = sheet.width / 4;
           const fh = sheet.height;
           ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
-        } else if (e.kind === 'orc' || e.kind === 'boss') {
+        } else if (e.kind === 'orc') {
           const sheet = ORC_ANIM[e.dir];
+          const fw = sheet.width / 4;
+          const fh = sheet.height;
+          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
+        } else if (e.kind === 'boss') {
+          const sheet = MUCK_ANIM[e.dir];
           const fw = sheet.width / 4;
           const fh = sheet.height;
           ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
@@ -1153,8 +1186,23 @@
       // Orbs & projectiles
       if (ORBS.length){ for (const o of ORBS){ ctx.drawImage(IMG.spark, (o.x||P.x)-8, (o.y||P.y)-8, 16, 16); } }
       if (PROJECTILES.length){ for (const pr of PROJECTILES){ ctx.drawImage(IMG.spark, pr.x-6, pr.y-6, 12, 12); } }
+      if (BOSS_PROJECTILES.length){ for (const bp of BOSS_PROJECTILES){ ctx.drawImage(IMG.mud, bp.x-8, bp.y-8, 16, 16); } }
 
       ctx.restore();
+
+      if (boss){
+        const barW = 300;
+        const barH = 16;
+        const x = (W - barW) / 2;
+        const y = 8;
+        ctx.fillStyle = '#311';
+        ctx.fillRect(x, y, barW, barH);
+        ctx.fillStyle = '#7a5230';
+        ctx.fillRect(x, y, (boss.hp / boss.hpMax) * barW, barH);
+        ctx.strokeStyle = '#fff';
+        ctx.lineWidth = 2;
+        ctx.strokeRect(x, y, barW, barH);
+      }
 
       // Screen flash on hit (brief red overlay)
       if (P.hitFlash > 0){


### PR DESCRIPTION
## Summary
- Introduce Muck Monster as stage 1 boss with dedicated mud animations and a top-screen health bar
- Add mud projectile attack that launches damaging sludge globs at the player
- Clear boss projectiles between stages and reset while loading mud assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c24bbc34f48329be64fc69e99e2526