### PR TITLE
feat: add class-specific upgrades

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -475,6 +475,7 @@
       critChance: 0,
       critMult: 1.6,
       doubleCoinChance: 0,
+      dodgeChance: 0,
       orbs: 0,
       orbDmg: 1,
       orbRadius: 60,
@@ -508,38 +509,22 @@
         { id:'twin', type:'Weapon', name:'Twin Strikes', desc:'Your melee hits strike twice.', note:'+1 multistrike', apply:()=>{ UPGR.multistrike+=1; } },
         { id:'longblade', type:'Weapon', name:'Longblade', desc:'Increase melee reach by 20%.', apply:()=>{ PHYS.atkRange = Math.round(PHYS.atkRange*1.2); } },
         { id:'sweeping', type:'Weapon', name:'Sweeping Arc', desc:'Widen melee arc by 15%.', apply:()=>{ PHYS.atkArc = Math.min(Math.PI*1.6, PHYS.atkArc*1.15); } },
-        { id:'quickhands', type:'Weapon', name:'Quick Hands', desc:'Attack more often (-12% cooldown).', apply:()=>{ AUTO.atkPeriod = Math.max(0.25, AUTO.atkPeriod*0.88); } },
-        { id:'keen', type:'Weapon', name:'Keen Edge', desc:'Melee damage +1.', apply:()=>{ UPGR.meleeDmg += 1; } },
-        { id:'orbs', type:'Spell', name:'Orbiting Sparks', desc:'Summon 1 orbiting spark that damages foes.', note:'Stacks add more sparks', apply:()=>{ UPGR.orbs += 1; } },
-        { id:'nova', type:'Spell', name:'Frost Nova', desc:'Every few seconds, blast and slow nearby foes.', note:'Period and damage improve with repeats', apply:()=>{ if(!UPGR.nova){ UPGR.nova=true; } else { UPGR.novaPeriod=Math.max(2.2, UPGR.novaPeriod*0.9); UPGR.novaDmg+=1; } } },
-        { id:'shards', type:'Spell', name:'Arc Shards', desc:'Periodically fire shards where you face.', note:'More shards with repeats', apply:()=>{ if(!UPGR.shards){ UPGR.shards=true; } else { UPGR.shardCount=Math.min(6, UPGR.shardCount+1); } } },
-        { id:'boots', type:'Upgrade', name:'Fleetfoot Boots', desc:'Run 20% faster.', apply:()=>{ P.spd = Math.round(P.spd*1.2); } },
-        { id:'heart', type:'Upgrade', name:'Heart Vessel', desc:'Max HP +1 and heal 1.', apply:()=>{ P.hpMax += 1; P.hp = Math.min(P.hpMax, P.hp+1); drawHearts(); } },
         { id:'leech', type:'Upgrade', name:'Vampiric Edge', desc:'On kill, small chance to heal 1.', apply:()=>{ UPGR.lifeStealChance = Math.min(0.5, UPGR.lifeStealChance + 0.12); } },
-        { id:'magnet', type:'Upgrade', name:'Coin Magnet', desc:'Coins are drawn to you from farther away.', apply:()=>{ UPGR.magnet += 1; } },
-        { id:'crit', type:'Upgrade', name:'Critical Focus', desc:'+8% crit chance on melee.', apply:()=>{ UPGR.critChance = Math.min(0.5, UPGR.critChance + 0.08); } },
-        { id:'doublecoin', type:'Upgrade', name:'Golden Touch', desc:'Chance for enemies to drop an extra coin.', apply:()=>{ UPGR.doubleCoinChance = Math.min(0.4, UPGR.doubleCoinChance + 0.12); } },
+        { id:'heart', type:'Upgrade', name:'Heart Vessel', desc:'Max HP +1 and heal 1.', apply:()=>{ P.hpMax += 1; P.hp = Math.min(P.hpMax, P.hp+1); drawHearts(); } },
       ],
       rogue: [
-        { id:'daggers', type:'Weapon', name:'Twin Daggers', desc:'Your strikes hit twice.', note:'+1 multistrike', apply:()=>{ UPGR.multistrike+=1; } },
         { id:'shadowstep', type:'Skill', name:'Shadowstep', desc:'Move 20% faster.', apply:()=>{ P.spd = Math.round(P.spd*1.2); } },
         { id:'poison', type:'Weapon', name:'Poisoned Edge', desc:'Melee damage +1.', apply:()=>{ UPGR.meleeDmg += 1; } },
-        { id:'quick', type:'Weapon', name:'Quick Slash', desc:'Attack more often (-12% cooldown).', apply:()=>{ AUTO.atkPeriod = Math.max(0.25, AUTO.atkPeriod*0.88); } },
         { id:'crit', type:'Skill', name:'Deadly Precision', desc:'+10% crit chance.', apply:()=>{ UPGR.critChance = Math.min(0.6, UPGR.critChance + 0.10); } },
-        { id:'shuriken', type:'Skill', name:'Throwing Stars', desc:'Periodically hurl shuriken forward.', note:'More with repeats', apply:()=>{ if(!UPGR.shards){ UPGR.shards=true; } else { UPGR.shardCount=Math.min(6, UPGR.shardCount+1); } } },
-        { id:'leech', type:'Skill', name:'Vampiric Daggers', desc:'On kill, small chance to heal 1.', apply:()=>{ UPGR.lifeStealChance = Math.min(0.5, UPGR.lifeStealChance + 0.12); } },
-        { id:'magnet', type:'Skill', name:'Pickpocket', desc:'Coins drawn from farther away.', apply:()=>{ UPGR.magnet += 1; } },
-        { id:'doublecoin', type:'Skill', name:'Cutpurse', desc:'Chance for enemies to drop an extra coin.', apply:()=>{ UPGR.doubleCoinChance = Math.min(0.4, UPGR.doubleCoinChance + 0.12); } },
+        { id:'dodge', type:'Skill', name:'Evasion', desc:'Chance to evade incoming hits.', note:'Chance increases with repeats', apply:()=>{ UPGR.dodgeChance = Math.min(0.5, (UPGR.dodgeChance||0) + 0.15); } },
+        { id:'heart', type:'Skill', name:'Second Wind', desc:'Max HP +1 and heal 1.', apply:()=>{ P.hpMax += 1; P.hp = Math.min(P.hpMax, P.hp+1); drawHearts(); } },
       ],
       wizard: [
         { id:'orbs', type:'Spell', name:'Arcane Orbs', desc:'Summon orbiting orbs that damage foes.', note:'Stacks add more orbs', apply:()=>{ UPGR.orbs += 1; } },
         { id:'nova', type:'Spell', name:'Frost Nova', desc:'Every few seconds, blast and slow nearby foes.', note:'Improves with repeats', apply:()=>{ if(!UPGR.nova){ UPGR.nova=true; } else { UPGR.novaPeriod=Math.max(2.2, UPGR.novaPeriod*0.9); UPGR.novaDmg+=1; } } },
         { id:'shards', type:'Spell', name:'Arcane Missiles', desc:'Periodically fire magic missiles.', note:'More with repeats', apply:()=>{ if(!UPGR.shards){ UPGR.shards=true; } else { UPGR.shardCount=Math.min(6, UPGR.shardCount+1); } } },
         { id:'focus', type:'Spell', name:'Spell Focus', desc:'Cast more often (-12% cooldown).', apply:()=>{ AUTO.atkPeriod = Math.max(0.25, AUTO.atkPeriod*0.88); } },
-        { id:'power', type:'Spell', name:'Empowered Bolt', desc:'Melee damage +1.', apply:()=>{ UPGR.meleeDmg += 1; } },
         { id:'wisdom', type:'Upgrade', name:'Wisdom', desc:'Max HP +1 and heal 1.', apply:()=>{ P.hpMax += 1; P.hp = Math.min(P.hpMax, P.hp+1); drawHearts(); } },
-        { id:'mana', type:'Upgrade', name:'Mana Surge', desc:'Run 20% faster.', apply:()=>{ P.spd = Math.round(P.spd*1.2); } },
-        { id:'crit', type:'Spell', name:'Arcane Potency', desc:'+8% crit chance.', apply:()=>{ UPGR.critChance = Math.min(0.5, UPGR.critChance + 0.08); } },
       ],
     };
 
@@ -609,7 +594,7 @@
       SCORE.value = 0; scoreEl.textContent = SCORE.value;
       COINS.value = 0; coinsEl.textContent = COINS.value; SHOP.idx = 0; SHOP.open = false;
       // Reset upgrades and spell state
-      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:0, critChance:0, critMult:1.6, doubleCoinChance:0, orbs:0, orbDmg:1, orbRadius:60, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1 });
+      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:0, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:60, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1 });
       if (stats.startOrbs) { UPGR.orbs = stats.startOrbs; }
       PROJECTILES = []; BOSS_PROJECTILES = []; ORBS = [];
       stage = 0;
@@ -1070,6 +1055,8 @@
             if (CHEAT.active) {
               P.hitFlash = 0.25;
               spark(P.x,P.y,'#ff8a8a');
+            } else if (UPGR.dodgeChance > 0 && Math.random() < UPGR.dodgeChance) {
+              P.iT = 0.6; P.hitFlash = 0.25; spark(P.x,P.y,'#a1ffd4');
             } else {
               P.hp -= 1; P.iT = 2.0; P.hitFlash = 0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); if (P.hp<=0) return gameOver();
             }
@@ -1164,7 +1151,7 @@
       for (let i=PROJECTILES.length-1;i>=0;i--){ const p=PROJECTILES[i]; p.life+=dt; p.x+=p.vx*dt; p.y+=p.vy*dt; if (p.life>p.ttl){ PROJECTILES.splice(i,1); continue; } for (const e of enemies){ if (e.hp<=0) continue; if (len(p.x-e.x,p.y-e.y)<16){ applyDamage(e, p.dmg, p.vx, p.vy, KNOCK.projectile); PROJECTILES.splice(i,1); break; } } }
 
       // Update boss projectiles
-      for (let i=BOSS_PROJECTILES.length-1;i>=0;i--){ const p=BOSS_PROJECTILES[i]; p.life+=dt; p.x+=p.vx*dt; p.y+=p.vy*dt; if (p.life>p.ttl){ BOSS_PROJECTILES.splice(i,1); continue; } if (len(p.x-P.x,p.y-P.y)<20){ if (P.iT<=0){ if (CHEAT.active){ P.hitFlash=0.25; spark(P.x,P.y,'#ff8a8a'); } else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); if (P.hp<=0) return gameOver(); } } BOSS_PROJECTILES.splice(i,1); } }
+      for (let i=BOSS_PROJECTILES.length-1;i>=0;i--){ const p=BOSS_PROJECTILES[i]; p.life+=dt; p.x+=p.vx*dt; p.y+=p.vy*dt; if (p.life>p.ttl){ BOSS_PROJECTILES.splice(i,1); continue; } if (len(p.x-P.x,p.y-P.y)<20){ if (P.iT<=0){ if (CHEAT.active){ P.hitFlash=0.25; spark(P.x,P.y,'#ff8a8a'); } else if (UPGR.dodgeChance>0 && Math.random()<UPGR.dodgeChance){ P.iT=0.6; P.hitFlash=0.25; spark(P.x,P.y,'#a1ffd4'); } else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); if (P.hp<=0) return gameOver(); } } BOSS_PROJECTILES.splice(i,1); } }
 
       // Wave & spawns (scale with larger world)
       if (!boss && !awaitingStage) {


### PR DESCRIPTION
## Summary
- differentiate coin-purchased abilities per class in Emberfall Gauntlet
- add dodge-based Evasion upgrade for rogue and associated damage checks
- reset upgrade state with new dodge chance value

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2de6354d48329add554c05ce9fddf