### PR TITLE
feat: add hill giant boss with slam attack

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -376,6 +376,17 @@
     MUCK_ANIM.left.src = 'assets/EG_enemy_boss_mudMonster_animation_walking_left_small.png';
     MUCK_ANIM.right.src = 'assets/EG_enemy_boss_mudMonster_animation_walking_right_small.png';
 
+    const HILL_ANIM = {
+      down: new Image(),
+      up: new Image(),
+      left: new Image(),
+      right: new Image(),
+    };
+    HILL_ANIM.down.src = 'assets/EG_enemy_boss_hillGiant_walking_down_small.png';
+    HILL_ANIM.up.src = 'assets/EG_enemy_boss_hillGiant_walking_up_small.png';
+    HILL_ANIM.left.src = 'assets/EG_enemy_boss_hillGiant_walking_left_small.png';
+    HILL_ANIM.right.src = 'assets/EG_enemy_boss_hillGiant_walking_right_small.png';
+
 
     const IMG = {
       coin: new Image(),
@@ -399,7 +410,7 @@
     ];
     const MAPS = MAP_FILES.map(src => { const i = new Image(); i.src = src; return i; });
 
-    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length;
+    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length + Object.keys(HILL_ANIM).length;
     for (const k in IMG) IMG[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const img of MAPS) img.addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in WIZ_ANIM) WIZ_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
@@ -409,6 +420,7 @@
     for (const k in IMP_ANIM) IMP_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in ORC_ANIM) ORC_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in MUCK_ANIM) MUCK_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in HILL_ANIM) HILL_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.rogue.addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.wizard.addEventListener('load', () => { if (++loaded === need) init(); });
 
@@ -491,6 +503,7 @@
     };
     let PROJECTILES = [];
     let BOSS_PROJECTILES = [];
+    let BOSS_SLAMS = [];
     let ORBS = [];
     const PARTICLES = [];
     // Visual FX containers
@@ -565,7 +578,7 @@
       currentMap = MAPS[stage];
       ARENA.x = 0; ARENA.y = 0; ARENA.w = currentMap.width; ARENA.h = currentMap.height;
       DENSITY = Math.max(1, Math.round(Math.max(ARENA.w / W, ARENA.h / H) * 1.5));
-      enemies = []; drops = []; PARTICLES.length = 0; BOSS_PROJECTILES = [];
+      enemies = []; drops = []; PARTICLES.length = 0; BOSS_PROJECTILES = []; BOSS_SLAMS = [];
       Object.assign(P, { x: ARENA.x + ARENA.w/2, y: ARENA.y + ARENA.h/2, vx:0, vy:0, dir:0, aimDir:0, swingAim:0, iT:0, atkT:0, autoT:0 });
       const stageMult = Math.pow(1.2, stage);
       Object.assign(SPAWN, { t:0, cd:2.2 / stageMult, wave:1, count:0 });
@@ -596,7 +609,7 @@
       // Reset upgrades and spell state
       Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:0, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:60, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1 });
       if (stats.startOrbs) { UPGR.orbs = stats.startOrbs; }
-      PROJECTILES = []; BOSS_PROJECTILES = []; ORBS = [];
+      PROJECTILES = []; BOSS_PROJECTILES = []; BOSS_SLAMS = []; ORBS = [];
       stage = 0;
       loadStage();
       drawHearts();
@@ -710,14 +723,16 @@
       const x = ARENA.x + ARENA.w/2;
       const y = ARENA.y + ARENA.h/2;
       const stageSpd = Math.pow(1.2, stage);
-      const b = { kind:'boss', x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp:60, hpMax:60, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, facing:0 };
+      const isHill = stage === 1;
+      const hp = isHill ? 90 : 60;
+      const b = { kind:'boss', bossType: isHill ? 'hillGiant' : 'mudMonster', x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, facing:0, slamT:0 };
       enemies.push(b);
       return b;
     }
 
     function handleBossDefeat(){
       boss = null;
-      BOSS_PROJECTILES = [];
+      BOSS_PROJECTILES = []; BOSS_SLAMS = [];
       awaitingStage = true;
       let remaining = 10;
       stageTimerEl.textContent = `Next Stage in ${remaining} seconds`;
@@ -1020,6 +1035,13 @@
               BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(e.facing)*140, vy:Math.sin(e.facing)*140, life:0, ttl:3 });
             }
           }
+          if (e.bossType === 'hillGiant'){
+            e.slamT += dt;
+            if (e.slamT >= 5){
+              e.slamT = 0;
+              BOSS_SLAMS.push({ x:e.x, y:e.y, facing:e.facing, t:0, windup:0.8, dur:0.3, w:120, l:150 });
+            }
+          }
         }
 
         // Walk animation for goblins, imps, orcs, and bosses
@@ -1152,6 +1174,7 @@
 
       // Update boss projectiles
       for (let i=BOSS_PROJECTILES.length-1;i>=0;i--){ const p=BOSS_PROJECTILES[i]; p.life+=dt; p.x+=p.vx*dt; p.y+=p.vy*dt; if (p.life>p.ttl){ BOSS_PROJECTILES.splice(i,1); continue; } if (len(p.x-P.x,p.y-P.y)<20){ if (P.iT<=0){ if (CHEAT.active){ P.hitFlash=0.25; spark(P.x,P.y,'#ff8a8a'); } else if (UPGR.dodgeChance>0 && Math.random()<UPGR.dodgeChance){ P.iT=0.6; P.hitFlash=0.25; spark(P.x,P.y,'#a1ffd4'); } else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); if (P.hp<=0) return gameOver(); } } BOSS_PROJECTILES.splice(i,1); } }
+      for (let i=BOSS_SLAMS.length-1;i>=0;i--){ const s=BOSS_SLAMS[i]; s.t+=dt; const active=s.t>=s.windup&&s.t<=s.windup+s.dur; if(active){ const rx=P.x-s.x, ry=P.y-s.y; const ca=Math.cos(-s.facing), sa=Math.sin(-s.facing); const lx=rx*ca-ry*sa, ly=rx*sa+ry*ca; if(0<=lx&&lx<=s.l&&Math.abs(ly)<=s.w/2){ if(P.iT<=0){ if(CHEAT.active){ P.hitFlash=0.25; spark(P.x,P.y,'#ff8a8a'); } else if(UPGR.dodgeChance>0 && Math.random()<UPGR.dodgeChance){ P.iT=0.6; P.hitFlash=0.25; spark(P.x,P.y,'#a1ffd4'); } else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); if(P.hp<=0) return gameOver(); } } BOSS_SLAMS.splice(i,1); continue; } } if(s.t> s.windup+s.dur) BOSS_SLAMS.splice(i,1); }
 
       // Wave & spawns (scale with larger world)
       if (!boss && !awaitingStage) {
@@ -1234,7 +1257,8 @@
           const fh = sheet.height;
           ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
         } else if (e.kind === 'boss') {
-          const sheet = MUCK_ANIM[e.dir];
+          const anim = e.bossType === 'hillGiant' ? HILL_ANIM : MUCK_ANIM;
+          const sheet = anim[e.dir];
           const fw = sheet.width / 4;
           const fh = sheet.height;
           ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
@@ -1358,6 +1382,16 @@
           ctx.beginPath();
           ctx.arc(bp.x, bp.y, 8, 0, Math.PI*2);
           ctx.fill();
+        }
+      }
+      if (BOSS_SLAMS.length){
+        for (const s of BOSS_SLAMS){
+          ctx.save();
+          ctx.translate(s.x, s.y);
+          ctx.rotate(s.facing);
+          ctx.fillStyle = s.t < s.windup ? 'rgba(255,0,0,0.3)' : 'rgba(255,0,0,0.6)';
+          ctx.fillRect(0, -s.w/2, s.l, s.w);
+          ctx.restore();
         }
       }
 


### PR DESCRIPTION
## Summary
- add hill giant sprite set for stage 2 boss
- give hill giant 50% more health and periodic slam attack with warning zone

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2f640c5c88329a6d337e29a9d52a2