### PR TITLE
feat: add hill giant boss with slam attack

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -376,6 +376,17 @@
     MUCK_ANIM.left.src = 'assets/EG_enemy_boss_mudMonster_animation_walking_left_small.png';
     MUCK_ANIM.right.src = 'assets/EG_enemy_boss_mudMonster_animation_walking_right_small.png';
 
+    const HILL_ANIM = {
+      down: new Image(),
+      up: new Image(),
+      left: new Image(),
+      right: new Image(),
+    };
+    HILL_ANIM.down.src = 'assets/EG_enemy_boss_hillGiant_walking_down_small.png';
+    HILL_ANIM.up.src = 'assets/EG_enemy_boss_hillGiant_walking_up_small.png';
+    HILL_ANIM.left.src = 'assets/EG_enemy_boss_hillGiant_walking_left_small.png';
+    HILL_ANIM.right.src = 'assets/EG_enemy_boss_hillGiant_walking_right_small.png';
+
 
     const IMG = {
       coin: new Image(),
@@ -399,7 +410,7 @@
     ];
     const MAPS = MAP_FILES.map(src => { const i = new Image(); i.src = src; return i; });
 
-    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length;
+    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length + Object.keys(HILL_ANIM).length;
     for (const k in IMG) IMG[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const img of MAPS) img.addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in WIZ_ANIM) WIZ_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
@@ -409,6 +420,7 @@
     for (const k in IMP_ANIM) IMP_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in ORC_ANIM) ORC_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in MUCK_ANIM) MUCK_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in HILL_ANIM) HILL_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.rogue.addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.wizard.addEventListener('load', () => { if (++loaded === need) init(); });
 
@@ -710,7 +722,13 @@
       const x = ARENA.x + ARENA.w/2;
       const y = ARENA.y + ARENA.h/2;
       const stageSpd = Math.pow(1.2, stage);
-      const b = { kind:'boss', x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp:60, hpMax:60, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, facing:0 };
+      let hp = 60;
+      let type = 'muck';
+      if (stage === 1){
+        hp = Math.round(60 * 1.5);
+        type = 'hill';
+      }
+      const b = { kind:'boss', type, x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, facing:0, slamT:0, slamTele:0 };
       enemies.push(b);
       return b;
     }
@@ -1020,6 +1038,31 @@
               BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(e.facing)*140, vy:Math.sin(e.facing)*140, life:0, ttl:3 });
             }
           }
+          if (e.type === 'hill'){
+            e.slamT += dt;
+            if (!e.slamTele && e.slamT >= 4){
+              e.slamTele = 0.7;
+            }
+            if (e.slamTele){
+              e.slamTele -= dt;
+              if (e.slamTele <= 0){
+                e.slamT = 0;
+                const ang = Math.atan2(P.y - e.y, P.x - e.x);
+                const distP = Math.hypot(P.x - e.x, P.y - e.y);
+                if (distP <= 100 && Math.abs(angleDiff(ang, e.facing)) <= Math.PI/3){
+                  if (P.iT<=0){
+                    if (CHEAT.active){
+                      P.hitFlash = 0.25; spark(P.x,P.y,'#ff8a8a');
+                    } else if (UPGR.dodgeChance>0 && Math.random()<UPGR.dodgeChance){
+                      P.iT = 0.6; P.hitFlash = 0.25; spark(P.x,P.y,'#a1ffd4');
+                    } else {
+                      P.hp -= 1; P.iT = 2.0; P.hitFlash = 0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); if (P.hp<=0) return gameOver();
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
 
         // Walk animation for goblins, imps, orcs, and bosses
@@ -1216,6 +1259,15 @@
 
       // Draw enemies with shadow (use sprite per type, size by enemy)
       for (const e of enemies){
+        if (e.kind === 'boss' && e.type === 'hill' && e.slamTele > 0){
+          const range = 100;
+          ctx.beginPath();
+          ctx.moveTo(e.x, e.y);
+          ctx.arc(e.x, e.y, range, e.facing - Math.PI/3, e.facing + Math.PI/3);
+          ctx.closePath();
+          ctx.fillStyle = 'rgba(255,0,0,0.3)';
+          ctx.fill();
+        }
         // shadow scaled to enemy size
         ctx.drawImage(IMG.shadow, e.x - e.w*0.7, e.y - e.h*0.35, e.w*1.4, e.h*0.7);
         if (e.kind === 'goblin'){
@@ -1234,7 +1286,7 @@
           const fh = sheet.height;
           ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
         } else if (e.kind === 'boss') {
-          const sheet = MUCK_ANIM[e.dir];
+          const sheet = e.type === 'hill' ? HILL_ANIM[e.dir] : MUCK_ANIM[e.dir];
           const fw = sheet.width / 4;
           const fh = sheet.height;
           ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);


### PR DESCRIPTION
## Summary
- add hill giant boss animations and asset loading
- spawn stage 2 hill giant with 50% more health and slam attack
- draw telegraphed slam area and apply damage in front of boss

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2f92feb4c8329bc1c050595b3527e