### PR TITLE
Add hunger demon boss with new attack patterns

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -398,6 +398,17 @@
     ABOMINATION_ANIM.left.src = 'assets/EG_enemy_boss_abomination_animation_walking_left_small.png';
     ABOMINATION_ANIM.right.src = 'assets/EG_enemy_boss_abomination_animation_walking_right_small.png';
 
+    const HUNGER_DEMON_ANIM = {
+      down: new Image(),
+      up: new Image(),
+      left: new Image(),
+      right: new Image(),
+    };
+    HUNGER_DEMON_ANIM.down.src = 'assets/EG_enemy_boss_hungerDemon_animation_walking_down_small.png';
+    HUNGER_DEMON_ANIM.up.src = 'assets/EG_enemy_boss_hungerDemon_animation_walking_up_small.png';
+    HUNGER_DEMON_ANIM.left.src = 'assets/EG_enemy_boss_hungerDemon_animation_walking_left_small.png';
+    HUNGER_DEMON_ANIM.right.src = 'assets/EG_enemy_boss_hungerDemon_animation_walking_right_small.png';
+
 
     const IMG = {
       coin: new Image(),
@@ -421,7 +432,7 @@
     ];
     const MAPS = MAP_FILES.map(src => { const i = new Image(); i.src = src; return i; });
 
-    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length + Object.keys(HILL_GIANT_ANIM).length;
+    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length + Object.keys(HILL_GIANT_ANIM).length + Object.keys(ABOMINATION_ANIM).length + Object.keys(HUNGER_DEMON_ANIM).length;
     for (const k in IMG) IMG[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const img of MAPS) img.addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in WIZ_ANIM) WIZ_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
@@ -432,6 +443,8 @@
     for (const k in ORC_ANIM) ORC_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in MUCK_ANIM) MUCK_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in HILL_GIANT_ANIM) HILL_GIANT_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in ABOMINATION_ANIM) ABOMINATION_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in HUNGER_DEMON_ANIM) HUNGER_DEMON_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.rogue.addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.wizard.addEventListener('load', () => { if (++loaded === need) init(); });
 
@@ -741,8 +754,11 @@
       } else if (stage === 2) {
         bossType = 'abomination';
         hp = 120;
+      } else if (stage === 3) {
+        bossType = 'hungerDemon';
+        hp = 150;
       }
-      const b = { kind:'boss', bossType, x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, facing:0, freezeT:0, pulse:0 };
+      const b = { kind:'boss', bossType, x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, blastT:0, facing:0, freezeT:0, pulse:0 };
       if (bossType === 'hillGiant') b.slamCd = 3;
       enemies.push(b);
       return b;
@@ -1050,11 +1066,33 @@
 
         if (e.kind === 'boss'){
           e.atkT += dt;
+          if (e.bossType === 'hungerDemon') e.blastT = (e.blastT || 0) + dt;
           if (e.bossType === 'abomination') {
             if (e.freezeT <= 0 && e.atkT >= 2.4){
               e.atkT = 0;
               const range = 90;
               e.pulse = 0.3;
+              e.pulseRange = range;
+              if (dist < range && P.iT<=0){
+                if (CHEAT.active){ P.hitFlash = 0.25; spark(P.x,P.y,'#ff8a8a'); }
+                else if (UPGR.dodgeChance>0 && Math.random()<UPGR.dodgeChance){ P.iT=0.6; P.hitFlash=0.25; spark(P.x,P.y,'#a1ffd4'); }
+                else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); if (P.hp<=0) return gameOver(); }
+              }
+              e.freezeT = 1.2;
+            }
+          } else if (e.bossType === 'hungerDemon') {
+            if (e.freezeT <= 0 && e.atkT >= 2.4){
+              e.atkT = 0;
+              const count = 8;
+              for (let i=0;i<count;i++){
+                const ang = (Math.PI*2 / count) * i;
+                BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(ang)*140, vy:Math.sin(ang)*140, life:0, ttl:3 });
+              }
+            }
+            if (e.freezeT <= 0 && e.blastT >= 5){
+              e.blastT = 0;
+              const range = 160;
+              e.pulse = 0.4;
               e.pulseRange = range;
               if (dist < range && P.iT<=0){
                 if (CHEAT.active){ P.hitFlash = 0.25; spark(P.x,P.y,'#ff8a8a'); }
@@ -1298,7 +1336,7 @@
             ctx.arc(e.x, e.y, e.slam.range, a0, a1);
             ctx.closePath();
             ctx.fill();
-          } else if (e.bossType === 'abomination' && e.pulse > 0){
+          } else if (e.pulse > 0){
             ctx.fillStyle = 'rgba(255,0,0,0.3)';
             ctx.beginPath();
             ctx.arc(e.x, e.y, e.pulseRange || 90, 0, Math.PI*2);
@@ -1321,7 +1359,7 @@
           const fh = sheet.height;
           ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
         } else if (e.kind === 'boss') {
-          const anim = e.bossType === 'hillGiant' ? HILL_GIANT_ANIM : e.bossType === 'abomination' ? ABOMINATION_ANIM : MUCK_ANIM;
+          const anim = e.bossType === 'hillGiant' ? HILL_GIANT_ANIM : e.bossType === 'abomination' ? ABOMINATION_ANIM : e.bossType === 'hungerDemon' ? HUNGER_DEMON_ANIM : MUCK_ANIM;
           const sheet = anim[e.dir];
           const fw = sheet.width / 4;
           const fh = sheet.height;


### PR DESCRIPTION
## Summary
- Add hunger demon stage 4 boss with new walking animations
- Spawn hunger demon in stage 4 and preload its assets
- Give hunger demon radial projectile spray and area blast that freezes after use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c30696ec188329b3c4039e5d25d5d4