### PR TITLE
Remove extra stage and add victory message

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -465,7 +465,6 @@
       'assets/EG_map_feywild01.png',
       'assets/EG_map_corruption01.png',
       'assets/EG_map_mountain01.png',
-      'assets/EG_map_corruption01.png',
     ];
     const MAPS = MAP_FILES.map(src => { const i = new Image(); i.src = src; return i; });
 
@@ -809,10 +808,19 @@
       boss = null;
       BOSS_PROJECTILES = [];
       awaitingStage = true;
+      if (nextStageInterval) { clearInterval(nextStageInterval); nextStageInterval = null; }
+      if (stage >= MAPS.length - 1) {
+        stageTimerEl.textContent = 'You Won!';
+        stageTimerEl.classList.remove('hidden');
+        setTimeout(() => {
+          stageTimerEl.classList.add('hidden');
+          gameOver();
+        }, 3000);
+        return;
+      }
       let remaining = 10;
       stageTimerEl.textContent = `Next Stage in ${remaining} seconds`;
       stageTimerEl.classList.remove('hidden');
-      if (nextStageInterval) { clearInterval(nextStageInterval); }
       nextStageInterval = setInterval(() => {
         remaining--;
         if (remaining > 0){


### PR DESCRIPTION
## Summary
- Drop unused sixth map so the game ends after five stages
- Show a "You Won" message for a few seconds after defeating the stage 5 boss before ending the game

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c31e5bbe54832983fa0eb992092a63