### PR TITLE
Disable arcane orb knockback in Emberfall

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -521,7 +521,7 @@
     // Melee arc narrowed so default swings are a tight cone ahead
     const PHYS = { friction: 0.86, atkDur: 0.18, atkRange: 64, atkArc: Math.PI*0.35 };
     // Knockback tuning
-    const KNOCK = { friction: 0.88, melee: 200, orb: 120, nova: 160, projectile: 180 };
+    const KNOCK = { friction: 0.88, melee: 200, orb: 0, nova: 160, projectile: 180 };
     // Frost Nova damage radius (visuals remain at ~90)
     const NOVA_RADIUS = 120;
     // Separate hitbox scaling so we can tighten player damage range


### PR DESCRIPTION
## Summary
- Prevent arcane orbs from pushing enemies by removing their knockback force

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c32a5120f883299a2aaa6329475ecc