### PR TITLE
feat: add chest and key drops to Emberfall Gauntlet

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -460,12 +460,18 @@
     const IMG = {
       coin: new Image(),
       heart: new Image(),
+      key: new Image(),
+      chestClosed: new Image(),
+      chestOpen: new Image(),
       shadow: new Image(),
       spark: new Image(),
       hero: CLASS_IMG.fighter,
     };
     IMG.coin.src = 'assets/eg_coin.svg';
     IMG.heart.src = 'assets/eg_heart.svg';
+    IMG.key.src = 'assets/EG_key.png';
+    IMG.chestClosed.src = 'assets/EG_chest_closed.png';
+    IMG.chestOpen.src = 'assets/EG_chest_open.png';
     IMG.shadow.src = 'assets/eg_shadow.svg';
     IMG.spark.src = 'assets/eg_spark.svg';
 
@@ -536,7 +542,7 @@
       [200, 250],
     ];
     let WAVE_LIMIT = STAGE_WAVE_COUNTS[0][0];
-    const SPAWN = { t: 0, cd: 2.2, wave: 1, count: 0 };
+    const SPAWN = { t: 0, cd: 2.2, wave: 1, count: 0, keyCarrier: 0 };
     let stage = 0;
     const STAGE_WAVES = 2;
     function updateWaveLimit() {
@@ -581,6 +587,8 @@
     let NOVA_FLASH = 0; // brief blue flash when nova triggers
     let enemies = [];
     let drops = [];
+    let chests = [];
+    let playerHasKey = false;
     let paused = false, running = false, gameOverHandled = false;
     let awaitingStage = false;
     let nextStageInterval = null;
@@ -649,15 +657,18 @@
       currentMap = MAPS[stage];
       ARENA.x = 0; ARENA.y = 0; ARENA.w = currentMap.width; ARENA.h = currentMap.height;
       DENSITY = Math.max(1, Math.round(Math.max(ARENA.w / W, ARENA.h / H) * 1.5));
-      enemies = []; drops = []; PARTICLES.length = 0; BOSS_PROJECTILES = [];
+      enemies = []; drops = []; chests = []; PARTICLES.length = 0; BOSS_PROJECTILES = [];
+      playerHasKey = false;
       Object.assign(P, { x: ARENA.x + ARENA.w/2, y: ARENA.y + ARENA.h/2, vx:0, vy:0, dir:0, aimDir:0, swingAim:0, iT:0, atkT:0, autoT:0 });
       const stageMult = Math.pow(1.2, stage);
-      Object.assign(SPAWN, { t:0, cd:2.2 / stageMult, wave:1, count:0 });
+      Object.assign(SPAWN, { t:0, cd:2.2 / stageMult, wave:1, count:0, keyCarrier:0 });
       updateWaveLimit();
+      SPAWN.keyCarrier = Math.floor(Math.random()*WAVE_LIMIT);
+      spawnChest();
       waveEl.textContent = SPAWN.wave;
       boss = null;
       const initial = Math.min(Math.floor(WAVE_LIMIT * 0.5), 40);
-      for (let i=0; i<initial; i++){ spawnEnemy(); SPAWN.count++; }
+      for (let i=0; i<initial; i++){ spawnEnemy(); }
     }
 
     function reset() {
@@ -776,6 +787,7 @@
 
     // Spawning
     function spawnEnemy(){
+      const idx = SPAWN.count;
       // Spawn outside player vicinity along arena edges
       const side = Math.floor(Math.random()*4);
       let x=ARENA.x+8, y=ARENA.y+8;
@@ -798,7 +810,10 @@
       if (kind==='imp'){ w=22; h=18; spd=130 * stageSpd; hp=Math.max(1,1+Math.floor(SPAWN.wave/3)); score=40; }
       else if (kind==='orc'){ w=ENEMY.w*2; h=ENEMY.h*2; spd=60 * stageSpd; hp=(3+Math.floor(SPAWN.wave/1.5))*3; score=240; }
 
-      enemies.push({ kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0 });
+      const enemy = { kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0 };
+      if (idx === SPAWN.keyCarrier) enemy.hasKey = true;
+      enemies.push(enemy);
+      SPAWN.count++;
     }
 
     function spawnBoss(){
@@ -854,6 +869,9 @@
     }
 
     function dropCoin(x,y){ drops.push({ x, y, w:DROP.w, h:DROP.h, t:0, kind:'coin', v: rand(40,70), a: rand(0,Math.PI*2) }); }
+    function dropHeart(x,y){ drops.push({ x, y, w:DROP.w, h:DROP.h, t:0, kind:'heart', v: rand(40,70), a: rand(0,Math.PI*2) }); }
+    function dropKey(x,y){ drops.push({ x, y, w:DROP.w, h:DROP.h, t:0, kind:'key', v: rand(40,70), a: rand(0,Math.PI*2) }); }
+    function spawnChest(){ const x = rand(ARENA.x+40, ARENA.x+ARENA.w-40); const y = rand(ARENA.y+40, ARENA.y+ARENA.h-40); chests.push({ x, y, open:false }); }
 
     function applyDamage(e, dmg=1, kx=0, ky=0, kb=0){
       e.hp -= dmg;
@@ -868,6 +886,7 @@
         } else {
           addScore(e.score||50);
           dropCoin(e.x, e.y);
+          if (e.hasKey) dropKey(e.x, e.y);
           // Life steal on kill
           if (UPGR.lifeStealChance > 0 && Math.random() < UPGR.lifeStealChance){ if (P.hp < P.hpMax){ P.hp += 1; drawHearts(); } }
           // Extra coin chance
@@ -1281,6 +1300,17 @@
         }
       }
 
+      // Chest interaction
+      for (const c of chests){
+        if (!c.open && playerHasKey && len(P.x-c.x,P.y-c.y)<24){
+          c.open = true;
+          playerHasKey = false;
+          const coins = Math.floor(rand(15,51));
+          for (let j=0;j<coins;j++) dropCoin(c.x + rand(-10,10), c.y + rand(-10,10));
+          dropHeart(c.x, c.y);
+        }
+      }
+
       // Collect drops
       for (let i=drops.length-1;i>=0;i--){
         const d=drops[i]; d.t += dt; const drift = Math.min(1,d.t*3);
@@ -1296,6 +1326,12 @@
             addScore(10);
             COINS.value += 1; coinsEl.textContent = COINS.value; spark(d.x,d.y,'#ffd16b');
             maybeOpenShop();
+          } else if (d.kind==='heart'){
+            if (P.hp < P.hpMax){ P.hp += 1; drawHearts(); }
+            spark(d.x,d.y,'#ff6b6b');
+          } else if (d.kind==='key'){
+            playerHasKey = true;
+            spark(d.x,d.y,'#fff');
           }
           drops.splice(i,1);
         }
@@ -1388,12 +1424,15 @@
           SPAWN.t = 0;
           let group = Math.min(8, Math.max(2, Math.ceil(DENSITY/2)) * Math.min(4, 1 + Math.floor(SPAWN.wave/2)));
           group = Math.min(group, WAVE_LIMIT - SPAWN.count);
-          for (let i=0;i<group; i++){ spawnEnemy(); SPAWN.count++; }
+          for (let i=0;i<group; i++){ spawnEnemy(); }
         }
         if (SPAWN.count >= WAVE_LIMIT && alive === 0){
           if (SPAWN.wave < STAGE_WAVES){
             SPAWN.wave += 1; waveEl.textContent = SPAWN.wave; SPAWN.count = 0; SPAWN.t = 0;
             updateWaveLimit();
+            SPAWN.keyCarrier = Math.floor(Math.random()*WAVE_LIMIT);
+            chests = [];
+            spawnChest();
           } else {
             boss = spawnBoss();
           }
@@ -1437,8 +1476,14 @@
       ctx.translate(-CAM.x, -CAM.y);
       drawBackground();
 
+      // Draw chests
+      for (const c of chests){ const img = c.open ? IMG.chestOpen : IMG.chestClosed; ctx.drawImage(img, c.x-16, c.y-16, 32, 32); }
+
       // Draw drops
-      for (const d of drops) { ctx.drawImage(IMG.coin, d.x-12, d.y-12, 24, 24); }
+      for (const d of drops) {
+        const img = d.kind==='coin'?IMG.coin : d.kind==='heart'?IMG.heart : d.kind==='key'?IMG.key:null;
+        if (img) ctx.drawImage(img, d.x-12, d.y-12, 24, 24);
+      }
 
       // Draw enemies with shadow (use sprite per type, size by enemy)
       for (const e of enemies){


### PR DESCRIPTION
## Summary
- spawn a chest at the start of each wave that opens with a key
- randomly tag one enemy per wave to drop a key
- opening chests yields coins and a healing heart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c330c1e1348329ad22a35d32bc9125