### PR TITLE
Add key drops to Emberfall waves

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -65,6 +65,8 @@
     .chip { background: var(--ui); border: 2px solid var(--gold); color: var(--ink); padding: 8px 12px; border-radius: 10px; font-size: 12px; box-shadow: 0 4px 14px rgba(255,215,0,0.25); }
     .hearts { display:flex; align-items:center; gap: 6px; }
     .hearts img { width: 20px; height: 20px; image-rendering: pixelated; }
+    .keys { display:flex; align-items:center; gap: 6px; }
+    .keys img { width: 20px; height: 20px; image-rendering: pixelated; }
 
     /* Audio toggle icon button */
     .audio-toggle { display:flex; align-items:center; gap:8px; }
@@ -124,6 +126,7 @@
       <div class="chip">Wave: <span id="wave">1</span></div>
       <div class="chip" title="Coins collected">Coins: <span id="coins">0</span></div>
       <div class="chip hearts" id="hearts"></div>
+      <div class="chip keys hidden" id="keys"></div>
       <div class="chip hidden" id="stageTimer"></div>
       <div class="audio-toggle" title="Toggle Audio (M)">
         <div id="audioIcon">
@@ -201,6 +204,7 @@
     const waveEl = document.getElementById('wave');
     const coinsEl = document.getElementById('coins');
     const heartsEl = document.getElementById('hearts');
+    const keysEl = document.getElementById('keys');
     const stageTimerEl = document.getElementById('stageTimer');
     const startOverlay = document.getElementById('startOverlay');
     const gameOverOverlay = document.getElementById('gameOver');
@@ -459,6 +463,7 @@
 
     const IMG = {
       coin: new Image(),
+      key: new Image(),
       heart: new Image(),
       shadow: new Image(),
       spark: new Image(),
@@ -466,6 +471,7 @@
       hero: CLASS_IMG.fighter,
     };
     IMG.coin.src = 'assets/eg_coin.svg';
+    IMG.key.src = 'assets/EG_key_small.png';
     IMG.heart.src = 'assets/eg_heart.svg';
     IMG.shadow.src = 'assets/eg_shadow.svg';
     IMG.spark.src = 'assets/eg_spark.svg';
@@ -538,7 +544,7 @@
       [200, 250],
     ];
     let WAVE_LIMIT = STAGE_WAVE_COUNTS[0][0];
-    const SPAWN = { t: 0, cd: 2.2, wave: 1, count: 0 };
+    const SPAWN = { t: 0, cd: 2.2, wave: 1, count: 0, keyAssigned: false };
     let stage = 0;
     const STAGE_WAVES = 2;
     function updateWaveLimit() {
@@ -551,6 +557,7 @@
     }
     let boss = null;
     const COINS = { value: 0 };
+    const KEYS = { value: 0 };
     const SHOP = { milestones: [10, 20, 40, 80, 120, 200, 300, 500, 700, 900, 1200], idx: 0, open: false };
     const UPGR = {
       meleeDmg: 1,
@@ -655,7 +662,7 @@
       enemies = []; drops = []; chests = []; PARTICLES.length = 0; BOSS_PROJECTILES = [];
       Object.assign(P, { x: ARENA.x + ARENA.w/2, y: ARENA.y + ARENA.h/2, vx:0, vy:0, dir:0, aimDir:0, swingAim:0, iT:0, atkT:0, autoT:0 });
       const stageMult = Math.pow(1.2, stage);
-      Object.assign(SPAWN, { t:0, cd:2.2 / stageMult, wave:1, count:0 });
+      Object.assign(SPAWN, { t:0, cd:2.2 / stageMult, wave:1, count:0, keyAssigned:false });
       updateWaveLimit();
       waveEl.textContent = SPAWN.wave;
       boss = null;
@@ -681,6 +688,7 @@
       AUTO.atkPeriod = 0.7;
       SCORE.value = 0; scoreEl.textContent = SCORE.value;
       COINS.value = 0; coinsEl.textContent = COINS.value; SHOP.idx = 0; SHOP.open = false;
+      KEYS.value = 0; drawKeys();
       // Reset upgrades and spell state
       Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:0, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:60, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1 });
       if (stats.startOrbs) { UPGR.orbs = stats.startOrbs; }
@@ -688,6 +696,7 @@
       stage = 0;
       loadStage();
       drawHearts();
+      drawKeys();
     }
 
     function start() { reset(); running = true; paused = false; startOverlay.classList.remove('show'); gameOverOverlay.classList.remove('show'); }
@@ -777,6 +786,7 @@
 
     // HUD
     function drawHearts(){ heartsEl.innerHTML=''; for (let i=0;i<P.hpMax;i++){ const img=document.createElement('img'); img.src=IMG.heart.src; img.style.opacity = i < P.hp ? '1' : '0.28'; heartsEl.appendChild(img);} }
+    function drawKeys(){ keysEl.innerHTML=''; for (let i=0;i<KEYS.value;i++){ const img=document.createElement('img'); img.src=IMG.key.src; keysEl.appendChild(img);} keysEl.classList.toggle('hidden', KEYS.value===0); }
 
     // Spawning
     function spawnEnemy(){
@@ -802,7 +812,9 @@
       if (kind==='imp'){ w=22; h=18; spd=130 * stageSpd; hp=Math.max(1,1+Math.floor(SPAWN.wave/3)); score=40; }
       else if (kind==='orc'){ w=ENEMY.w*2; h=ENEMY.h*2; spd=60 * stageSpd; hp=(3+Math.floor(SPAWN.wave/1.5))*3; score=240; }
 
-      enemies.push({ kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0 });
+      const enemy = { kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0 };
+      if (!SPAWN.keyAssigned){ enemy.hasKey = true; SPAWN.keyAssigned = true; }
+      enemies.push(enemy);
     }
 
     function spawnBoss(){
@@ -858,6 +870,7 @@
     }
 
     function dropCoin(x,y){ drops.push({ x, y, w:DROP.w, h:DROP.h, t:0, kind:'coin', v: rand(40,70), a: rand(0,Math.PI*2) }); }
+    function dropKey(x,y){ drops.push({ x, y, w:DROP.w, h:DROP.h, t:0, kind:'key', v: rand(40,70), a: rand(0,Math.PI*2) }); }
 
     function spawnChest(){
       const side = Math.floor(Math.random()*4);
@@ -895,6 +908,7 @@
           handleBossDefeat();
         } else {
           addScore(e.score||50);
+          if (e.hasKey) dropKey(e.x, e.y);
           dropCoin(e.x, e.y);
           // Life steal on kill
           if (UPGR.lifeStealChance > 0 && Math.random() < UPGR.lifeStealChance){ if (P.hp < P.hpMax){ P.hp += 1; drawHearts(); } }
@@ -1333,6 +1347,8 @@
             addScore(10);
             COINS.value += 1; coinsEl.textContent = COINS.value; spark(d.x,d.y,'#ffd16b');
             maybeOpenShop();
+          } else if (d.kind==='key'){
+            KEYS.value += 1; drawKeys(); spark(d.x,d.y,'#ffd16b');
           }
           drops.splice(i,1);
         }
@@ -1429,7 +1445,7 @@
         }
         if (SPAWN.count >= WAVE_LIMIT && alive === 0){
           if (SPAWN.wave < STAGE_WAVES){
-            SPAWN.wave += 1; waveEl.textContent = SPAWN.wave; SPAWN.count = 0; SPAWN.t = 0;
+            SPAWN.wave += 1; waveEl.textContent = SPAWN.wave; SPAWN.count = 0; SPAWN.t = 0; SPAWN.keyAssigned = false;
             spawnChest();
             updateWaveLimit();
           } else {
@@ -1479,7 +1495,7 @@
       for (const c of chests) { ctx.drawImage(IMG.chest, c.x-16, c.y-16, 32, 32); }
 
       // Draw drops
-      for (const d of drops) { ctx.drawImage(IMG.coin, d.x-12, d.y-12, 24, 24); }
+      for (const d of drops) { const img = d.kind==='coin'?IMG.coin:IMG.key; ctx.drawImage(img, d.x-12, d.y-12, 24, 24); }
 
       // Draw enemies with shadow (use sprite per type, size by enemy)
       for (const e of enemies){


### PR DESCRIPTION
## Summary
- Ensure each wave spawns one key-carrying enemy that drops a collectible key
- Display collected keys as icons in the HUD using existing key asset
- Track keys and reset state between runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c33c98939c8329a1422df46d847e0d