### PR TITLE
Animate stage 1 boss mud projectiles in Emberfall

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -455,6 +455,7 @@
       spark: new Image(),
       chest: new Image(),
       chestOpen: new Image(),
+      mudProjectile: new Image(),
       hero: CLASS_IMG.fighter,
     };
     IMG.coin.src = 'assets/eg_coin.svg';
@@ -464,6 +465,7 @@
     IMG.spark.src = 'assets/eg_spark.svg';
     IMG.chest.src = 'assets/EG_chest_closed_small.png';
     IMG.chestOpen.src = 'assets/EG_chest_open_small.png';
+    IMG.mudProjectile.src = 'assets/EG_projectile_mud_small.png';
 
     const MAP_FILES = [
       'assets/EG_map_mirewatch01.png',
@@ -1238,7 +1240,11 @@
             e.atkT = 0;
             const diff = angleDiff(Math.atan2(dy, dx), e.facing);
             if (Math.abs(diff) <= Math.PI/3){
-              BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(e.facing)*140, vy:Math.sin(e.facing)*140, life:0, ttl:3 });
+              if (e.bossType === 'muck') {
+                BOSS_PROJECTILES.push({ kind:'mud', frame:0, animT:0, x:e.x, y:e.y, vx:Math.cos(e.facing)*140, vy:Math.sin(e.facing)*140, life:0, ttl:3 });
+              } else {
+                BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(e.facing)*140, vy:Math.sin(e.facing)*140, life:0, ttl:3 });
+              }
             }
           }
           if (e.bossType === 'hillGiant'){
@@ -1427,6 +1433,10 @@
           continue;
         }
         p.x += p.vx * dt; p.y += p.vy * dt;
+        if (p.kind === 'mud'){
+          p.animT += dt;
+          if (p.animT > 0.1){ p.animT = 0; p.frame = (p.frame + 1) % 4; }
+        }
         if (p.life > p.ttl){ BOSS_PROJECTILES.splice(i,1); continue; }
         if (len(p.x-P.x,p.y-P.y) < 20){
           if (P.iT<=0){
@@ -1675,6 +1685,11 @@
             ctx.fillStyle = 'purple';
             ctx.fillRect(0, -4, 240, 8);
             ctx.restore();
+          } else if (bp.kind === 'mud') {
+            const sheet = IMG.mudProjectile;
+            const fw = sheet.width / 4;
+            const fh = sheet.height;
+            ctx.drawImage(sheet, bp.frame * fw, 0, fw, fh, bp.x - fw/2, bp.y - fh/2, fw, fh);
           } else {
             ctx.fillStyle = bp.kind === 'slow' ? 'red' : bp.kind === 'fast' ? 'orange' : 'brown';
             ctx.beginPath();


### PR DESCRIPTION
## Summary
- Load 4-frame mud projectile sprite
- Use mud sprite for Stage 1 boss attacks and animate frames

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c373db819c832996c5cd607bacbf4e