### PR TITLE
Use slime projectile sprites for late bosses

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -440,6 +440,13 @@
     HILL_GIANT_PROJECTILE_ANIM.left.src = 'assets/EG_projectile_rock_left_small.png';
     HILL_GIANT_PROJECTILE_ANIM.right.src = 'assets/EG_projectile_rock_right_small.png';
 
+    const SLIME_PROJECTILE_ANIM = {
+      left: new Image(),
+      right: new Image(),
+    };
+    SLIME_PROJECTILE_ANIM.left.src = 'assets/EG_projectile_slime_left_small.png';
+    SLIME_PROJECTILE_ANIM.right.src = 'assets/EG_projectile_slime_right_small.png';
+
     const HILL_GIANT_ANIM = {
       down: new Image(),
       up: new Image(),
@@ -1237,7 +1244,9 @@
               const count = 8;
               for (let i=0;i<count;i++){
                 const ang = (Math.PI*2 / count) * i;
-                BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(ang)*140, vy:Math.sin(ang)*140, life:0, ttl:3 });
+                const vx = Math.cos(ang) * 140;
+                const vy = Math.sin(ang) * 140;
+                BOSS_PROJECTILES.push({ kind:'slime', dir: vx < 0 ? 'left' : 'right', x:e.x, y:e.y, vx, vy, life:0, ttl:3, frame:0, animT:0 });
               }
             }
             if (e.freezeT <= 0 && e.blastT >= 5){
@@ -1258,8 +1267,12 @@
               const count = 8;
               for (let i=0; i<count; i++){
                 const ang = (Math.PI*2 / count) * i;
-                BOSS_PROJECTILES.push({ kind:'slow', dmg:2, x:e.x, y:e.y, vx:Math.cos(ang)*90, vy:Math.sin(ang)*90, life:0, ttl:4 });
-                BOSS_PROJECTILES.push({ kind:'fast', dmg:1, x:e.x, y:e.y, vx:Math.cos(ang)*180, vy:Math.sin(ang)*180, life:0, ttl:2 });
+                const vxSlow = Math.cos(ang) * 90;
+                const vySlow = Math.sin(ang) * 90;
+                BOSS_PROJECTILES.push({ kind:'slime', dmg:2, dir: vxSlow < 0 ? 'left' : 'right', x:e.x, y:e.y, vx:vxSlow, vy:vySlow, life:0, ttl:4, frame:0, animT:0 });
+                const vxFast = Math.cos(ang) * 180;
+                const vyFast = Math.sin(ang) * 180;
+                BOSS_PROJECTILES.push({ kind:'slime', dmg:1, dir: vxFast < 0 ? 'left' : 'right', x:e.x, y:e.y, vx:vxFast, vy:vyFast, life:0, ttl:2, frame:0, animT:0 });
               }
               const beamAng = Math.atan2(dy, dx);
               BOSS_PROJECTILES.push({ kind:'beam', dmg:1, x:e.x, y:e.y, ang:beamAng, life:0, ttl:1 });
@@ -1485,7 +1498,7 @@
           continue;
         }
         p.x += p.vx * dt; p.y += p.vy * dt;
-        if (p.kind === 'muck' || p.kind === 'rock'){
+        if (p.kind === 'muck' || p.kind === 'rock' || p.kind === 'slime'){
           p.animT += dt;
           if (p.animT >= 0.12){ p.animT = 0; p.frame = (p.frame + 1) % 4; }
         }
@@ -1744,6 +1757,11 @@
             ctx.drawImage(sheet, bp.frame * fw, 0, fw, fh, bp.x - fw/2, bp.y - fh/2, fw, fh);
           } else if (bp.kind === 'rock'){
             const sheet = HILL_GIANT_PROJECTILE_ANIM[bp.dir];
+            const fw = sheet.width / 4;
+            const fh = sheet.height;
+            ctx.drawImage(sheet, bp.frame * fw, 0, fw, fh, bp.x - fw/2, bp.y - fh/2, fw, fh);
+          } else if (bp.kind === 'slime'){
+            const sheet = SLIME_PROJECTILE_ANIM[bp.dir];
             const fw = sheet.width / 4;
             const fh = sheet.height;
             ctx.drawImage(sheet, bp.frame * fw, 0, fw, fh, bp.x - fw/2, bp.y - fh/2, fw, fh);


### PR DESCRIPTION
## Summary
- Add slime projectile animation sprites and apply them to stage 4 and 5 boss attacks
- Animate slime projectiles when moving left or right

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c38ed7f558832999479950f6d9d74a