### PR TITLE
feat(emberfall): double hero and enemy size

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -548,11 +548,11 @@
     // Arena dimensions will match the chosen map image
     const ARENA = { x: 0, y: 0, w: 0, h: 0 };
     const CAM = { x: 0, y: 0 };
-    const P = { x: W/2, y: H/2, vx: 0, vy: 0, spd: 2400, w: 28, h: 28, dir: 0, aimDir: 0, swingAim: 0, hp: 5, hpMax: 5, iT: 0, atkT: 0, autoT: 0, hitFlash: 0 };
+    const P = { x: W/2, y: H/2, vx: 0, vy: 0, spd: 2400, w: 56, h: 56, dir: 0, aimDir: 0, swingAim: 0, hp: 5, hpMax: 5, iT: 0, atkT: 0, autoT: 0, hitFlash: 0 };
     const WIZ_ANIM_STATE = { dir: 'down', frame: 0, t: 0 };
     const FIGHT_ANIM_STATE = { dir: 'down', frame: 0, t: 0 };
     const ROGUE_ANIM_STATE = { dir: 'down', frame: 0, t: 0 };
-    const ENEMY = { spd: 90, w: 26, h: 22 }; // default goblin baseline
+    const ENEMY = { spd: 90, w: 52, h: 44 }; // default goblin baseline
     // Fixed enemy speed: 45% of baseline (55% slower), no scaling
     const ENEMY_SPEED = Math.round(ENEMY.spd * 0.45);
     // Simple AI tuning: chase when close, wander when far; keep away from arena walls
@@ -851,10 +851,10 @@
       // Spawn outside player vicinity along arena edges
       const side = Math.floor(Math.random()*4);
       let x=ARENA.x+8, y=ARENA.y+8;
-      if (side===0) { x = rand(ARENA.x+16, ARENA.x+ARENA.w-16); y = ARENA.y+10; }
-      if (side===1) { x = ARENA.x+ARENA.w-10; y = rand(ARENA.y+16, ARENA.y+ARENA.h-16); }
-      if (side===2) { x = rand(ARENA.x+16, ARENA.x+ARENA.w-16); y = ARENA.y+ARENA.h-10; }
-      if (side===3) { x = ARENA.x+10; y = rand(ARENA.y+16, ARENA.y+ARENA.h-16); }
+      if (side===0) { x = rand(ARENA.x+32, ARENA.x+ARENA.w-32); y = ARENA.y+10; }
+      if (side===1) { x = ARENA.x+ARENA.w-10; y = rand(ARENA.y+32, ARENA.y+ARENA.h-32); }
+      if (side===2) { x = rand(ARENA.x+32, ARENA.x+ARENA.w-32); y = ARENA.y+ARENA.h-10; }
+      if (side===3) { x = ARENA.x+10; y = rand(ARENA.y+32, ARENA.y+ARENA.h-32); }
 
       // Choose monster type: guarantee variety from the start
       const r = Math.random();
@@ -867,7 +867,7 @@
       const stageSpd = Math.pow(1.2, stage);
       let w=ENEMY.w, h=ENEMY.h, spd=ENEMY.spd * stageSpd, hp=2+Math.floor(SPAWN.wave/2), score=50;
       // Make imp a bit faster than baseline and orc slower; reward orcs more
-      if (kind==='imp'){ w=22; h=18; spd=130 * stageSpd; hp=Math.max(1,1+Math.floor(SPAWN.wave/3)); score=40; }
+      if (kind==='imp'){ w=44; h=36; spd=130 * stageSpd; hp=Math.max(1,1+Math.floor(SPAWN.wave/3)); score=40; }
       else if (kind==='orc'){ w=ENEMY.w*2; h=ENEMY.h*2; spd=60 * stageSpd; hp=(3+Math.floor(SPAWN.wave/1.5))*3; score=240; }
 
       const enemy = { kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0 };
@@ -1126,7 +1126,7 @@
       P.vx *= pF; P.vy *= pF;
       P.x += P.vx*dt; P.y += P.vy*dt;
       // Clamp to arena
-        P.x = clamp(P.x, ARENA.x+16, ARENA.x+ARENA.w-16); P.y = clamp(P.y, ARENA.y+16, ARENA.y+ARENA.h-16);
+        P.x = clamp(P.x, ARENA.x+32, ARENA.x+ARENA.w-32); P.y = clamp(P.y, ARENA.y+32, ARENA.y+ARENA.h-32);
         if (currentClass === 'wizard') updateWizardAnim(dt);
         else if (currentClass === 'fighter') updateFighterAnim(dt);
         else if (currentClass === 'rogue') updateRogueAnim(dt);
@@ -1639,23 +1639,23 @@
           const sheet = GOBLIN_ANIM[e.dir];
           const fw = sheet.width / 4;
           const fh = sheet.height;
-          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
+          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 12, e.w, e.h + 12);
         } else if (e.kind === 'imp') {
           const sheet = IMP_ANIM[e.dir];
           const fw = sheet.width / 4;
           const fh = sheet.height;
-          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
+          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 12, e.w, e.h + 12);
         } else if (e.kind === 'orc') {
           const sheet = ORC_ANIM[e.dir];
           const fw = sheet.width / 4;
           const fh = sheet.height;
-          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
+          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 12, e.w, e.h + 12);
         } else if (e.kind === 'boss') {
           const anim = e.bossType === 'hillGiant' ? HILL_GIANT_ANIM : e.bossType === 'abomination' ? ABOMINATION_ANIM : e.bossType === 'hungerDemon' ? HUNGER_DEMON_ANIM : e.bossType === 'beholder' ? BEHOLDER_ANIM : MUCK_ANIM;
           const sheet = anim[e.dir];
           const fw = sheet.width / 4;
           const fh = sheet.height;
-          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
+          ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 12, e.w, e.h + 12);
         }
         // Slow effect visual: pulsing frosty halo while slowed
         if (e.slowT && e.slowT > 0){
@@ -1673,7 +1673,7 @@
       }
 
       // Draw player shadow + hero (blink on i-frames)
-      ctx.drawImage(IMG.shadow, P.x-20, P.y-10, 40, 20);
+      ctx.drawImage(IMG.shadow, P.x-40, P.y-20, 80, 40);
       // Sword trail when attacking (non-wizard only)
       if (currentClass !== 'wizard' && P.atkT>0){
         ctx.save();
@@ -1744,20 +1744,20 @@
             const sheet = WIZ_ANIM[WIZ_ANIM_STATE.dir];
             const fw = sheet.width / 4;
             const fh = sheet.height;
-            ctx.drawImage(sheet, WIZ_ANIM_STATE.frame * fw, 0, fw, fh, -18, -22, 36, 36);
+            ctx.drawImage(sheet, WIZ_ANIM_STATE.frame * fw, 0, fw, fh, -36, -44, 72, 72);
           } else if (currentClass === 'fighter'){
             const sheet = FIGHT_ANIM[FIGHT_ANIM_STATE.dir];
             const fw = sheet.width / 4;
             const fh = sheet.height;
-            ctx.drawImage(sheet, FIGHT_ANIM_STATE.frame * fw, 0, fw, fh, -18, -22, 36, 36);
+            ctx.drawImage(sheet, FIGHT_ANIM_STATE.frame * fw, 0, fw, fh, -36, -44, 72, 72);
           } else if (currentClass === 'rogue'){
             const sheet = ROGUE_ANIM[ROGUE_ANIM_STATE.dir];
             const fw = sheet.width / 4;
             const fh = sheet.height;
-            ctx.drawImage(sheet, ROGUE_ANIM_STATE.frame * fw, 0, fw, fh, -18, -22, 36, 36);
+            ctx.drawImage(sheet, ROGUE_ANIM_STATE.frame * fw, 0, fw, fh, -36, -44, 72, 72);
           } else {
             ctx.rotate(P.dir + Math.sin(t*0.01)*0.02);
-            ctx.drawImage(IMG.hero, -18, -22, 36, 36);
+            ctx.drawImage(IMG.hero, -36, -44, 72, 72);
           }
           ctx.restore();
         }


### PR DESCRIPTION
## Summary
- double base dimensions for player and enemies
- adjust spawn bounds, shadow sizes, and drawing offsets for new scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3fa91df508329b5157c884830027e