### PR TITLE
feat(emberfall): expand stage3 boss blast radius

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1238,7 +1238,7 @@
           if (e.bossType === 'abomination') {
             if (e.freezeT <= 0 && e.atkT >= 2.4){
               e.atkT = 0;
-              const range = 90;
+              const range = 180;
               e.pulse = 0.3;
               e.pulseRange = range;
               if (dist < range && P.iT<=0){


### PR DESCRIPTION
## Summary
- double the abomination's 360° blast radius for the stage 3 boss from 90px to 180px

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4348bbb80832993bb0b30b9a53fa0