### PR TITLE
Increase hunger demon blast radius

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1261,7 +1261,7 @@
             }
             if (e.freezeT <= 0 && e.blastT >= 5){
               e.blastT = 0;
-              const range = 160;
+              const range = 240;
               e.pulse = 0.4;
               e.pulseRange = range;
               if (dist < range && P.iT<=0){


### PR DESCRIPTION
## Summary
- Expand the stage 3 boss (hunger demon) radial blast radius by 50%

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c454b717dc8329b0f2e5d2ce3c5a89