### PR TITLE
feat: expand bastion builder map

### DIFF
--- a/bastion-builder/index.html
+++ b/bastion-builder/index.html
@@ -203,7 +203,7 @@
     }
 
     // Grid and sizing
-    let COLS = 14, ROWS = 10, tile = 48; // computed on resize
+    let COLS = 28, ROWS = 20, tile = 48; // computed on resize
     let pixelRatio = Math.max(1, Math.floor(window.devicePixelRatio || 1));
 
     // Assets


### PR DESCRIPTION
## Summary
- expand Bastion Builder grid to 28x20 for a larger battle map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c457f382cc8329b35c191791a8b6dc