### PR TITLE
Scale hero, boss, and enemy sprites

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -550,7 +550,7 @@
     // Arena dimensions will match the chosen map image
     const ARENA = { x: 0, y: 0, w: 0, h: 0 };
     const CAM = { x: 0, y: 0 };
-    const P = { x: W/2, y: H/2, vx: 0, vy: 0, spd: 2400, w: 28, h: 28, dir: 0, aimDir: 0, swingAim: 0, hp: 5, hpMax: 5, iT: 0, atkT: 0, autoT: 0, hitFlash: 0 };
+    const P = { x: W/2, y: H/2, vx: 0, vy: 0, spd: 2400, w: 42, h: 42, dir: 0, aimDir: 0, swingAim: 0, hp: 5, hpMax: 5, iT: 0, atkT: 0, autoT: 0, hitFlash: 0 };
     const WIZ_ANIM_STATE = { dir: 'down', frame: 0, t: 0 };
     const FIGHT_ANIM_STATE = { dir: 'down', frame: 0, t: 0 };
     const ROGUE_ANIM_STATE = { dir: 'down', frame: 0, t: 0 };
@@ -871,6 +871,8 @@
       // Make imp a bit faster than baseline and orc slower; reward orcs more
       if (kind==='imp'){ w=22; h=18; spd=130 * stageSpd; hp=Math.max(1,1+Math.floor(SPAWN.wave/3)); score=40; }
       else if (kind==='orc'){ w=ENEMY.w*2; h=ENEMY.h*2; spd=60 * stageSpd; hp=(3+Math.floor(SPAWN.wave/1.5))*3; score=240; }
+      w *= 1.75;
+      h *= 1.75;
 
       const enemy = { kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0 };
       if (needsKeys() && !SPAWN.keyAssigned){ enemy.hasKey = true; SPAWN.keyAssigned = true; }
@@ -898,7 +900,7 @@
       }
       // Reduce boss health by 50%
       hp *= 0.5;
-      const b = { kind:'boss', bossType, x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4, h:ENEMY.h*4, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, blastT:0, facing:0, freezeT:0, pulse:0 };
+      const b = { kind:'boss', bossType, x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4*1.5, h:ENEMY.h*4*1.5, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, blastT:0, facing:0, freezeT:0, pulse:0 };
       if (bossType === 'hillGiant') b.slamCd = 3;
       switchMusic(BOSS_TRACKS);
       enemies.push(b);
@@ -1128,7 +1130,7 @@
       P.vx *= pF; P.vy *= pF;
       P.x += P.vx*dt; P.y += P.vy*dt;
       // Clamp to arena
-        P.x = clamp(P.x, ARENA.x+16, ARENA.x+ARENA.w-16); P.y = clamp(P.y, ARENA.y+16, ARENA.y+ARENA.h-16);
+        P.x = clamp(P.x, ARENA.x+24, ARENA.x+ARENA.w-24); P.y = clamp(P.y, ARENA.y+24, ARENA.y+ARENA.h-24);
         if (currentClass === 'wizard') updateWizardAnim(dt);
         else if (currentClass === 'fighter') updateFighterAnim(dt);
         else if (currentClass === 'rogue') updateRogueAnim(dt);
@@ -1676,7 +1678,7 @@
       }
 
       // Draw player shadow + hero (blink on i-frames)
-      ctx.drawImage(IMG.shadow, P.x-20, P.y-10, 40, 20);
+      ctx.drawImage(IMG.shadow, P.x-30, P.y-15, 60, 30);
       // Sword trail when attacking (non-wizard only)
       if (currentClass !== 'wizard' && P.atkT>0){
         ctx.save();
@@ -1747,20 +1749,20 @@
             const sheet = WIZ_ANIM[WIZ_ANIM_STATE.dir];
             const fw = sheet.width / 4;
             const fh = sheet.height;
-            ctx.drawImage(sheet, WIZ_ANIM_STATE.frame * fw, 0, fw, fh, -18, -22, 36, 36);
+            ctx.drawImage(sheet, WIZ_ANIM_STATE.frame * fw, 0, fw, fh, -27, -31, 54, 54);
           } else if (currentClass === 'fighter'){
             const sheet = FIGHT_ANIM[FIGHT_ANIM_STATE.dir];
             const fw = sheet.width / 4;
             const fh = sheet.height;
-            ctx.drawImage(sheet, FIGHT_ANIM_STATE.frame * fw, 0, fw, fh, -18, -22, 36, 36);
+            ctx.drawImage(sheet, FIGHT_ANIM_STATE.frame * fw, 0, fw, fh, -27, -31, 54, 54);
           } else if (currentClass === 'rogue'){
             const sheet = ROGUE_ANIM[ROGUE_ANIM_STATE.dir];
             const fw = sheet.width / 4;
             const fh = sheet.height;
-            ctx.drawImage(sheet, ROGUE_ANIM_STATE.frame * fw, 0, fw, fh, -18, -22, 36, 36);
+            ctx.drawImage(sheet, ROGUE_ANIM_STATE.frame * fw, 0, fw, fh, -27, -31, 54, 54);
           } else {
             ctx.rotate(P.dir + Math.sin(t*0.01)*0.02);
-            ctx.drawImage(IMG.hero, -18, -22, 36, 36);
+            ctx.drawImage(IMG.hero, -27, -31, 54, 54);
           }
           ctx.restore();
         }


### PR DESCRIPTION
## Summary
- enlarge hero hitbox and rendering by 50%
- scale regular enemies by 75%
- enlarge bosses by 50% and adjust player boundaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c461100bec8329a7f4cfcdb76a19e3