### PR TITLE
Reduce Emberfall upgrade gold costs

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -595,7 +595,7 @@
     let boss = null;
     const COINS = { value: 0 };
     const KEYS = { value: 0 };
-    const SHOP = { milestones: [10, 20, 40, 80, 120, 200, 300, 500, 700, 900, 1200], idx: 0, open: false };
+    const SHOP = { milestones: [7, 14, 28, 56, 84, 140, 210, 350, 490, 630, 840], idx: 0, open: false };
     const UPGRADE_LEVELS = Object.create(null);
     const TAKEN_UPGRADES = Object.create(null); // id -> { id, name, type, desc, levels }
     const UPGR = {
@@ -1847,7 +1847,7 @@
       let next = SHOP.milestones[SHOP.idx];
       if (next == null){
         const last = SHOP.milestones[SHOP.milestones.length - 1];
-        next = last + 300 * (SHOP.idx - SHOP.milestones.length + 1);
+        next = last + 210 * (SHOP.idx - SHOP.milestones.length + 1);
       }
       if (COINS.value >= next){ openShop(); }
     }


### PR DESCRIPTION
## Summary
- Reduce gold needed for Emberfall upgrades by 30%
- Scale post-milestone upgrade costs to match reduction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c470cbda9c8329bed9797b4b9086a2