### PR TITLE
Double stage 2 boss projectile speed

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1387,8 +1387,8 @@
                 const vy = Math.sin(e.facing)*140;
                 BOSS_PROJECTILES.push({ kind:'muck', dir: vx < 0 ? 'left' : 'right', x:e.x, y:e.y, vx, vy, life:0, ttl:3, frame:0, animT:0 });
               } else if (e.bossType === 'hillGiant') {
-                const vx = Math.cos(e.facing)*140;
-                const vy = Math.sin(e.facing)*140;
+                const vx = Math.cos(e.facing)*280;
+                const vy = Math.sin(e.facing)*280;
                 BOSS_PROJECTILES.push({ kind:'rock', dir: vx < 0 ? 'left' : 'right', x:e.x, y:e.y, vx, vy, life:0, ttl:3, frame:0, animT:0 });
               } else {
                 BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(e.facing)*140, vy:Math.sin(e.facing)*140, life:0, ttl:3 });


### PR DESCRIPTION
## Summary
- Double the hill giant's projectile velocity in Emberfall Gauntlet's stage 2 boss fight.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f02aa4f48329afb25a8c9f406a08