### PR TITLE
feat(emberfall): add muck monster SFX

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -347,6 +347,8 @@
       goblinHurt: new Audio('assets/sfx_goblin_hurt.wav'),
       impHurt: new Audio('assets/sfx_imp_hurt.wav'),
       orcHurt: new Audio('assets/sfx_orc_hurt.wav'),
+      bossMudMonsterHurt: new Audio('assets/sfx_boss_mudMonster_hurt.wav'),
+      bossMudMonsterKilled: new Audio('assets/sfx_boss_mudMonster_killed.wav'),
     };
     // Preload sounds and play via clones to allow rapid overlaps
     Object.values(SFX).forEach(a => { try { a.load(); } catch(e){} });
@@ -357,10 +359,11 @@
       } catch(e){}
     }
     function playHeroHit(){ playSfx(currentClass === 'wizard' ? SFX.heroWizardHit : SFX.heroFighterHit); }
-    function playEnemyHit(kind){
-      if (kind === 'imp') playSfx(SFX.impHurt);
-      else if (kind === 'orc') playSfx(SFX.orcHurt);
-      else if (kind === 'goblin') playSfx(SFX.goblinHurt);
+    function playEnemyHit(e){
+      if (e.kind === 'imp') playSfx(SFX.impHurt);
+      else if (e.kind === 'orc') playSfx(SFX.orcHurt);
+      else if (e.kind === 'goblin') playSfx(SFX.goblinHurt);
+      else if (e.kind === 'boss' && e.bossType === 'muck' && e.hp > 0) playSfx(SFX.bossMudMonsterHurt);
     }
 
     // Assets (SVG/PNG art)
@@ -1017,9 +1020,10 @@
     function applyDamage(e, dmg=1, kx=0, ky=0, kb=0){
       e.hp -= dmg;
       spark(e.x,e.y,'#aef');
-      playEnemyHit(e.kind);
+      playEnemyHit(e);
       if (e.hp<=0){
         if (e.kind === 'boss'){
+          if (e.bossType === 'muck') playSfx(SFX.bossMudMonsterKilled);
           addScore(e.score||1000);
           for (let i=0;i<10;i++) dropCoin(e.x + rand(-20,20), e.y + rand(-20,20));
           if (UPGR.lifeStealChance > 0 && Math.random() < UPGR.lifeStealChance){ if (P.hp < P.hpMax){ P.hp += 1; drawHearts(); } }


### PR DESCRIPTION
## Summary
- play unique hurt sound when Muck Monster takes damage
- trigger death sound on Muck Monster defeat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c54cc98c1c832985203784aa00c9d5