### PR TITLE
Optimize Emberfall sound playback

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -318,11 +318,22 @@
       switchMusic(STANDARD_TRACKS);
     }
 
-    const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const audioCtx = new (window.AudioContext || window.webkitAudioContext)({ latencyHint: 'interactive' });
+    let audioWarmed = false;
+    function warmAudio(){
+      // Play a silent buffer once to wake up the audio hardware and avoid first-play lag
+      const buf = audioCtx.createBuffer(1, 1, audioCtx.sampleRate);
+      const src = audioCtx.createBufferSource();
+      src.buffer = buf;
+      src.connect(audioCtx.destination);
+      src.start();
+      src.disconnect();
+    }
     function resumeAudio(){
       if (audioCtx.state === 'suspended') {
         try { audioCtx.resume(); } catch(e) {}
       }
+      if (!audioWarmed) { warmAudio(); audioWarmed = true; }
     }
 
     // Audio mute state and controls (persist like Nova Striker)
@@ -369,16 +380,16 @@
       ['bossHillGiantKilled', 'assets/sfx_boss_hillGiant_killed.wav'],
     ].forEach(([n, s]) => loadSfx(n, s));
 
-    async function playSfx(name){
+    function playSfx(name){
       if (muted) return;
       const buffer = SFX[name];
       if (!buffer) return;
       try {
-        if (audioCtx.state === 'suspended') await audioCtx.resume();
+        if (audioCtx.state === 'suspended') audioCtx.resume().catch(() => {});
         const src = audioCtx.createBufferSource();
         src.buffer = buffer;
         src.connect(audioCtx.destination);
-        src.start(0);
+        src.start();
       } catch(e){}
     }
     function playHeroHit(){ playSfx(currentClass === 'wizard' ? 'heroWizardHit' : 'heroFighterHit'); }

--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -318,6 +318,13 @@
       switchMusic(STANDARD_TRACKS);
     }
 
+    const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    function resumeAudio(){
+      if (audioCtx.state === 'suspended') {
+        try { audioCtx.resume(); } catch(e) {}
+      }
+    }
+
     // Audio mute state and controls (persist like Nova Striker)
     let muted = false;
     const LS_MUTE_KEY = 'emberfall-gauntlet:muted';
@@ -330,43 +337,57 @@
       muted = !!m;
       music.muted = muted;
       if (muted) {
-        try { music.pause(); } catch(e) {}
-      } else if (musicStarted) {
-        music.play().catch(()=>{});
+        try { music.pause(); audioCtx.suspend(); } catch(e) {}
+      } else {
+        if (musicStarted) music.play().catch(()=>{});
+        try { audioCtx.resume(); } catch(e) {}
       }
       updateAudioIcon();
       try { localStorage.setItem(LS_MUTE_KEY, muted ? '1' : '0'); } catch(e) {}
     }
     function toggleAudio(){ setMuted(!muted); }
 
-    // Sound effects
-    const SFX = {
-      heroFighterHit: new Audio('assets/sfx_hero_fighter_hit.wav'),
-      heroWizardHit: new Audio('assets/sfx_hero_wizard_hit.wav'),
-      coin: new Audio('assets/sfx_coin.wav'),
-      goblinHurt: new Audio('assets/sfx_goblin_hurt.wav'),
-      impHurt: new Audio('assets/sfx_imp_hurt.wav'),
-      orcHurt: new Audio('assets/sfx_orc_hurt.wav'),
-      bossMudMonsterHurt: new Audio('assets/sfx_boss_mudMonster_hurt.wav'),
-      bossMudMonsterKilled: new Audio('assets/sfx_boss_mudMonster_killed.wav'),
-      bossHillGiantHurt: new Audio('assets/sfx_boss_hillGiant_hurt.wav'),
-      bossHillGiantKilled: new Audio('assets/sfx_boss_hillGiant_killed.wav'),
-    };
-    // Preload sounds and play via clones to allow rapid overlaps
-    Object.values(SFX).forEach(a => { try { a.load(); } catch(e){} });
-    function playSfx(a){
+    // Sound effects using Web Audio for low latency
+    const SFX = {};
+    function loadSfx(name, src){
+      fetch(src)
+        .then(r => r.arrayBuffer())
+        .then(b => audioCtx.decodeAudioData(b))
+        .then(buf => { SFX[name] = buf; })
+        .catch(() => {});
+    }
+    [
+      ['heroFighterHit', 'assets/sfx_hero_fighter_hit.wav'],
+      ['heroWizardHit', 'assets/sfx_hero_wizard_hit.wav'],
+      ['coin', 'assets/sfx_coin.wav'],
+      ['goblinHurt', 'assets/sfx_goblin_hurt.wav'],
+      ['impHurt', 'assets/sfx_imp_hurt.wav'],
+      ['orcHurt', 'assets/sfx_orc_hurt.wav'],
+      ['bossMudMonsterHurt', 'assets/sfx_boss_mudMonster_hurt.wav'],
+      ['bossMudMonsterKilled', 'assets/sfx_boss_mudMonster_killed.wav'],
+      ['bossHillGiantHurt', 'assets/sfx_boss_hillGiant_hurt.wav'],
+      ['bossHillGiantKilled', 'assets/sfx_boss_hillGiant_killed.wav'],
+    ].forEach(([n, s]) => loadSfx(n, s));
+
+    async function playSfx(name){
       if (muted) return;
+      const buffer = SFX[name];
+      if (!buffer) return;
       try {
-        a.cloneNode().play();
+        if (audioCtx.state === 'suspended') await audioCtx.resume();
+        const src = audioCtx.createBufferSource();
+        src.buffer = buffer;
+        src.connect(audioCtx.destination);
+        src.start(0);
       } catch(e){}
     }
-    function playHeroHit(){ playSfx(currentClass === 'wizard' ? SFX.heroWizardHit : SFX.heroFighterHit); }
+    function playHeroHit(){ playSfx(currentClass === 'wizard' ? 'heroWizardHit' : 'heroFighterHit'); }
     function playEnemyHit(e){
-      if (e.kind === 'imp') playSfx(SFX.impHurt);
-      else if (e.kind === 'orc') playSfx(SFX.orcHurt);
-      else if (e.kind === 'goblin') playSfx(SFX.goblinHurt);
-      else if (e.kind === 'boss' && e.bossType === 'muck' && e.hp > 0) playSfx(SFX.bossMudMonsterHurt);
-      else if (e.kind === 'boss' && e.bossType === 'hillGiant' && e.hp > 0) playSfx(SFX.bossHillGiantHurt);
+      if (e.kind === 'imp') playSfx('impHurt');
+      else if (e.kind === 'orc') playSfx('orcHurt');
+      else if (e.kind === 'goblin') playSfx('goblinHurt');
+      else if (e.kind === 'boss' && e.bossType === 'muck' && e.hp > 0) playSfx('bossMudMonsterHurt');
+      else if (e.kind === 'boss' && e.bossType === 'hillGiant' && e.hp > 0) playSfx('bossHillGiantHurt');
     }
 
     // Assets (SVG/PNG art)
@@ -738,6 +759,8 @@
         if (saved !== null) setMuted(saved === '1'); else updateAudioIcon();
       } catch(e) { updateAudioIcon(); }
       if (audioIcon) audioIcon.addEventListener('click', toggleAudio);
+      window.addEventListener('keydown', resumeAudio, { once: true });
+      window.addEventListener('pointerdown', resumeAudio, { once: true });
     }
 
     function loadStage() {
@@ -788,7 +811,14 @@
       drawKeys();
     }
 
-    function start() { reset(); running = true; paused = false; startOverlay.classList.remove('show'); gameOverOverlay.classList.remove('show'); }
+    function start() {
+      resumeAudio();
+      reset();
+      running = true;
+      paused = false;
+      startOverlay.classList.remove('show');
+      gameOverOverlay.classList.remove('show');
+    }
     function gameOver(win = false) {
       if (gameOverHandled) return;
       gameOverHandled = true;
@@ -1026,8 +1056,8 @@
       playEnemyHit(e);
       if (e.hp<=0){
         if (e.kind === 'boss'){
-          if (e.bossType === 'muck') playSfx(SFX.bossMudMonsterKilled);
-          else if (e.bossType === 'hillGiant') playSfx(SFX.bossHillGiantKilled);
+          if (e.bossType === 'muck') playSfx('bossMudMonsterKilled');
+          else if (e.bossType === 'hillGiant') playSfx('bossHillGiantKilled');
           addScore(e.score||1000);
           for (let i=0;i<10;i++) dropCoin(e.x + rand(-20,20), e.y + rand(-20,20));
           if (UPGR.lifeStealChance > 0 && Math.random() < UPGR.lifeStealChance){ if (P.hp < P.hpMax){ P.hp += 1; drawHearts(); } }
@@ -1524,7 +1554,7 @@
         if (len(P.x-d.x,P.y-d.y)<22){
           if (d.kind==='coin'){
             addScore(10);
-            COINS.value += 1; coinsEl.textContent = COINS.value; spark(d.x,d.y,'#ffd16b'); playSfx(SFX.coin);
+            COINS.value += 1; coinsEl.textContent = COINS.value; spark(d.x,d.y,'#ffd16b'); playSfx('coin');
             maybeOpenShop();
           } else if (d.kind==='key'){
             KEYS.value += 1; drawKeys(); spark(d.x,d.y,'#ffd16b');


### PR DESCRIPTION
## Summary
- switch Emberfall SFX to preloaded Web Audio buffers for low-latency playback
- suspend/resume audio context when toggling mute to keep sound responsive
- resume Web Audio context on first user interaction so sound effects actually play

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c557a45ce08329a05ac92f965b9098