### PR TITLE
Alternate Abomination attacks and limit wave range

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1011,7 +1011,7 @@
       }
       // Reduce boss health by 50%
       hp *= 0.5;
-      const b = { kind:'boss', bossType, x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4*1.5, h:ENEMY.h*4*1.5, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, blastT:0, facing:0, freezeT:0, pulse:0 };
+      const b = { kind:'boss', bossType, x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4*1.5, h:ENEMY.h*4*1.5, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, blastT:0, facing:0, freezeT:0, pulse:0, nextAtk:'pulse' };
       if (bossType === 'hillGiant') b.slamCd = 3;
       switchMusic(BOSS_TRACKS);
       enemies.push(b);
@@ -1378,14 +1378,19 @@
             if (e.freezeT <= 0 && e.atkT >= 2.4){
               e.atkT = 0;
               const range = 120;
-              e.pulse = 0.3;
-              e.pulseRange = range;
-              if (dist < range && P.iT<=0){
-                if (CHEAT.active){ P.hitFlash = 0.25; spark(P.x,P.y,'#ff8a8a'); }
-                else if (UPGR.dodgeChance>0 && Math.random()<UPGR.dodgeChance){ P.iT=0.6; P.hitFlash=0.25; spark(P.x,P.y,'#a1ffd4'); }
-                else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); playHeroHit(); if (P.hp<=0) return gameOver(); }
+              if (e.nextAtk === 'wave') {
+                BOSS_PROJECTILES.push({ kind:'wave', x:e.x, y:e.y, r:0, maxR:range*2, speed:200, width:20, dmg:1, life:0 });
+                e.nextAtk = 'pulse';
+              } else {
+                e.pulse = 0.3;
+                e.pulseRange = range;
+                if (dist < range && P.iT<=0){
+                  if (CHEAT.active){ P.hitFlash = 0.25; spark(P.x,P.y,'#ff8a8a'); }
+                  else if (UPGR.dodgeChance>0 && Math.random()<UPGR.dodgeChance){ P.iT=0.6; P.hitFlash=0.25; spark(P.x,P.y,'#a1ffd4'); }
+                  else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); playHeroHit(); if (P.hp<=0) return gameOver(); }
+                }
+                e.nextAtk = 'wave';
               }
-              BOSS_PROJECTILES.push({ kind:'wave', x:e.x, y:e.y, r:range, maxR:e.w*2, speed:200, width:20, dmg:1, life:0 });
               e.freezeT = 1.2;
             }
           } else if (e.bossType === 'hungerDemon') {


### PR DESCRIPTION
## Summary
- Add attack state tracking to bosses
- Alternate Abomination's pulse and wave attacks, limiting wave distance to twice the pulse radius

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c59c277db883298d8572a99cb1794a