### PR TITLE
Reduce Hunger Demon pulse radius

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1406,7 +1406,7 @@
             }
             if (e.freezeT <= 0 && e.blastT >= 5){
               e.blastT = 0;
-              const range = 240;
+              const range = 120;
               e.pulse = 0.4;
               e.pulseRange = range;
               if (dist < range && P.iT<=0){


### PR DESCRIPTION
## Summary
- Halve the Hunger Demon's pulse attack radius in Emberfall Gauntlet stage 4

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5a5539b7c83299e8f24936e11b03a