### PR TITLE
Increase boss hurt/kill SFX volume

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -508,10 +508,13 @@
         const node = s.cloneNode();
         if (audioCtx) {
           const source = audioCtx.createMediaElementSource(node);
-          source.connect(sfxGain);
+          const gain = audioCtx.createGain();
+          gain.gain.value = (s === SFX.bossHit || s === SFX.bossKill) ? 1.5 : 1;
+          source.connect(gain);
+          gain.connect(sfxGain);
           if (audioCtx.state === 'suspended') audioCtx.resume();
         } else {
-          node.volume = 1;
+          node.volume = (s === SFX.bossHit || s === SFX.bossKill) ? 1.5 : 1;
         }
         node.play();
       } catch {}

--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -396,7 +396,10 @@
         if (audioCtx.state === 'suspended') audioCtx.resume().catch(() => {});
         const src = audioCtx.createBufferSource();
         src.buffer = buffer;
-        src.connect(audioCtx.destination);
+        const gain = audioCtx.createGain();
+        gain.gain.value = (name.startsWith('boss') && (name.endsWith('Hurt') || name.endsWith('Killed'))) ? 1.5 : 1;
+        src.connect(gain);
+        gain.connect(audioCtx.destination);
         src.start();
       } catch(e){}
     }


### PR DESCRIPTION
## Summary
- Boost volume for boss hurt and death effects in Emberfall Gauntlet
- Boost volume for boss hit and kill effects in Core Crisis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c5da40e48329bd2bbd352b5677f4