### PR TITLE
Adjust polymorph wave radius scaling

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1260,7 +1260,9 @@
 
   function emitPolymorphWave(x,y){
     const chance = UPGR.polyChance || 0;
-    POLY_WAVES.push({ x, y, r: 0, speed: 360, life: 0, ttl: 1.4, chance, hit: new Set() });
+    const level = Math.max(1, UPGR.polyLevel || 0);
+    const startRadius = 200 + (level - 1) * 75;
+    POLY_WAVES.push({ x, y, r: startRadius, speed: 360, life: 0, ttl: 1.4, chance, hit: new Set() });
     polymorphWaveBurst(x,y);
   }
 


### PR DESCRIPTION
## Summary
- start the wizard's polymorph wave with a 200px radius and scale it by 75px per upgrade level

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c87e12ded08329ad254db570793618