### PR TITLE
Adjust polymorph wave radius scaling

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -726,6 +726,7 @@
       polyTimer: 0,
       polyChance: 0,
       polyLevel: 0,
+      polyRadius: 0,
       shards: false,
       shardPeriod: 0.85,
       shardTimer: 0,
@@ -746,6 +747,7 @@
       UPGR.polymorph = level > 0;
       UPGR.polyLevel = level;
       UPGR.polyChance = level > 0 ? Math.min(0.5, 0.1 * level) : 0;
+      UPGR.polyRadius = level > 0 ? 200 + (level - 1) * 50 : 0;
       if (fromUpgrade && level > 0 && !prev){
         UPGR.polyTimer = UPGR.polyPeriod;
       }
@@ -888,7 +890,7 @@
       COINS.value = 0; coinsEl.textContent = COINS.value; SHOP.idx = 0; SHOP.open = false;
       KEYS.value = 0; drawKeys();
       // Reset upgrades and spell state
-      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:1, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:72, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, polymorph:false, polyPeriod:7, polyTimer:0, polyChance:0, polyLevel:0, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1, arrowPeriod:0.90, arrowTimer:0, arrowSpeed:360, arrowDmg:1, arrowCount:1, arrowPierce:false });
+      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:1, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:72, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, polymorph:false, polyPeriod:7, polyTimer:0, polyChance:0, polyLevel:0, polyRadius:0, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1, arrowPeriod:0.90, arrowTimer:0, arrowSpeed:360, arrowDmg:1, arrowCount:1, arrowPierce:false });
       if (stats.startOrbs) { UPGR.orbs = stats.startOrbs; }
       // Reset upgrade tracking
       for (const k in UPGRADE_LEVELS) delete UPGRADE_LEVELS[k];
@@ -1260,7 +1262,11 @@
 
   function emitPolymorphWave(x,y){
     const chance = UPGR.polyChance || 0;
-    POLY_WAVES.push({ x, y, r: 0, speed: 360, life: 0, ttl: 1.4, chance, hit: new Set() });
+    const radius = UPGR.polyRadius || 0;
+    if (radius <= 0) return;
+    const speed = 360;
+    const ttl = Math.max(0.1, radius / speed);
+    POLY_WAVES.push({ x, y, r: 0, speed, life: 0, ttl, chance, hit: new Set(), maxR: radius });
     polymorphWaveBurst(x,y);
   }
 
@@ -1823,7 +1829,8 @@
         for (let i=POLY_WAVES.length-1;i>=0;i--){
           const wave = POLY_WAVES[i];
           wave.life += dt;
-          wave.r += wave.speed * dt;
+          const maxR = wave.maxR !== undefined ? wave.maxR : Infinity;
+          wave.r = Math.min(wave.r + wave.speed * dt, maxR);
           for (const e of enemies){
             if (e.hp<=0 || e.kind === 'boss') continue;
             if (wave.hit.has(e)) continue;


### PR DESCRIPTION
## Summary
- track a dedicated polymorph wave radius that starts at 200px and grows by 50px per upgrade level (max 400px)
- update the polymorph wave emission logic to respect the level-based radius and end the wave once it reaches that size

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c882dae4208329bbe886418760aeb6