### PR TITLE
Adjust polymorph wave radius scaling

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -703,6 +703,8 @@
     const COINS = { value: 0 };
     const KEYS = { value: 0 };
     const SHOP = { milestones: [7, 14, 28, 56, 84, 140, 210, 350, 490, 630, 840], idx: 0, open: false };
+    const POLYMORPH_BASE_RADIUS = 150;
+    const POLYMORPH_RADIUS_STEP = 50;
     const UPGRADE_LEVELS = Object.create(null);
     const TAKEN_UPGRADES = Object.create(null); // id -> { id, name, type, desc, levels }
     const UPGR = {
@@ -725,6 +727,7 @@
       polyPeriod: 7,
       polyTimer: 0,
       polyChance: 0,
+      polyRadius: 0,
       polyLevel: 0,
       shards: false,
       shardPeriod: 0.85,
@@ -746,6 +749,7 @@
       UPGR.polymorph = level > 0;
       UPGR.polyLevel = level;
       UPGR.polyChance = level > 0 ? Math.min(0.5, 0.1 * level) : 0;
+      UPGR.polyRadius = level > 0 ? POLYMORPH_BASE_RADIUS + POLYMORPH_RADIUS_STEP * (level - 1) : 0;
       if (fromUpgrade && level > 0 && !prev){
         UPGR.polyTimer = UPGR.polyPeriod;
       }
@@ -888,7 +892,7 @@
       COINS.value = 0; coinsEl.textContent = COINS.value; SHOP.idx = 0; SHOP.open = false;
       KEYS.value = 0; drawKeys();
       // Reset upgrades and spell state
-      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:1, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:72, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, polymorph:false, polyPeriod:7, polyTimer:0, polyChance:0, polyLevel:0, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1, arrowPeriod:0.90, arrowTimer:0, arrowSpeed:360, arrowDmg:1, arrowCount:1, arrowPierce:false });
+      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:1, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:72, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, polymorph:false, polyPeriod:7, polyTimer:0, polyChance:0, polyRadius:0, polyLevel:0, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1, arrowPeriod:0.90, arrowTimer:0, arrowSpeed:360, arrowDmg:1, arrowCount:1, arrowPierce:false });
       if (stats.startOrbs) { UPGR.orbs = stats.startOrbs; }
       // Reset upgrade tracking
       for (const k in UPGRADE_LEVELS) delete UPGRADE_LEVELS[k];
@@ -1260,7 +1264,9 @@
 
   function emitPolymorphWave(x,y){
     const chance = UPGR.polyChance || 0;
-    POLY_WAVES.push({ x, y, r: 0, speed: 360, life: 0, ttl: 1.4, chance, hit: new Set() });
+    const radius = UPGR.polyRadius || 0;
+    if (radius <= 0) return;
+    POLY_WAVES.push({ x, y, r: 0, maxR: radius, speed: 360, life: 0, ttl: 1.4, chance, hit: new Set() });
     polymorphWaveBurst(x,y);
   }
 
@@ -1823,7 +1829,8 @@
         for (let i=POLY_WAVES.length-1;i>=0;i--){
           const wave = POLY_WAVES[i];
           wave.life += dt;
-          wave.r += wave.speed * dt;
+          const maxR = wave.maxR ?? UPGR.polyRadius ?? 0;
+          wave.r = Math.min(maxR, wave.r + wave.speed * dt);
           for (const e of enemies){
             if (e.hp<=0 || e.kind === 'boss') continue;
             if (wave.hit.has(e)) continue;


### PR DESCRIPTION
## Summary
- add constants to define the polymorph wave radius progression and store it on the upgrade state
- clamp polymorph waves to the computed radius when spawning and updating so each level adds 50px up to 350px
- reset the stored radius alongside other upgrade stats when starting a new run

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c889e40adc8329af8f2615810cedc7