### PR TITLE
Adjust polymorph wave radius scaling

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -726,6 +726,7 @@
       polyTimer: 0,
       polyChance: 0,
       polyLevel: 0,
+      polyRadius: 0,
       shards: false,
       shardPeriod: 0.85,
       shardTimer: 0,
@@ -746,6 +747,7 @@
       UPGR.polymorph = level > 0;
       UPGR.polyLevel = level;
       UPGR.polyChance = level > 0 ? Math.min(0.5, 0.1 * level) : 0;
+      UPGR.polyRadius = level > 0 ? Math.min(300, 100 + 50 * (level - 1)) : 0;
       if (fromUpgrade && level > 0 && !prev){
         UPGR.polyTimer = UPGR.polyPeriod;
       }
@@ -801,7 +803,7 @@
       wizard: [
         { id:'orbs', type:'Spell', name:'Arcane Orbs', desc:'Summon orbiting orbs that damage foes.', note:'Stacks add more orbs', apply:()=>{ UPGR.orbs += 1; } },
         { id:'nova', type:'Spell', name:'Frost Nova', desc:'Every few seconds, blast and slow nearby foes.', note:'Improves with repeats', apply:()=>{ if(!UPGR.nova){ UPGR.nova=true; } else { UPGR.novaPeriod=Math.max(2.2, UPGR.novaPeriod*0.9); UPGR.novaDmg+=1; } } },
-        { id:'polymorph', type:'Spell', name:'Polymorph', desc:'Release a transforming wave that may turn foes into coins or hearts.', note:'Chance increases with repeats (max 50%). Bosses are immune.', maxLevel:5, apply:()=>{ refreshPolymorphState(true); } },
+        { id:'polymorph', type:'Spell', name:'Polymorph', desc:'Release a transforming wave that may turn foes into coins or hearts.', note:'Chance increases with repeats (max 50%) and radius grows +50 (max 300). Bosses are immune.', maxLevel:5, apply:()=>{ refreshPolymorphState(true); } },
         { id:'shards', type:'Spell', name:'Arcane Missiles', desc:'Periodically fire magic missiles.', note:'More with repeats', apply:()=>{ if(!UPGR.shards){ UPGR.shards=true; } else { UPGR.shardCount=Math.min(6, UPGR.shardCount+1); } } },
         { id:'focus', type:'Spell', name:'Spell Focus', desc:'Cast more often (-12% cooldown).', apply:()=>{ AUTO.atkPeriod = Math.max(0.25, AUTO.atkPeriod*0.88); } },
         { id:'wisdom', type:'Upgrade', name:'Wisdom', desc:'Max HP +1 and heal 1.', apply:()=>{ P.hpMax += 1; P.hp = Math.min(P.hpMax, P.hp+1); drawHearts(); } },
@@ -888,7 +890,7 @@
       COINS.value = 0; coinsEl.textContent = COINS.value; SHOP.idx = 0; SHOP.open = false;
       KEYS.value = 0; drawKeys();
       // Reset upgrades and spell state
-      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:1, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:72, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, polymorph:false, polyPeriod:7, polyTimer:0, polyChance:0, polyLevel:0, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1, arrowPeriod:0.90, arrowTimer:0, arrowSpeed:360, arrowDmg:1, arrowCount:1, arrowPierce:false });
+      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:1, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:72, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, polymorph:false, polyPeriod:7, polyTimer:0, polyChance:0, polyLevel:0, polyRadius:0, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1, arrowPeriod:0.90, arrowTimer:0, arrowSpeed:360, arrowDmg:1, arrowCount:1, arrowPierce:false });
       if (stats.startOrbs) { UPGR.orbs = stats.startOrbs; }
       // Reset upgrade tracking
       for (const k in UPGRADE_LEVELS) delete UPGRADE_LEVELS[k];
@@ -1260,7 +1262,10 @@
 
   function emitPolymorphWave(x,y){
     const chance = UPGR.polyChance || 0;
-    POLY_WAVES.push({ x, y, r: 0, speed: 360, life: 0, ttl: 1.4, chance, hit: new Set() });
+    const maxR = Math.max(0, UPGR.polyRadius || 0);
+    const speed = 360;
+    const ttl = 0.8 + (maxR / 480);
+    POLY_WAVES.push({ x, y, r: 0, speed, life: 0, ttl, chance, hit: new Set(), maxR });
     polymorphWaveBurst(x,y);
   }
 
@@ -1823,7 +1828,8 @@
         for (let i=POLY_WAVES.length-1;i>=0;i--){
           const wave = POLY_WAVES[i];
           wave.life += dt;
-          wave.r += wave.speed * dt;
+          const nextR = wave.r + wave.speed * dt;
+          wave.r = wave.maxR != null ? Math.min(wave.maxR, nextR) : nextR;
           for (const e of enemies){
             if (e.hp<=0 || e.kind === 'boss') continue;
             if (wave.hit.has(e)) continue;
@@ -2444,7 +2450,7 @@
         if (cls === 'wizard') lines.push(`<div class=\"section\">Spells</div>`);
         if (cls === 'wizard') lines.push(`<div><b>Orbs:</b> ${UPGR.orbs||0} (dmg ${UPGR.orbDmg||0}, radius ${UPGR.orbRadius||0})</div>`);
         if (cls === 'wizard') lines.push(`<div><b>Frost Nova:</b> ${UPGR.nova?`ON (period ${UPGR.novaPeriod.toFixed(2)}s, dmg ${UPGR.novaDmg})`:'OFF'}</div>`);
-        if (cls === 'wizard') lines.push(`<div><b>Polymorph:</b> ${UPGR.polymorph?`ON (chance ${fmtPct(UPGR.polyChance)} per wave, period ${UPGR.polyPeriod.toFixed(2)}s)`:'OFF'}</div>`);
+        if (cls === 'wizard') lines.push(`<div><b>Polymorph:</b> ${UPGR.polymorph?`ON (chance ${fmtPct(UPGR.polyChance)} per wave, period ${UPGR.polyPeriod.toFixed(2)}s, radius ${fmt(UPGR.polyRadius)}px)`:'OFF'}</div>`);
         if (cls === 'wizard') lines.push(`<div><b>Arcane Missiles:</b> ${UPGR.shards?`ON (count ${UPGR.shardCount}, period ${UPGR.shardPeriod.toFixed(2)}s, speed ${UPGR.shardSpeed})`:'OFF'}</div>`);
 
         lines.push(`<div class="section">Survival & Utility</div>`);
@@ -2477,7 +2483,7 @@
               case 'dodge': stat = `dodge ${fmtPct(UPGR.dodgeChance)}`; break;
               case 'orbs': stat = `orbs ${UPGR.orbs} dmg ${UPGR.orbDmg}`; break;
               case 'nova': stat = `${UPGR.nova?`period ${UPGR.novaPeriod.toFixed(2)}s dmg ${UPGR.novaDmg}`:'OFF'}`; break;
-              case 'polymorph': stat = `${UPGR.polymorph?`chance ${fmtPct(UPGR.polyChance)} period ${UPGR.polyPeriod.toFixed(2)}s`:'OFF'}`; break;
+              case 'polymorph': stat = `${UPGR.polymorph?`chance ${fmtPct(UPGR.polyChance)} period ${UPGR.polyPeriod.toFixed(2)}s radius ${fmt(UPGR.polyRadius)}px`:'OFF'}`; break;
               case 'shards': stat = `${UPGR.shards?`count ${UPGR.shardCount} period ${UPGR.shardPeriod.toFixed(2)}s`:'OFF'}`; break;
               case 'focus': stat = `attack period ${AUTO.atkPeriod.toFixed(2)}s`; break;
               case 'piercing': stat = `pierce ON`; break;


### PR DESCRIPTION
## Summary
- limit the wizard's polymorph wave to a level-based radius that starts at 100px and grows by 50px per upgrade, capped at 300px
- display the current polymorph radius in stats and update the upgrade note to reflect the new scaling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c88e2685e883298098d4c7d7dd8279