### PR TITLE
Improve stage 3 boss tracking

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1479,7 +1479,9 @@
         const isGoat = e.kind === 'goatCoin' || e.kind === 'goatHeart';
         if (e.kind === 'boss'){
           const targetAng = Math.atan2(dy, dx);
-          const turnRate = e.bossType === 'muck' ? 0.9/1.5 : 0.9; // rad/sec
+          let turnRate = 0.9; // rad/sec baseline
+          if (e.bossType === 'muck') turnRate /= 1.5;
+          else if (e.bossType === 'abomination') turnRate = Math.PI * 24; // Stage 3 boss snaps to the player
           const diff = angleDiff(targetAng, e.facing);
           const maxTurn = turnRate * dt;
           if (Math.abs(diff) < maxTurn) e.facing = targetAng;


### PR DESCRIPTION
## Summary
- let the stage 3 abomination boss rotate much faster so it can keep up with the player
- keep the existing slower turning for the other bosses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b36679ac8329a0bd03f2cd5398a6