### PR TITLE
Add on-screen movement pad for Emberfall mobile controls

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -103,12 +103,70 @@
     }
 
     /* Mobile controls */
-    .mobile-ctrls { position: absolute; right: 12px; bottom: 10px; z-index: 7; pointer-events: none; }
-    .actions { pointer-events: auto; }
+    .mobile-ctrls {
+      position: absolute;
+      left: 12px;
+      right: 12px;
+      bottom: 12px;
+      z-index: 7;
+      pointer-events: none;
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .mobile-ctrls .movement { pointer-events: auto; display: flex; flex-direction: column; align-items: flex-start; gap: 8px; }
+    .mobile-ctrls .movement .label { font-size: 11px; color: rgba(255,255,255,0.75); letter-spacing: 0.08em; text-transform: uppercase; }
+    .move-pad {
+      width: 160px;
+      height: 160px;
+      border-radius: 50%;
+      border: 3px solid rgba(255,215,0,0.4);
+      background: rgba(8,12,20,0.72);
+      box-shadow: 0 8px 22px rgba(0,0,0,0.5);
+      position: relative;
+      overflow: hidden;
+      touch-action: none;
+      user-select: none;
+      -webkit-user-select: none;
+      pointer-events: auto;
+      transition: border-color .2s ease, box-shadow .2s ease;
+    }
+    .move-pad::after {
+      content: '';
+      position: absolute;
+      inset: 14px;
+      border-radius: 50%;
+      border: 1px dashed rgba(255,215,0,0.25);
+      pointer-events: none;
+    }
+    .move-pad.active { border-color: rgba(255,215,0,0.75); box-shadow: 0 10px 26px rgba(0,0,0,0.55); }
+    .move-handle {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 70px;
+      height: 70px;
+      border-radius: 50%;
+      border: 2px solid rgba(255,215,0,0.65);
+      background: linear-gradient(45deg, var(--teal), #4682B4);
+      box-shadow: 0 6px 18px rgba(72,137,187,0.55);
+      transform: translate(calc(-50% + var(--move-x, 0px)), calc(-50% + var(--move-y, 0px)));
+      transition: transform .08s ease;
+      pointer-events: none;
+    }
+    .move-pad.active .move-handle { background: linear-gradient(45deg, var(--emerald), #4fa9d6); transition: none; }
+    .actions { pointer-events: auto; display:flex; gap: 10px; align-items: flex-end; }
     .ctrl { width: 60px; height: 60px; border-radius: 14px; border: 2px solid var(--gold); background: rgba(0,0,0,0.55); color: #fff; display: grid; place-items: center; font-size: 16px; user-select: none; -webkit-user-select: none; touch-action: none; box-shadow: 0 4px 12px rgba(0,0,0,0.35); }
     .ctrl:active { filter: brightness(1.15); }
     .ctrl.big { width: 90px; height: 90px; border-radius: 18px; font-size: 14px; background: linear-gradient(45deg, var(--teal), #4682B4); }
     .ctrl.small { width: 64px; height: 40px; border-radius: 10px; font-size: 12px; background: rgba(0,0,0,0.55); }
+
+    @media (max-width: 640px) {
+      .move-pad { width: 132px; height: 132px; }
+      .move-handle { width: 58px; height: 58px; }
+    }
   </style>
   <script>
     const GAME_ID = 'emberfall-gauntlet';
@@ -146,6 +204,12 @@
 
     <!-- Mobile controls (shown on touch devices) -->
       <div id="mobileCtrls" class="mobile-ctrls hidden" aria-hidden="true">
+        <div class="movement">
+          <span class="label">Move</span>
+          <div id="movePad" class="move-pad" role="application" aria-label="Drag to move">
+            <div id="moveHandle" class="move-handle"></div>
+          </div>
+        </div>
         <div class="actions">
           <button id="btnPause" class="ctrl small" aria-label="Pause">PAUSE</button>
         </div>
@@ -164,7 +228,7 @@
           <button id="startBtn" class="btn">Start</button>
           <a class="btn" href="../leaderboard.html?gameId=emberfall-gauntlet">Leaderboard</a>
         </div>
-          <div class="small" style="margin-top:10px">Move: WASD/Arrows or touch & drag. Pause: P. Audio: M. Stats: C</div>
+          <div class="small" style="margin-top:10px">Move: WASD/Arrows or on-screen touch pad. Pause: P or Pause button. Audio: M. Stats: C</div>
       </div>
     </div>
 
@@ -992,36 +1056,145 @@
       const btnPause = document.getElementById('btnPause');
       if (btnPause) btnPause.addEventListener('click', ()=> { paused = !paused; });
 
-      let startX = 0, startY = 0, active = false;
-      const dead = 20;
-      const clear = ()=>{ key.left = key.right = key.up = key.down = false; active = false; };
-      const move = (x,y)=>{
-        const dx = x - startX;
-        const dy = y - startY;
+      const movePad = document.getElementById('movePad');
+      const moveHandle = document.getElementById('moveHandle');
+      const dead = 18;
+      let dragActive = false;
+      let startX = 0, startY = 0;
+      let dragVector = null;
+      let padVector = null;
+
+      const updateKeysFromState = ()=>{
+        const vec = padVector || dragVector;
+        if (!vec) {
+          key.left = key.right = key.up = key.down = false;
+          return;
+        }
+        const { dx, dy } = vec;
         key.left = dx < -dead;
         key.right = dx > dead;
         key.up = dy < -dead;
         key.down = dy > dead;
       };
+      const setVector = (source, dx, dy)=>{
+        if (source === 'pad') padVector = { dx, dy };
+        else dragVector = { dx, dy };
+        updateKeysFromState();
+      };
+      const clearVector = (source)=>{
+        if (source === 'pad') padVector = null;
+        else dragVector = null;
+        updateKeysFromState();
+      };
+      const resetPadVisual = ()=>{
+        if (movePad) movePad.classList.remove('active');
+        if (moveHandle) {
+          moveHandle.style.setProperty('--move-x', '0px');
+          moveHandle.style.setProperty('--move-y', '0px');
+        }
+      };
+
+      const startDrag = (x, y)=>{ startX = x; startY = y; dragActive = true; };
+      const updateDrag = (x, y)=>{ if (!dragActive) return; setVector('drag', x - startX, y - startY); };
+      const endDrag = ()=>{ dragActive = false; clearVector('drag'); };
 
       canvas.addEventListener('pointerdown', (e)=>{
-        startX = e.clientX; startY = e.clientY; active = true;
+        startDrag(e.clientX, e.clientY);
         try{ canvas.setPointerCapture(e.pointerId); }catch{}
       });
-      canvas.addEventListener('pointermove', (e)=>{ if(active) move(e.clientX, e.clientY); });
-      canvas.addEventListener('pointerup', (e)=>{ clear(); try{ canvas.releasePointerCapture(e.pointerId); }catch{} });
-      canvas.addEventListener('pointercancel', clear);
-      canvas.addEventListener('pointerleave', clear);
+      canvas.addEventListener('pointermove', (e)=>{ updateDrag(e.clientX, e.clientY); });
+      canvas.addEventListener('pointerup', (e)=>{
+        endDrag();
+        try{ canvas.releasePointerCapture(e.pointerId); }catch{}
+      });
+      canvas.addEventListener('pointercancel', endDrag);
+      canvas.addEventListener('pointerleave', endDrag);
 
-      // Touch fallback
+      // Touch fallback for canvas
       canvas.addEventListener('touchstart', (e)=>{
-        if(e.touches.length){ const t=e.touches[0]; startX=t.clientX; startY=t.clientY; active=true; }
+        if(!e.touches.length) return;
+        const t = e.touches[0];
+        startDrag(t.clientX, t.clientY);
       }, { passive: true });
       canvas.addEventListener('touchmove', (e)=>{
-        if(active && e.touches.length){ const t=e.touches[0]; move(t.clientX, t.clientY); }
+        if(!dragActive || !e.touches.length) return;
+        const t = e.touches[0];
+        updateDrag(t.clientX, t.clientY);
       }, { passive: true });
-      canvas.addEventListener('touchend', clear, { passive: true });
-      canvas.addEventListener('touchcancel', clear, { passive: true });
+      canvas.addEventListener('touchend', (e)=>{
+        if (!e.touches.length) {
+          endDrag();
+        }
+      }, { passive: true });
+      canvas.addEventListener('touchcancel', endDrag, { passive: true });
+
+      if (movePad && moveHandle) {
+        const handleLimit = ()=>Math.max(0, (movePad.clientWidth - moveHandle.clientWidth) / 2);
+        const setHandlePosition = (dx, dy)=>{
+          const limit = handleLimit();
+          let hx = dx;
+          let hy = dy;
+          const dist = Math.hypot(dx, dy) || 0;
+          if (dist > limit && limit > 0) {
+            const angle = Math.atan2(dy, dx);
+            hx = Math.cos(angle) * limit;
+            hy = Math.sin(angle) * limit;
+          }
+          moveHandle.style.setProperty('--move-x', `${hx}px`);
+          moveHandle.style.setProperty('--move-y', `${hy}px`);
+        };
+        const updatePad = (clientX, clientY)=>{
+          const rect = movePad.getBoundingClientRect();
+          const cx = rect.left + rect.width / 2;
+          const cy = rect.top + rect.height / 2;
+          const dx = clientX - cx;
+          const dy = clientY - cy;
+          setVector('pad', dx, dy);
+          setHandlePosition(dx, dy);
+        };
+        const endPad = ()=>{ resetPadVisual(); clearVector('pad'); };
+
+        movePad.addEventListener('pointerdown', (e)=>{
+          e.preventDefault();
+          movePad.classList.add('active');
+          updatePad(e.clientX, e.clientY);
+          try{ movePad.setPointerCapture(e.pointerId); }catch{}
+        });
+        movePad.addEventListener('pointermove', (e)=>{
+          if (!movePad.classList.contains('active')) return;
+          updatePad(e.clientX, e.clientY);
+        });
+        movePad.addEventListener('pointerup', (e)=>{
+          endPad();
+          try{ movePad.releasePointerCapture(e.pointerId); }catch{}
+        });
+        movePad.addEventListener('pointercancel', endPad);
+        movePad.addEventListener('pointerleave', ()=>{
+          if (!movePad.classList.contains('active')) return;
+          endPad();
+        });
+
+        movePad.addEventListener('touchstart', (e)=>{
+          if(!e.touches.length) return;
+          movePad.classList.add('active');
+          const t = e.touches[0];
+          updatePad(t.clientX, t.clientY);
+        }, { passive: true });
+        movePad.addEventListener('touchmove', (e)=>{
+          if(!movePad.classList.contains('active') || !e.touches.length) return;
+          const t = e.touches[0];
+          updatePad(t.clientX, t.clientY);
+        }, { passive: true });
+        movePad.addEventListener('touchend', (e)=>{
+          if (e.touches.length) {
+            const t = e.touches[0];
+            updatePad(t.clientX, t.clientY);
+          } else {
+            endPad();
+          }
+        }, { passive: true });
+        movePad.addEventListener('touchcancel', endPad, { passive: true });
+      }
     }
 
     // Utility


### PR DESCRIPTION
## Summary
- add a visible touch movement pad beside the Emberfall playfield for mobile devices
- update touch control handling so the new pad drives player movement while coexisting with drag controls
- tweak the start overlay instructions to mention the on-screen pad

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8bfc90d3483298696331c0a8f8ce0