### PR TITLE
Ensure Emberfall bosses wait for polymorphed goats

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1971,15 +1971,17 @@
       // Wave & spawns (scale with larger world)
       if (!boss && !awaitingStage) {
         SPAWN.t += dt;
-        const alive = enemies.filter(e=>e.hp>0).length;
+        const livingThreats = enemies.filter(e => e.hp > 0 && e.kind !== 'goatCoin' && e.kind !== 'goatHeart');
+        // Demon goats created by Polymorph still need to be cleared before a boss can spawn.
+        const goatsRemain = enemies.some(e => e.hp > 0 && (e.kind === 'goatCoin' || e.kind === 'goatHeart'));
         const targetCount = Math.min((6 + SPAWN.wave*2) * DENSITY, WAVE_LIMIT);
-        if (SPAWN.count < WAVE_LIMIT && alive < targetCount && SPAWN.t > SPAWN.cd){
+        if (SPAWN.count < WAVE_LIMIT && livingThreats.length < targetCount && SPAWN.t > SPAWN.cd){
           SPAWN.t = 0;
           let group = Math.min(8, Math.max(2, Math.ceil(DENSITY/2)) * Math.min(4, 1 + Math.floor(SPAWN.wave/2)));
           group = Math.min(group, WAVE_LIMIT - SPAWN.count);
           for (let i=0;i<group; i++){ spawnEnemy(); SPAWN.count++; }
         }
-        if (SPAWN.count >= WAVE_LIMIT && alive === 0){
+        if (SPAWN.count >= WAVE_LIMIT && livingThreats.length === 0 && !goatsRemain){
           if (SPAWN.wave < STAGE_WAVES){
             SPAWN.wave += 1; waveEl.textContent = SPAWN.wave; SPAWN.count = 0; SPAWN.t = 0; SPAWN.keyAssigned = false;
             spawnChest();


### PR DESCRIPTION
## Summary
- treat polymorphed goats as threats that block boss spawns until they are cleared
- keep wave pacing based on active threats while still counting goats for boss gating

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8c663ef408329816a3142447bb0b3