### PR TITLE
Prevent bosses from being affected by sleep

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -2049,7 +2049,7 @@
           const maxR = wave.maxR ?? Infinity;
           wave.r = Math.min(maxR, wave.r + wave.speed * dt);
           for (const e of enemies){
-            if (e.hp<=0) continue;
+            if (e.hp<=0 || e.kind === 'boss') continue;
             if (wave.hit.has(e)) continue;
             const buffer = Math.max(e.w||0, e.h||0) * 0.35;
             if (len(e.x-wave.x, e.y-wave.y) <= wave.r + buffer){


### PR DESCRIPTION
## Summary
- prevent the wizard's sleep spell from applying sleep to boss enemies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8e4e8af5883299d1d04a6ba1d1e90