### PR TITLE
Add wizard fireball spell with piercing projectiles

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -591,6 +591,17 @@
     SLIME_PROJECTILE_ANIM.left.src = 'assets/EG_projectile_slime_left_small.png';
     SLIME_PROJECTILE_ANIM.right.src = 'assets/EG_projectile_slime_right_small.png';
 
+    const FIREBALL_PROJECTILE_ANIM = {
+      left: new Image(),
+      right: new Image(),
+      up: new Image(),
+      down: new Image(),
+    };
+    FIREBALL_PROJECTILE_ANIM.left.src = 'assets/EG_projectile_fire_left_small.png';
+    FIREBALL_PROJECTILE_ANIM.right.src = 'assets/EG_projectile_fire_right_small.png';
+    FIREBALL_PROJECTILE_ANIM.up.src = 'assets/EG_projectile_fire_up_small.png';
+    FIREBALL_PROJECTILE_ANIM.down.src = 'assets/EG_projectile_fire_down_small.png';
+
     const HILL_GIANT_ANIM = {
       down: new Image(),
       up: new Image(),
@@ -673,7 +684,7 @@
     ];
     const MAPS = MAP_FILES.map(src => { const i = new Image(); i.src = src; return i; });
 
-    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length + Object.keys(HILL_GIANT_ANIM).length + Object.keys(ABOMINATION_ANIM).length + Object.keys(HUNGER_DEMON_ANIM).length + Object.keys(BEHOLDER_ANIM).length + Object.keys(GOAT_ANIM).length;
+    let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length + Object.keys(HILL_GIANT_ANIM).length + Object.keys(ABOMINATION_ANIM).length + Object.keys(HUNGER_DEMON_ANIM).length + Object.keys(BEHOLDER_ANIM).length + Object.keys(GOAT_ANIM).length + Object.keys(MUCK_PROJECTILE_ANIM).length + Object.keys(HILL_GIANT_PROJECTILE_ANIM).length + Object.keys(SLIME_PROJECTILE_ANIM).length + Object.keys(FIREBALL_PROJECTILE_ANIM).length;
     for (const k in IMG) IMG[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const img of MAPS) img.addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in WIZ_ANIM) WIZ_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
@@ -688,6 +699,10 @@
     for (const k in HUNGER_DEMON_ANIM) HUNGER_DEMON_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in BEHOLDER_ANIM) BEHOLDER_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     for (const k in GOAT_ANIM) GOAT_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in MUCK_PROJECTILE_ANIM) MUCK_PROJECTILE_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in HILL_GIANT_PROJECTILE_ANIM) HILL_GIANT_PROJECTILE_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in SLIME_PROJECTILE_ANIM) SLIME_PROJECTILE_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
+    for (const k in FIREBALL_PROJECTILE_ANIM) FIREBALL_PROJECTILE_ANIM[k].addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.rogue.addEventListener('load', () => { if (++loaded === need) init(); });
     CLASS_IMG.wizard.addEventListener('load', () => { if (++loaded === need) init(); });
 
@@ -734,6 +749,13 @@
     const ORB_MAX_COUNT = 4;
     const ORB_BASE_SPEED = 13.5 * 0.7; // 70% of previous 13.5 baseline
     const ORB_SPEED_LEVEL_STEP = 0.10; // +10% per upgrade
+    const FIREBALL_BASE_RANGE = 200;
+    const FIREBALL_RANGE_STEP = 50;
+    const FIREBALL_MAX_RANGE = 400;
+    const FIREBALL_PERIOD_BASE = 3.0;
+    const FIREBALL_SPEED = 360;
+    const FIREBALL_FRAME_TIME = 0.09;
+    const FIREBALL_DMG = 2;
     // Separate hitbox scaling so we can tighten player damage range
     // Reduce player hitbox for fairness: smaller damage window
     const HITBOX = { player: 0.24, enemy: 0.3 };
@@ -854,6 +876,20 @@
         UPGR.sleepTimer = UPGR.sleepPeriod;
       }
     }
+
+    function refreshFireballState(fromUpgrade = false){
+      const prev = UPGR.fireball;
+      const level = Math.min(5, UPGRADE_LEVELS.fireball || 0);
+      UPGR.fireball = level > 0;
+      UPGR.fireballLevel = level;
+      UPGR.fireballRange = level > 0 ? Math.min(FIREBALL_MAX_RANGE, FIREBALL_BASE_RANGE + (level - 1) * FIREBALL_RANGE_STEP) : 0;
+      if (!Number.isFinite(UPGR.fireballDmg) || UPGR.fireballDmg <= 0){
+        UPGR.fireballDmg = FIREBALL_DMG;
+      }
+      if (fromUpgrade && level > 0 && !prev){
+        UPGR.fireballTimer = UPGR.fireballPeriod;
+      }
+    }
     let PROJECTILES = [];
     let BOSS_PROJECTILES = [];
     let ORBS = [];
@@ -906,6 +942,7 @@
     registerSpellCooldown({ periodKey: 'polyPeriod', timerKey: 'polyTimer', min: 0.5 });
     registerSpellCooldown({ periodKey: 'shardPeriod', timerKey: 'shardTimer', min: 0.2 });
     registerSpellCooldown({ periodKey: 'sleepPeriod', timerKey: 'sleepTimer', min: 2 });
+    registerSpellCooldown({ periodKey: 'fireballPeriod', timerKey: 'fireballTimer', min: 1 });
 
     const POOLS = {
       fighter: [
@@ -941,6 +978,7 @@
         { id:'nova', type:'Spell', name:'Frost Nova', desc:'Every few seconds, blast and slow nearby foes.', note:'Improves with repeats', apply:()=>{ if(!UPGR.nova){ UPGR.nova=true; } else { UPGR.novaPeriod=Math.max(2.2, UPGR.novaPeriod*0.9); UPGR.novaDmg+=1; } } },
         { id:'polymorph', type:'Spell', name:'Polymorph', desc:'Release a transforming wave that turns foes into demon goats that drop coins or hearts.', note:'Chance increases with repeats (max 50%). Bosses are immune.', maxLevel:5, apply:()=>{ refreshPolymorphState(true); } },
         { id:'sleep', type:'Spell', name:'Sleep', desc:'Send out a drowsy wave that can lull foes to sleep.', note:'200px wave, 33% sleep for 5s (+5s per level).', maxLevel:5, apply:()=>{ refreshSleepState(true); } },
+        { id:'fireball', type:'Spell', name:'Fireball', desc:'Periodically launch piercing fireballs in all four directions.', note:'Range +50px per level (max 400px).', maxLevel:5, apply:()=>{ refreshFireballState(true); } },
         { id:'shards', type:'Spell', name:'Arcane Missiles', desc:'Periodically fire magic missiles.', note:'More with repeats', apply:()=>{ if(!UPGR.shards){ UPGR.shards=true; } else { UPGR.shardCount=Math.min(6, UPGR.shardCount+1); } } },
         { id:'focus', type:'Spell', name:'Spell Focus', desc:'Reduce all spell cooldowns by 12%.', note:'Stacks multiplicatively', apply:()=>{ const factor = 0.88; reduceSpellCooldowns(factor); UPGR.spellCooldownMult = +(UPGR.spellCooldownMult * factor).toFixed(3); } },
         { id:'wisdom', type:'Upgrade', name:'Wisdom', desc:'Max HP +1 and heal 1.', apply:()=>{ P.hpMax += 1; P.hp = Math.min(P.hpMax, P.hp+1); drawHearts(); } },
@@ -1027,7 +1065,7 @@
       COINS.value = 0; coinsEl.textContent = COINS.value; SHOP.idx = 0; SHOP.open = false;
       KEYS.value = 0; drawKeys();
       // Reset upgrades and spell state
-      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:1, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:72, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, polymorph:false, polyPeriod:7, polyTimer:0, polyChance:0, polyLevel:0, polyRadius:0, sleep:false, sleepPeriod:8, sleepTimer:0, sleepChance:0, sleepLevel:0, sleepDuration:0, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1, spellCooldownMult:1, arrowPeriod:0.90, arrowTimer:0, arrowSpeed:360, arrowDmg:1, arrowCount:1, arrowPierce:false });
+      Object.assign(UPGR, { meleeDmg:1, multistrike:1, lifeStealChance:0, magnet:1, critChance:0, critMult:1.6, doubleCoinChance:0, dodgeChance:0, orbs:0, orbDmg:1, orbRadius:72, nova:false, novaPeriod:6, novaTimer:0, novaDmg:1, polymorph:false, polyPeriod:7, polyTimer:0, polyChance:0, polyLevel:0, polyRadius:0, sleep:false, sleepPeriod:8, sleepTimer:0, sleepChance:0, sleepLevel:0, sleepDuration:0, shards:false, shardPeriod:0.85, shardTimer:0, shardSpeed:320, shardCount:1, fireball:false, fireballPeriod:FIREBALL_PERIOD_BASE, fireballTimer:0, fireballRange:0, fireballLevel:0, fireballDmg:FIREBALL_DMG, spellCooldownMult:1, arrowPeriod:0.90, arrowTimer:0, arrowSpeed:360, arrowDmg:1, arrowCount:1, arrowPierce:false });
       if (stats.startOrbs) { UPGR.orbs = Math.min(ORB_MAX_COUNT, stats.startOrbs); }
       // Reset upgrade tracking
       for (const k in UPGRADE_LEVELS) delete UPGRADE_LEVELS[k];
@@ -1432,6 +1470,24 @@
     const speed = radius / ttl;
     SLEEP_WAVES.push({ x, y, r: 0, speed, life: 0, ttl, chance, duration, maxR: radius, hit: new Set() });
     sleepWaveBurst(x,y);
+  }
+
+  function emitFireballBurst(x,y){
+    const range = UPGR.fireballRange || 0;
+    if (range <= 0) return;
+    const speed = FIREBALL_SPEED;
+    const ttl = range / speed;
+    const dmg = UPGR.fireballDmg || FIREBALL_DMG;
+    const dirs = [
+      { dir: 'left', vx: -speed, vy: 0 },
+      { dir: 'right', vx: speed, vy: 0 },
+      { dir: 'up', vx: 0, vy: -speed },
+      { dir: 'down', vx: 0, vy: speed },
+    ];
+    for (const info of dirs){
+      PROJECTILES.push({ kind:'fireball', dir:info.dir, x, y, vx:info.vx, vy:info.vy, life:0, ttl, dmg, frame:0, animT:0, pierce:true });
+    }
+    spark(x, y, '#ff9d4d');
   }
 
   function polymorphWaveBurst(x,y){
@@ -2090,25 +2146,46 @@
       // Spells: forward shards
       if (UPGR.shards){ UPGR.shardTimer += dt; if (UPGR.shardTimer >= UPGR.shardPeriod){ UPGR.shardTimer = 0; const dir = P.aimDir; const spread = 0.22; const cnt = UPGR.shardCount; for (let i=0;i<cnt;i++){ const a = dir + (i-(cnt-1)/2)*spread; PROJECTILES.push({ x:P.x, y:P.y, vx:Math.cos(a)*320, vy:Math.sin(a)*320, life:0, ttl:1.2, dmg:1 }); } } }
 
+      if (UPGR.fireball){
+        UPGR.fireballTimer += dt;
+        if (UPGR.fireballTimer >= UPGR.fireballPeriod){
+          UPGR.fireballTimer = 0;
+          emitFireballBurst(P.x, P.y);
+        }
+      }
+
       // Update projectiles
       for (let i=PROJECTILES.length-1;i>=0;i--){
         const p=PROJECTILES[i];
         p.life+=dt;
+        if (p.kind === 'fireball'){
+          p.animT = (p.animT || 0) + dt;
+          while (p.animT >= FIREBALL_FRAME_TIME){
+            p.animT -= FIREBALL_FRAME_TIME;
+            p.frame = ((p.frame||0) + 1) % 4;
+          }
+        }
         p.x+=p.vx*dt;
         p.y+=p.vy*dt;
         if (p.x < ARENA.x || p.x > ARENA.x + ARENA.w || p.y < ARENA.y || p.y > ARENA.y + ARENA.h){ PROJECTILES.splice(i,1); continue; }
         if (p.life>p.ttl){ PROJECTILES.splice(i,1); continue; }
         let removed = false;
+        const canPierce = p.pierce || (p.kind==='arrow' && UPGR.arrowPierce);
+        let hitStore = null;
+        if (canPierce){
+          if (p.hit && !(p.hit instanceof Set)){
+            p.hit = new Set(p.hit);
+          }
+          if (!p.hit) p.hit = new Set();
+          hitStore = p.hit;
+        }
         for (const e of enemies){
           if (e.hp<=0) continue;
-          // Prevent re-hitting the same enemy when piercing
-          if (p.kind==='arrow' && UPGR.arrowPierce && p.hit && p.hit.includes(e)) continue;
+          if (hitStore && hitStore.has(e)) continue;
           if (len(p.x-e.x,p.y-e.y) < 16){
             applyDamage(e, p.dmg, p.vx, p.vy, KNOCK.projectile);
-            if (p.kind==='arrow' && UPGR.arrowPierce){
-              if (!p.hit) p.hit = [];
-              p.hit.push(e);
-              // do not remove; allow piercing further targets
+            if (hitStore){
+              hitStore.add(e);
             } else {
               PROJECTILES.splice(i,1);
               removed = true;
@@ -2555,6 +2632,16 @@
             ctx.fillStyle = '#7b9bb3';
             ctx.fillRect(-8, -2, 3, 4);
             ctx.restore();
+          } else if (pr.kind === 'fireball'){
+            const sheet = FIREBALL_PROJECTILE_ANIM[pr.dir];
+            if (sheet && sheet.width){
+              const fw = sheet.width / 4;
+              const fh = sheet.height;
+              const frame = (pr.frame||0) % 4;
+              ctx.drawImage(sheet, frame * fw, 0, fw, fh, pr.x - fw/2, pr.y - fh/2, fw, fh);
+            } else {
+              ctx.drawImage(IMG.spark, pr.x-8, pr.y-8, 16, 16);
+            }
           } else {
             ctx.drawImage(IMG.spark, pr.x-6, pr.y-6, 12, 12);
           }
@@ -2757,6 +2844,7 @@
         if (cls === 'wizard') lines.push(`<div><b>Frost Nova:</b> ${UPGR.nova?`ON (period ${UPGR.novaPeriod.toFixed(2)}s, dmg ${UPGR.novaDmg})`:'OFF'}</div>`);
         if (cls === 'wizard') lines.push(`<div><b>Polymorph:</b> ${UPGR.polymorph?`ON (chance ${fmtPct(UPGR.polyChance)} per wave, period ${UPGR.polyPeriod.toFixed(2)}s)`:'OFF'}</div>`);
         if (cls === 'wizard') lines.push(`<div><b>Sleep:</b> ${UPGR.sleep?`ON (chance ${fmtPct(UPGR.sleepChance)}, period ${UPGR.sleepPeriod.toFixed(2)}s, duration ${UPGR.sleepDuration.toFixed(0)}s)`:'OFF'}</div>`);
+        if (cls === 'wizard') lines.push(`<div><b>Fireball:</b> ${UPGR.fireball?`ON (period ${UPGR.fireballPeriod.toFixed(2)}s, range ${fmt(UPGR.fireballRange)}px, dmg ${UPGR.fireballDmg})`:'OFF'}</div>`);
         if (cls === 'wizard') lines.push(`<div><b>Arcane Missiles:</b> ${UPGR.shards?`ON (count ${UPGR.shardCount}, period ${UPGR.shardPeriod.toFixed(2)}s, speed ${UPGR.shardSpeed})`:'OFF'}</div>`);
         if (cls === 'wizard' && UPGR.spellCooldownMult < 0.999) lines.push(`<div><b>Spell Focus:</b> ${fmtPct(1 - UPGR.spellCooldownMult)} faster cooldowns</div>`);
 
@@ -2792,6 +2880,7 @@
               case 'nova': stat = `${UPGR.nova?`period ${UPGR.novaPeriod.toFixed(2)}s dmg ${UPGR.novaDmg}`:'OFF'}`; break;
               case 'polymorph': stat = `${UPGR.polymorph?`chance ${fmtPct(UPGR.polyChance)} period ${UPGR.polyPeriod.toFixed(2)}s`:'OFF'}`; break;
               case 'sleep': stat = `${UPGR.sleep?`chance ${fmtPct(UPGR.sleepChance)} dur ${UPGR.sleepDuration.toFixed(0)}s`:'OFF'}`; break;
+              case 'fireball': stat = `${UPGR.fireball?`range ${fmt(UPGR.fireballRange)}px dmg ${UPGR.fireballDmg} period ${UPGR.fireballPeriod.toFixed(2)}s`:'OFF'}`; break;
               case 'shards': stat = `${UPGR.shards?`count ${UPGR.shardCount} period ${UPGR.shardPeriod.toFixed(2)}s`:'OFF'}`; break;
               case 'focus': stat = `spell CD ${fmtPct(1 - UPGR.spellCooldownMult)} faster`; break;
               case 'piercing': stat = `pierce ON`; break;


### PR DESCRIPTION
## Summary
- add a wizard fireball upgrade that launches four-direction piercing projectiles with range scaling per level
- load and animate new fireball projectile sprites while updating projectile handling to support piercing sets
- surface the spell in stats and upgrade tracking alongside existing wizard abilities

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c95685351883298de0509c2ca26fee