### PR TITLE
Double wizard fireball damage

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -755,7 +755,7 @@
     const FIREBALL_PERIOD_BASE = 3.0;
     const FIREBALL_SPEED = 360;
     const FIREBALL_FRAME_TIME = 0.09;
-    const FIREBALL_DMG = 2;
+    const FIREBALL_DMG = 4;
     // Separate hitbox scaling so we can tighten player damage range
     // Reduce player hitbox for fairness: smaller damage window
     const HITBOX = { player: 0.24, enemy: 0.3 };


### PR DESCRIPTION
## Summary
- double the base fireball damage constant so the wizard's fireball ability deals twice the damage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9628741cc83299433165876d9fbbc