### PR TITLE
Double Emberfall boss pushback

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1901,8 +1901,8 @@
               e.pulseRange = range;
               if (dist < range && P.iT<=0){
                 const [nx,ny]=norm(P.x-e.x,P.y-e.y);
-                P.vx += nx*200;
-                P.vy += ny*200;
+                P.vx += nx*400;
+                P.vy += ny*400;
                 if (CHEAT.active){ P.hitFlash = 0.25; spark(P.x,P.y,'#ff8a8a'); }
                 else if (UPGR.dodgeChance>0 && Math.random()<UPGR.dodgeChance){ P.iT=0.6; P.hitFlash=0.25; spark(P.x,P.y,'#a1ffd4'); }
                 else { P.hp-=1; P.iT=2.0; P.hitFlash=0.25; drawHearts(); spark(P.x,P.y,'#ff8a8a'); playHeroHit(); if (P.hp<=0) return gameOver(); }


### PR DESCRIPTION
## Summary
- double the velocity impulse applied to the player when a boss blast lands so the pushback distance is doubled

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9b85fe8508329ac8d3a46c7739bed