### PR TITLE
Add terrain generation for stage two forest map

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -672,6 +672,17 @@
       swampBush04: new Image(),
       swampRock02: new Image(),
       swampRock03: new Image(),
+      forestTree01: new Image(),
+      forestTree02: new Image(),
+      forestTree03: new Image(),
+      forestTree04: new Image(),
+      forestBush01: new Image(),
+      forestBush02: new Image(),
+      forestBush03: new Image(),
+      forestRock01: new Image(),
+      forestRock02: new Image(),
+      forestRock03: new Image(),
+      forestRock04: new Image(),
       hero: CLASS_IMG.fighter,
     };
     IMG.coin.src = 'assets/eg_coin.svg';
@@ -688,6 +699,17 @@
     IMG.swampBush04.src = 'assets/EG_terrain_swamp_bush04_small.png';
     IMG.swampRock02.src = 'assets/EG_terrain_swamp_rock02_small.png';
     IMG.swampRock03.src = 'assets/EG_terrain_swamp_rock03_small.png';
+    IMG.forestTree01.src = 'assets/EG_terrain_forest_tree01_small.png';
+    IMG.forestTree02.src = 'assets/EG_terrain_forest_tree02_small.png';
+    IMG.forestTree03.src = 'assets/EG_terrain_forest_tree03_small.png';
+    IMG.forestTree04.src = 'assets/EG_terrain_forest_tree04_small.png';
+    IMG.forestBush01.src = 'assets/EG_terrain_forest_bush01_small.png';
+    IMG.forestBush02.src = 'assets/EG_terrain_forest_bush02_small.png';
+    IMG.forestBush03.src = 'assets/EG_terrain_forest_bush03_small.png';
+    IMG.forestRock01.src = 'assets/EG_terrain_forest_rock01_small.png';
+    IMG.forestRock02.src = 'assets/EG_terrain_forest_rock02_small.png';
+    IMG.forestRock03.src = 'assets/EG_terrain_forest_rock03_small.png';
+    IMG.forestRock04.src = 'assets/EG_terrain_forest_rock04_small.png';
 
     const MAP_FILES = [
       'assets/EG_map_mirewatch01.png',
@@ -903,8 +925,287 @@
       return results;
     }
 
+    function generateStageOneTerrain(){
+      if (!ARENA || !ARENA.w || !ARENA.h) return [];
+
+      const marginX = Math.max(72, Math.min(ARENA.w * 0.08, 140));
+      const marginY = Math.max(72, Math.min(ARENA.h * 0.08, 140));
+      const minX = ARENA.x + marginX;
+      const maxX = ARENA.x + ARENA.w - marginX;
+      const minY = ARENA.y + marginY;
+      const maxY = ARENA.y + ARENA.h - marginY;
+      if (minX >= maxX || minY >= maxY) return [];
+
+      const centerX = ARENA.x + ARENA.w / 2;
+      const centerY = ARENA.y + ARENA.h / 2;
+      const centerHalfW = Math.min(ARENA.w * 0.25, 260);
+      const centerHalfH = Math.min(ARENA.h * 0.25, 220);
+
+      const tree01Width = IMG.forestTree01.width || 128;
+      const tree01Height = IMG.forestTree01.height || 128;
+      const tree02Width = IMG.forestTree02.width || tree01Width;
+      const tree02Height = IMG.forestTree02.height || tree01Height;
+      const tree03Width = IMG.forestTree03.width || tree01Width;
+      const tree03Height = IMG.forestTree03.height || tree01Height;
+      const tree04Width = IMG.forestTree04.width || tree01Width;
+      const tree04Height = IMG.forestTree04.height || tree01Height;
+      const bush01Width = (IMG.forestBush01.width || 0) * 0.5 || 64;
+      const bush01Height = (IMG.forestBush01.height || 0) * 0.5 || 64;
+      const bush02Width = (IMG.forestBush02.width || 0) * 0.5 || 64;
+      const bush02Height = (IMG.forestBush02.height || 0) * 0.5 || 64;
+      const bush03Width = (IMG.forestBush03.width || 0) * 0.5 || 64;
+      const bush03Height = (IMG.forestBush03.height || 0) * 0.5 || 64;
+      const rock01Width = (IMG.forestRock01.width || 0) * 0.5 || 64;
+      const rock01Height = (IMG.forestRock01.height || 0) * 0.5 || 64;
+      const rock02Width = (IMG.forestRock02.width || 0) * 0.5 || 64;
+      const rock02Height = (IMG.forestRock02.height || 0) * 0.5 || 64;
+      const rock03Width = (IMG.forestRock03.width || 0) * 0.5 || 64;
+      const rock03Height = (IMG.forestRock03.height || 0) * 0.5 || 64;
+      const rock04Width = (IMG.forestRock04.width || 0) * 0.5 || 64;
+      const rock04Height = (IMG.forestRock04.height || 0) * 0.5 || 64;
+
+      const meta = {
+        tree01: {
+          img: IMG.forestTree01,
+          anchor: 'bottom',
+          width: tree01Width,
+          height: tree01Height,
+          collider: { w: tree01Width * 0.48, h: Math.min(96, tree01Height * 0.6), anchor: 'bottom' },
+        },
+        tree02: {
+          img: IMG.forestTree02,
+          anchor: 'bottom',
+          width: tree02Width,
+          height: tree02Height,
+          collider: { w: tree02Width * 0.48, h: Math.min(96, tree02Height * 0.6), anchor: 'bottom' },
+        },
+        tree03: {
+          img: IMG.forestTree03,
+          anchor: 'bottom',
+          width: tree03Width,
+          height: tree03Height,
+          collider: { w: tree03Width * 0.5, h: Math.min(100, tree03Height * 0.62), anchor: 'bottom' },
+        },
+        tree04: {
+          img: IMG.forestTree04,
+          anchor: 'bottom',
+          width: tree04Width,
+          height: tree04Height,
+          collider: { w: tree04Width * 0.5, h: Math.min(100, tree04Height * 0.62), anchor: 'bottom' },
+        },
+        bush01: {
+          img: IMG.forestBush01,
+          anchor: 'bottom',
+          width: bush01Width,
+          height: bush01Height,
+          collider: { w: bush01Width * 0.7, h: bush01Height * 0.55, anchor: 'bottom' },
+        },
+        bush02: {
+          img: IMG.forestBush02,
+          anchor: 'bottom',
+          width: bush02Width,
+          height: bush02Height,
+          collider: { w: bush02Width * 0.7, h: bush02Height * 0.55, anchor: 'bottom' },
+        },
+        bush03: {
+          img: IMG.forestBush03,
+          anchor: 'bottom',
+          width: bush03Width,
+          height: bush03Height,
+          collider: { w: bush03Width * 0.7, h: bush03Height * 0.55, anchor: 'bottom' },
+        },
+        rock01: {
+          img: IMG.forestRock01,
+          anchor: 'bottom',
+          width: rock01Width,
+          height: rock01Height,
+          collider: { w: rock01Width * 0.8, h: rock01Height * 0.7, anchor: 'bottom' },
+        },
+        rock02: {
+          img: IMG.forestRock02,
+          anchor: 'bottom',
+          width: rock02Width,
+          height: rock02Height,
+          collider: { w: rock02Width * 0.8, h: rock02Height * 0.7, anchor: 'bottom' },
+        },
+        rock03: {
+          img: IMG.forestRock03,
+          anchor: 'bottom',
+          width: rock03Width,
+          height: rock03Height,
+          collider: { w: rock03Width * 0.8, h: rock03Height * 0.7, anchor: 'bottom' },
+        },
+        rock04: {
+          img: IMG.forestRock04,
+          anchor: 'bottom',
+          width: rock04Width,
+          height: rock04Height,
+          collider: { w: rock04Width * 0.8, h: rock04Height * 0.7, anchor: 'bottom' },
+        },
+      };
+
+      const placements = [];
+      const results = [];
+      const counts = {
+        tree01: 2,
+        tree02: 1,
+        tree03: 1,
+        tree04: 1,
+        bush01: 3,
+        bush02: 3,
+        bush03: 3,
+        rock01: 4,
+        rock02: 4,
+        rock03: 4,
+        rock04: 4,
+      };
+
+      const treeTypes = ['tree01', 'tree02', 'tree03', 'tree04'];
+
+      function withinBounds(x, y){
+        return x >= minX && x <= maxX && y >= minY && y <= maxY;
+      }
+
+      function inCenterClear(x, y){
+        return Math.abs(x - centerX) < centerHalfW && Math.abs(y - centerY) < centerHalfH;
+      }
+
+      function hasSpacing(x, y, ignore = null){
+        for (const p of placements){
+          if (ignore && p === ignore) continue;
+          if (Math.hypot(x - p.x, y - p.y) < TERRAIN_MIN_DISTANCE) return false;
+        }
+        return true;
+      }
+
+      function farFromTrees(x, y, dist = 200){
+        for (const p of placements){
+          if (!treeTypes.includes(p.type)) continue;
+          if (Math.hypot(x - p.x, y - p.y) < dist) return false;
+        }
+        return true;
+      }
+
+      function recordPlacement(type, x, y){
+        const cfg = meta[type];
+        if (!cfg) return null;
+        const obj = {
+          img: cfg.img,
+          x,
+          y,
+          sortY: y,
+          anchor: cfg.anchor,
+        };
+        if (cfg.width) obj.w = cfg.width;
+        if (cfg.height) obj.h = cfg.height;
+        if (cfg.collider) obj.collider = { ...cfg.collider };
+        const placement = { type, x, y, obj };
+        placements.push(placement);
+        results.push(obj);
+        return placement;
+      }
+
+      function findPosition(opts = {}){
+        const attempts = opts.attempts || TERRAIN_BASE_ATTEMPTS;
+        const avoidUntil = opts.allowCenterAfter != null ? opts.allowCenterAfter : Math.floor(attempts * 0.6);
+        for (let i = 0; i < attempts; i++){
+          const x = Math.round(rand(minX, maxX));
+          const y = Math.round(rand(minY, maxY));
+          if (!withinBounds(x, y)) continue;
+          if (i < avoidUntil && inCenterClear(x, y)) continue;
+          if (!hasSpacing(x, y)) continue;
+          if (opts.filter && !opts.filter(x, y)) continue;
+          return { x, y };
+        }
+        return null;
+      }
+
+      function placeGeneral(type, opts = {}){
+        const primary = findPosition(opts);
+        if (primary) return recordPlacement(type, primary.x, primary.y);
+        const relaxed = findPosition({ ...opts, allowCenterAfter: 0 });
+        if (!relaxed) return null;
+        return recordPlacement(type, relaxed.x, relaxed.y);
+      }
+
+      function placeNear(type, target, range = {}, filter){
+        if (!target || counts[type] <= 0) return null;
+        const min = range.min != null ? range.min : TERRAIN_MIN_DISTANCE;
+        const max = range.max != null ? Math.max(range.max, min) : min + 160;
+        const attempts = range.attempts || TERRAIN_BASE_ATTEMPTS;
+        for (let phase = 0; phase < 2; phase++){
+          for (let i = 0; i < attempts; i++){
+            const dist = rand(min, max);
+            const angle = rand(0, Math.PI * 2);
+            const x = Math.round(target.x + Math.cos(angle) * dist);
+            const y = Math.round(target.y + Math.sin(angle) * dist);
+            if (!withinBounds(x, y)) continue;
+            if (phase === 0 && inCenterClear(x, y)) continue;
+            if (!hasSpacing(x, y, target)) continue;
+            const actual = Math.hypot(x - target.x, y - target.y);
+            if (actual < min || actual > max) continue;
+            if (filter && !filter(x, y)) continue;
+            return recordPlacement(type, x, y);
+          }
+        }
+        return null;
+      }
+
+      function placeRemaining(type, opts){
+        while (counts[type] > 0){
+          const placed = placeGeneral(type, opts);
+          if (!placed) break;
+          counts[type]--;
+        }
+      }
+
+      const treeNearRock = counts.tree01 > 0 ? placeGeneral('tree01') : null;
+      if (treeNearRock) counts.tree01--;
+      if (treeNearRock && counts.rock04 > 0){
+        let rockBesideTree = placeNear('rock04', treeNearRock, { min: TERRAIN_MIN_DISTANCE, max: TERRAIN_MIN_DISTANCE + 140 });
+        if (!rockBesideTree){
+          rockBesideTree = placeNear('rock04', treeNearRock, { min: TERRAIN_MIN_DISTANCE, max: TERRAIN_MIN_DISTANCE + 220, attempts: TERRAIN_BASE_ATTEMPTS * 2 });
+        }
+        if (rockBesideTree) counts.rock04--;
+      }
+
+      const treeNearBush = counts.tree02 > 0 ? placeGeneral('tree02') : null;
+      if (treeNearBush) counts.tree02--;
+      if (treeNearBush && counts.bush01 > 0){
+        let bushBesideTree = placeNear('bush01', treeNearBush, { min: TERRAIN_MIN_DISTANCE, max: TERRAIN_MIN_DISTANCE + 140 });
+        if (!bushBesideTree){
+          bushBesideTree = placeNear('bush01', treeNearBush, { min: TERRAIN_MIN_DISTANCE, max: TERRAIN_MIN_DISTANCE + 220, attempts: TERRAIN_BASE_ATTEMPTS * 2 });
+        }
+        if (bushBesideTree) counts.bush01--;
+      }
+
+      const bushNearRock = counts.bush02 > 0 ? placeGeneral('bush02', { filter: (x, y) => farFromTrees(x, y, 220) }) : null;
+      if (bushNearRock) counts.bush02--;
+      if (bushNearRock && counts.rock02 > 0){
+        let rockByBush = placeNear('rock02', bushNearRock, { min: TERRAIN_MIN_DISTANCE, max: TERRAIN_MIN_DISTANCE + 140 }, (x, y) => farFromTrees(x, y, 200));
+        if (!rockByBush){
+          rockByBush = placeNear('rock02', bushNearRock, { min: TERRAIN_MIN_DISTANCE, max: TERRAIN_MIN_DISTANCE + 220, attempts: TERRAIN_BASE_ATTEMPTS * 2 }, (x, y) => farFromTrees(x, y, 200));
+        }
+        if (rockByBush) counts.rock02--;
+      }
+
+      placeRemaining('tree01');
+      placeRemaining('tree03');
+      placeRemaining('tree04');
+      placeRemaining('bush01');
+      placeRemaining('bush02', { filter: (x, y) => farFromTrees(x, y, 160) });
+      placeRemaining('bush03');
+      placeRemaining('rock01');
+      placeRemaining('rock02', { filter: (x, y) => farFromTrees(x, y, 160) });
+      placeRemaining('rock03');
+      placeRemaining('rock04');
+
+      return results;
+    }
+
     const STAGE_TERRAIN_TEMPLATES = Array.from({ length: MAP_FILES.length }, () => []);
     STAGE_TERRAIN_TEMPLATES[0] = generateStageZeroTerrain;
+    STAGE_TERRAIN_TEMPLATES[1] = generateStageOneTerrain;
 
     let loaded = 0; const need = Object.keys(IMG).length + MAPS.length + 2 + Object.keys(WIZ_ANIM).length + Object.keys(FIGHT_ANIM).length + Object.keys(ROGUE_ANIM).length + Object.keys(GOBLIN_ANIM).length + Object.keys(IMP_ANIM).length + Object.keys(ORC_ANIM).length + Object.keys(MUCK_ANIM).length + Object.keys(HILL_GIANT_ANIM).length + Object.keys(ABOMINATION_ANIM).length + Object.keys(HUNGER_DEMON_ANIM).length + Object.keys(BEHOLDER_ANIM).length + Object.keys(GOAT_ANIM).length + Object.keys(MUCK_PROJECTILE_ANIM).length + Object.keys(HILL_GIANT_PROJECTILE_ANIM).length + Object.keys(SLIME_PROJECTILE_ANIM).length + Object.keys(FIREBALL_PROJECTILE_ANIM).length;
     for (const k in IMG) IMG[k].addEventListener('load', () => { if (++loaded === need) init(); });


### PR DESCRIPTION
## Summary
- load Emberfall forest terrain assets for stage two
- add a terrain generator that distributes trees, bushes, and rocks with spacing and adjacency rules when stage two starts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb17baa68483299d8c092fca245be5