### PR TITLE
Implement multi-phase Muck boss split

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -1606,6 +1606,9 @@
       hungerDemon:  { x: HITBOX.enemy, y: HITBOX.enemy },
       beholder:     { x: HITBOX.enemy, y: HITBOX.enemy },
     };
+    const MUCK_PHASE_SCALES = [1, 0.5, 0.25];
+    const MUCK_PROJECTILE_SCALES = [1, 1, 0.5];
+    const MUCK_PHASE_HP_MULT = [1, 0.5, 0.2];
     function getEnemyHitboxScale(e){
       if (!e) return ENEMY_HITBOX.default;
       if (e.kind === 'boss' && e.bossType && ENEMY_HITBOX[e.bossType]) return ENEMY_HITBOX[e.bossType];
@@ -2221,6 +2224,83 @@
       obj.x = clamp(obj.x, ARENA.x + pad, ARENA.x + ARENA.w - pad);
       obj.y = clamp(obj.y, ARENA.y + pad, ARENA.y + ARENA.h - pad);
     };
+    function createBossTracker(bossType, stageSpd){
+      return { bossType, stageSpd, nodes: new Set(), hp: 0, hpMax: 1, rewardScore: 2000 };
+    }
+    function recalcBossTracker(tracker){
+      if (!tracker) return;
+      let hp = 0;
+      let hpMax = 0;
+      for (const entity of tracker.nodes){
+        if (!entity || entity.hp <= 0){
+          tracker.nodes.delete(entity);
+          continue;
+        }
+        hp += Math.max(0, entity.hp);
+        hpMax += entity.hpMax || 0;
+      }
+      tracker.hp = hp;
+      tracker.hpMax = hpMax > 0 ? hpMax : 1;
+    }
+    function registerBossEntity(entity, tracker){
+      if (!tracker) return entity;
+      tracker.nodes.add(entity);
+      entity.bossController = tracker;
+      recalcBossTracker(tracker);
+      return entity;
+    }
+    function unregisterBossEntity(entity){
+      const tracker = entity && entity.bossController;
+      if (!tracker) return;
+      tracker.nodes.delete(entity);
+      recalcBossTracker(tracker);
+    }
+    function createMuckBossEntity(tracker, generation, x, y, options = {}){
+      const baseSize = tracker && tracker.muckBaseSize ? tracker.muckBaseSize : { w: ENEMY.w*4*1.5, h: ENEMY.h*4*1.5 };
+      const baseHp = tracker && tracker.baseHp ? tracker.baseHp : Math.max(1, options.baseHp || 30);
+      const stageSpd = tracker && tracker.stageSpd ? tracker.stageSpd : 1;
+      const scale = MUCK_PHASE_SCALES[generation] ?? MUCK_PHASE_SCALES[MUCK_PHASE_SCALES.length - 1];
+      const hpMult = MUCK_PHASE_HP_MULT[generation] ?? MUCK_PHASE_HP_MULT[MUCK_PHASE_HP_MULT.length - 1];
+      const hp = Math.max(1, Math.round(baseHp * hpMult));
+      const entity = registerBossEntity({
+        kind:'boss',
+        bossType:'muck',
+        x,
+        y,
+        vx:0,
+        vy:0,
+        kx:0,
+        ky:0,
+        w: baseSize.w * scale,
+        h: baseSize.h * scale,
+        hp,
+        hpMax: hp,
+        spd: options.spd ?? (75 * stageSpd),
+        score: options.score ?? (generation === 0 ? (tracker ? tracker.rewardScore : 2000) : 0),
+        t:0,
+        ang:0,
+        wanderT:0,
+        dir:'down',
+        frame:0,
+        animT:0,
+        atkT:0,
+        blastT:0,
+        facing:0,
+        freezeT:0,
+        pulse:0,
+        nextAtk:'pulse',
+        rayT:0,
+        sleepT:0,
+        sleepMax:0,
+      }, tracker);
+      entity.projectileScale = MUCK_PROJECTILE_SCALES[generation] ?? 1;
+      entity.muckGeneration = generation;
+      entity.muckBaseHp = baseHp;
+      entity.muckBaseSize = baseSize;
+      enemies.push(entity);
+      clampToArena(entity, Math.max(24, Math.min(entity.w, entity.h) * 0.5));
+      return entity;
+    }
     const len = (x,y)=>Math.hypot(x,y);
     const norm = (x,y)=>{const l=Math.hypot(x,y)||1;return [x/l,y/l];};
     const angleDiff = (a,b)=>Math.atan2(Math.sin(a-b),Math.cos(a-b));
@@ -2313,14 +2393,46 @@
       }
       // Reduce boss health by 50%
       hp *= 0.5;
-        const b = { kind:'boss', bossType, x, y, vx:0, vy:0, kx:0, ky:0, w:ENEMY.w*4*1.5, h:ENEMY.h*4*1.5, hp, hpMax:hp, spd:75 * stageSpd, score:2000, t:0, ang:0, wanderT:0, dir:'down', frame:0, animT:0, atkT:0, blastT:0, facing:0, freezeT:0, pulse:0, nextAtk:'pulse', rayT:0, sleepT:0, sleepMax:0 };
-      if (bossType === 'hillGiant') b.slamCd = 3;
+      const tracker = createBossTracker(bossType, stageSpd);
+      tracker.rewardScore = 2000;
+      tracker.baseHp = hp;
       switchMusic(BOSS_TRACKS);
-      enemies.push(b);
-      return b;
+      if (bossType === 'muck'){
+        tracker.muckBaseSize = { w: ENEMY.w*4*1.5, h: ENEMY.h*4*1.5 };
+        createMuckBossEntity(tracker, 0, x, y, { spd: 75 * stageSpd, score: tracker.rewardScore });
+      } else {
+        const b = registerBossEntity({
+          kind:'boss', bossType, x, y, vx:0, vy:0, kx:0, ky:0,
+          w:ENEMY.w*4*1.5, h:ENEMY.h*4*1.5,
+          hp, hpMax:hp,
+          spd:75* stageSpd,
+          score:2000,
+          t:0,
+          ang:0,
+          wanderT:0,
+          dir:'down',
+          frame:0,
+          animT:0,
+          atkT:0,
+          blastT:0,
+          facing:0,
+          freezeT:0,
+          pulse:0,
+          nextAtk:'pulse',
+          rayT:0,
+          sleepT:0,
+          sleepMax:0,
+        }, tracker);
+        if (bossType === 'hillGiant') b.slamCd = 3;
+        enemies.push(b);
+      }
+      return tracker;
     }
-
     function handleBossDefeat(){
+      const tracker = boss;
+      if (tracker && tracker.nodes && typeof tracker.nodes.clear === 'function'){
+        tracker.nodes.clear();
+      }
       boss = null;
       BOSS_PROJECTILES = [];
       awaitingStage = true;
@@ -2352,6 +2464,50 @@
       drops.push({ x, y, w:DROP.w, h:DROP.h, t:0, kind:'key', v: rand(40,70), a: rand(0,Math.PI*2) });
     }
     function dropHeart(x,y){ drops.push({ x, y, w:DROP.w, h:DROP.h, t:0, kind:'heart', v: rand(40,70), a: rand(0,Math.PI*2) }); }
+
+    function handleMuckBossDeath(e){
+      if (!e) return { defeated: true };
+      const tracker = e.bossController;
+      if (!tracker){
+        return { defeated: true };
+      }
+      tracker.nodes.delete(e);
+      const baseSize = tracker.muckBaseSize || { w: ENEMY.w*4*1.5, h: ENEMY.h*4*1.5 };
+      const generation = e.muckGeneration || 0;
+      if (generation === 0){
+        const spread = Math.max(32, (baseSize.w || e.w) * 0.35);
+        const offsets = [
+          { x: -spread, y: 0 },
+          { x: spread, y: 0 },
+        ];
+        for (const off of offsets){
+          createMuckBossEntity(tracker, 1, e.x + off.x, e.y + off.y);
+        }
+        recalcBossTracker(tracker);
+        return { defeated: false };
+      }
+      if (generation === 1){
+        const spreadX = Math.max(26, (baseSize.w || e.w) * 0.3);
+        const spreadY = Math.max(26, (baseSize.h || e.h) * 0.25);
+        const offsets = [
+          { x: -spreadX, y: -spreadY },
+          { x: spreadX, y: -spreadY },
+          { x: -spreadX, y: spreadY },
+          { x: spreadX, y: spreadY },
+        ];
+        for (const off of offsets){
+          createMuckBossEntity(tracker, 2, e.x + off.x, e.y + off.y);
+        }
+        recalcBossTracker(tracker);
+        return { defeated: false };
+      }
+      recalcBossTracker(tracker);
+      if (tracker.nodes.size === 0){
+        if (tracker.rewardScore != null) e.score = tracker.rewardScore;
+        return { defeated: true };
+      }
+      return { defeated: false };
+    }
 
     function polymorphEnemy(e){
       if (!e || e.hp <= 0 || e.kind === 'boss' || e.kind === 'goatCoin' || e.kind === 'goatHeart') return;
@@ -2423,8 +2579,19 @@
       e.hp -= dmg;
       spark(e.x,e.y,'#aef');
       playEnemyHit(e);
+      if (e.kind === 'boss' && e.bossController){
+        recalcBossTracker(e.bossController);
+      }
       if (e.hp<=0){
         if (e.kind === 'boss'){
+          if (e.bossType === 'muck'){
+            const result = handleMuckBossDeath(e);
+            if (!result.defeated){
+              return;
+            }
+          } else {
+            unregisterBossEntity(e);
+          }
           if (e.bossType === 'muck') playSfx('bossMudMonsterKilled');
           else if (e.bossType === 'hillGiant') playSfx('bossHillGiantKilled');
           else if (e.bossType === 'abomination') playSfx('bossAbominationKilled');
@@ -2988,7 +3155,7 @@
               if (e.bossType === 'muck'){
                 const vx = Math.cos(e.facing)*140;
                 const vy = Math.sin(e.facing)*140;
-                BOSS_PROJECTILES.push({ kind:'muck', dir: vx < 0 ? 'left' : 'right', x:e.x, y:e.y, vx, vy, life:0, ttl:3, frame:0, animT:0 });
+                BOSS_PROJECTILES.push({ kind:'muck', dir: vx < 0 ? 'left' : 'right', x:e.x, y:e.y, vx, vy, life:0, ttl:3, frame:0, animT:0, scale: e.projectileScale || 1 });
               } else if (e.bossType === 'hillGiant') {
                 const vx = Math.cos(e.facing)*280;
                 const vy = Math.sin(e.facing)*280;
@@ -3395,7 +3562,8 @@
           if (p.animT >= 0.12){ p.animT = 0; p.frame = (p.frame + 1) % 4; }
         }
         if (p.life > p.ttl){ BOSS_PROJECTILES.splice(i,1); continue; }
-        if (len(p.x-P.x,p.y-P.y) < 20){
+        const hitRadius = 20 * (p.scale || 1);
+        if (len(p.x-P.x,p.y-P.y) < hitRadius){
           if (P.iT<=0){
             const dmg = p.dmg || 1;
             if (CHEAT.active){ pushPlayerByVector(p.vx, p.vy); P.hitFlash=0.25; spark(P.x,P.y,'#ff8a8a'); }
@@ -3872,9 +4040,14 @@
             ctx.stroke();
           } else if (bp.kind === 'muck'){
             const sheet = MUCK_PROJECTILE_ANIM[bp.dir];
-            const fw = sheet.width / 4;
-            const fh = sheet.height;
-            ctx.drawImage(sheet, bp.frame * fw, 0, fw, fh, bp.x - fw/2, bp.y - fh/2, fw, fh);
+            if (sheet && sheet.width){
+              const fw = sheet.width / 4;
+              const fh = sheet.height;
+              const scale = bp.scale || 1;
+              const dw = fw * scale;
+              const dh = fh * scale;
+              ctx.drawImage(sheet, bp.frame * fw, 0, fw, fh, bp.x - dw/2, bp.y - dh/2, dw, dh);
+            }
           } else if (bp.kind === 'rock'){
             const sheet = HILL_GIANT_PROJECTILE_ANIM[bp.dir];
             const fw = sheet.width / 4;


### PR DESCRIPTION
## Summary
- add boss tracker utilities to support multi-entity encounters
- update the Muck boss to split into smaller generations with scaled visuals and projectiles
- adjust boss health bar updates and projectile collision radii to respect scaled projectiles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb7f4a2fe08329be7582100138ee0f