### PR TITLE
Adjust baby beholder behavior in Emberfall

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -2332,6 +2332,7 @@
       const baseX = parent && typeof parent.x === 'number' ? parent.x : ARENA.x + ARENA.w / 2;
       const baseY = parent && typeof parent.y === 'number' ? parent.y : ARENA.y + ARENA.h / 2;
       const baseFacing = parent && typeof parent.facing === 'number' ? parent.facing : 0;
+      const parentSpd = parent && typeof parent.spd === 'number' ? parent.spd : 75 * stageSpd;
       const baby = {
         kind:'babyBeholder',
         x: clamp(baseX + rand(-28, 28), ARENA.x + 16, ARENA.x + ARENA.w - 16),
@@ -2344,8 +2345,8 @@
         h: height,
         hp,
         hpMax: hp,
-        spd: 65 * stageSpd,
-        score: 400,
+        spd: parentSpd * 0.5,
+        score: 50,
         t:0,
         ang: Math.random() * Math.PI * 2,
         wanderT: 0,
@@ -3196,7 +3197,7 @@
             if (e.bossType === 'beholder') e.rayT = (e.rayT || 0) + dt;
             if (e.bossType === 'beholder'){
               e.minionTimer = (e.minionTimer || 0) + dt;
-              if (e.minionTimer >= 3){
+              if (e.minionTimer >= 5){
                 e.minionTimer = 0;
                 let babies = 0;
                 for (const other of enemies){
@@ -3326,22 +3327,24 @@
             e.rayT = (e.rayT || 0) + dt;
             if (e.freezeT <= 0 && e.atkT >= 2){
               e.atkT = 0;
-              const count = 8;
               const slowSpeed = 45;
               const fastSpeed = 90;
               const pushDist = 50;
-              for (let i=0; i<count; i++){
-                const ang = (Math.PI*2 / count) * i;
-                const vxSlow = Math.cos(ang) * slowSpeed;
-                const vySlow = Math.sin(ang) * slowSpeed;
-                BOSS_PROJECTILES.push({ kind:'slime', source:'babyBeholder', dmg:1, dir: vxSlow < 0 ? 'left' : 'right', x:e.x, y:e.y, vx:vxSlow, vy:vySlow, life:0, ttl:2, frame:0, animT:0, scale:0.5, push:pushDist });
-                const vxFast = Math.cos(ang) * fastSpeed;
-                const vyFast = Math.sin(ang) * fastSpeed;
-                BOSS_PROJECTILES.push({ kind:'slime', source:'babyBeholder', dmg:0.5, dir: vxFast < 0 ? 'left' : 'right', x:e.x, y:e.y, vx:vxFast, vy:vyFast, life:0, ttl:1, frame:0, animT:0, scale:0.5, push:pushDist });
-              }
+              const aimAng = Math.atan2(dy, dx);
+              const dirX = Math.cos(aimAng);
+              const dirY = Math.sin(aimAng);
+              const rangeMultiplier = 2;
+              const slowTtl = 2 * rangeMultiplier;
+              const fastTtl = 1 * rangeMultiplier;
+              const vxSlow = dirX * slowSpeed;
+              const vySlow = dirY * slowSpeed;
+              BOSS_PROJECTILES.push({ kind:'slime', source:'babyBeholder', dmg:1, dir: vxSlow < 0 ? 'left' : 'right', x:e.x, y:e.y, vx:vxSlow, vy:vySlow, life:0, ttl:slowTtl, frame:0, animT:0, scale:0.5, push:pushDist });
+              const vxFast = dirX * fastSpeed;
+              const vyFast = dirY * fastSpeed;
+              BOSS_PROJECTILES.push({ kind:'slime', source:'babyBeholder', dmg:0.5, dir: vxFast < 0 ? 'left' : 'right', x:e.x, y:e.y, vx:vxFast, vy:vyFast, life:0, ttl:fastTtl, frame:0, animT:0, scale:0.5, push:pushDist });
               if (e.rayT >= 4){
-                const beamAng = Math.atan2(dy, dx);
-                BOSS_PROJECTILES.push({ kind:'beam', source:'babyBeholder', dmg:0.5, x:e.x, y:e.y, ang:beamAng, life:0, ttl:0.5, scale:0.5, push:50, length:120 });
+                const beamAng = aimAng;
+                BOSS_PROJECTILES.push({ kind:'beam', source:'babyBeholder', dmg:0.5, x:e.x, y:e.y, ang:beamAng, life:0, ttl:0.5, scale:0.5, push:50, length:240 });
                 e.rayT = 0;
               }
             }


### PR DESCRIPTION
## Summary
- slow the beholder boss's minion spawns to one baby every five seconds while keeping the cap at five active
- make baby beholders award standard enemy XP and move at half the beholder boss's speed
- rework baby beholder attacks to fire two long-range shots toward the player and extend their beam reach

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd3b7b6cc48329ada9b3b15791c23b