### PR TITLE
Adjust baby beholder behaviour on stage 5

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -2333,6 +2333,7 @@
       const baseY = parent && typeof parent.y === 'number' ? parent.y : ARENA.y + ARENA.h / 2;
       const baseFacing = parent && typeof parent.facing === 'number' ? parent.facing : 0;
       const parentSpd = parent && typeof parent.spd === 'number' ? parent.spd : 75 * stageSpd;
+      const babySpeedMult = stage === 4 ? 1.5 : 0.5;
       const baby = {
         kind:'babyBeholder',
         x: clamp(baseX + rand(-28, 28), ARENA.x + 16, ARENA.x + ARENA.w - 16),
@@ -2345,7 +2346,7 @@
         h: height,
         hp,
         hpMax: hp,
-        spd: parentSpd * 0.5,
+        spd: parentSpd * babySpeedMult,
         score: 50,
         t:0,
         ang: Math.random() * Math.PI * 2,
@@ -3327,21 +3328,30 @@
             e.rayT = (e.rayT || 0) + dt;
             if (e.freezeT <= 0 && e.atkT >= 2){
               e.atkT = 0;
-              const slowSpeed = 45;
-              const fastSpeed = 90;
+              const baseBossSpeed = 180;
+              const baseBossTtl = 2;
+              const bossRange = baseBossSpeed * baseBossTtl;
+              const projectileSpeed = baseBossSpeed * 2;
+              const projectileRange = bossRange * 2;
+              const projectileTtl = projectileRange / projectileSpeed;
               const pushDist = 50;
               const aimAng = Math.atan2(dy, dx);
               const dirX = Math.cos(aimAng);
               const dirY = Math.sin(aimAng);
-              const rangeMultiplier = 2;
-              const slowTtl = 2 * rangeMultiplier;
-              const fastTtl = 1 * rangeMultiplier;
-              const vxSlow = dirX * slowSpeed;
-              const vySlow = dirY * slowSpeed;
-              BOSS_PROJECTILES.push({ kind:'slime', source:'babyBeholder', dmg:1, dir: vxSlow < 0 ? 'left' : 'right', x:e.x, y:e.y, vx:vxSlow, vy:vySlow, life:0, ttl:slowTtl, frame:0, animT:0, scale:0.5, push:pushDist });
-              const vxFast = dirX * fastSpeed;
-              const vyFast = dirY * fastSpeed;
-              BOSS_PROJECTILES.push({ kind:'slime', source:'babyBeholder', dmg:0.5, dir: vxFast < 0 ? 'left' : 'right', x:e.x, y:e.y, vx:vxFast, vy:vyFast, life:0, ttl:fastTtl, frame:0, animT:0, scale:0.5, push:pushDist });
+              const vx = dirX * projectileSpeed;
+              const vy = dirY * projectileSpeed;
+              const perpX = -dirY;
+              const perpY = dirX;
+              const offset = 12;
+              const projectiles = [
+                { off: offset, dmg: 1 },
+                { off: -offset, dmg: 0.5 },
+              ];
+              for (const proj of projectiles){
+                const px = e.x + perpX * proj.off;
+                const py = e.y + perpY * proj.off;
+                BOSS_PROJECTILES.push({ kind:'slime', source:'babyBeholder', dmg:proj.dmg, dir: vx < 0 ? 'left' : 'right', x:px, y:py, vx, vy, life:0, ttl:projectileTtl, frame:0, animT:0, scale:0.5, push:pushDist });
+              }
               if (e.rayT >= 4){
                 const beamAng = aimAng;
                 BOSS_PROJECTILES.push({ kind:'beam', source:'babyBeholder', dmg:0.5, x:e.x, y:e.y, ang:beamAng, life:0, ttl:0.5, scale:0.5, push:50, length:240 });
@@ -3974,7 +3984,7 @@
             const fh = sheet.height;
             ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
           }
-          const skipStunStars = e.kind === 'boss' && e.bossType === 'abomination';
+          const skipStunStars = (e.kind === 'boss' && e.bossType === 'abomination') || e.kind === 'babyBeholder';
           if (e.freezeT && e.freezeT > 0 && !skipStunStars){
             const cx = e.x;
             const cy = e.y - e.h * 0.85;


### PR DESCRIPTION
## Summary
- speed up stage 5 baby beholders so they move faster than the beholder boss
- update their projectile pattern to fire a fast twin shot with doubled range compared to the boss
- stop baby beholders from showing stun stars so pausing no longer displays the effect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdaa6fee708329b45e99bfee420eb9