### PR TITLE
Hide Stage 5 boss pause stars

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -3984,7 +3984,10 @@
             const fh = sheet.height;
             ctx.drawImage(sheet, e.frame * fw, 0, fw, fh, e.x - e.w/2, e.y - e.h/2 - 6, e.w, e.h + 6);
           }
-          const skipStunStars = (e.kind === 'boss' && e.bossType === 'abomination') || e.kind === 'babyBeholder';
+          const skipStunStars =
+            (e.kind === 'boss' && e.bossType === 'abomination') ||
+            e.kind === 'babyBeholder' ||
+            (paused && e.kind === 'boss' && e.bossType === 'beholder');
           if (e.freezeT && e.freezeT > 0 && !skipStunStars){
             const cx = e.x;
             const cy = e.y - e.h * 0.85;


### PR DESCRIPTION
## Summary
- prevent the stage 5 beholder boss from drawing stun stars while the game is paused

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdae94abdc832998b86eb2099ab721