### PR TITLE
Double hill giant cone radius

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -4575,7 +4575,7 @@
           if (e.bossType === 'hillGiant'){
             e.slamCd = (e.slamCd||0) - dt;
             if (!e.slam && e.slamCd <= 0){
-              e.slam = { t:0, tele:0.8, arc:Math.PI/2, range:120, done:false };
+              e.slam = { t:0, tele:0.8, arc:Math.PI/2, range:240, done:false };
               e.slamCd = 5;
             }
             if (e.slam){


### PR DESCRIPTION
## Summary
- double the hill giant boss slam cone radius to expand its damage reach during stage 2

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d27b3544388329b8fe8b15608ce5cf