### PR TITLE
Adjust Emberfall enemy scaling across later stages

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -3539,6 +3539,25 @@
     }
 
     // Spawning
+    function getStageEnemyModifiers(stageIndex = stage){
+      const displayStage = (stageIndex | 0) + 1;
+      const hp = { imp: 0, goblin: 0, orc: 0 };
+      const dmg = { imp: 0, goblin: 0, orc: 0 };
+      if (displayStage >= 2){
+        hp.imp += 1; hp.goblin += 1; hp.orc += 2;
+      }
+      if (displayStage >= 4){
+        hp.imp += 1; hp.goblin += 1; hp.orc += 2;
+      }
+      if (displayStage >= 3){
+        dmg.imp += 2; dmg.goblin += 1; dmg.orc += 1;
+      }
+      if (displayStage >= 5){
+        dmg.imp += 2; dmg.goblin += 1; dmg.orc += 1;
+      }
+      return { hp, dmg };
+    }
+
     function spawnEnemy(){
       // Spawn outside player vicinity along arena edges
       const side = Math.floor(Math.random()*4);
@@ -3557,14 +3576,24 @@
 
       // Stats per type
       const stageSpd = Math.pow(1.2, stage);
+      const mods = getStageEnemyModifiers(stage);
       let w=ENEMY.w, h=ENEMY.h, spd=ENEMY.spd * stageSpd, hp=2+Math.floor(SPAWN.wave/2), score=50;
+      let contactDmg = 1 + mods.dmg.goblin;
       // Make imp a bit faster than baseline and orc slower; reward orcs more
-      if (kind==='imp'){ w=22; h=18; spd=130 * stageSpd; hp=Math.max(1,1+Math.floor(SPAWN.wave/3)); score=40; }
-      else if (kind==='orc'){ w=ENEMY.w*2; h=ENEMY.h*2; spd=60 * stageSpd; hp=(3+Math.floor(SPAWN.wave/1.5))*3; score=240; }
+      if (kind==='imp'){
+        w=22; h=18; spd=130 * stageSpd; hp=Math.max(1,1+Math.floor(SPAWN.wave/3)) + mods.hp.imp; score=40;
+        contactDmg = 1 + mods.dmg.imp;
+      }
+      else if (kind==='orc'){
+        w=ENEMY.w*2; h=ENEMY.h*2; spd=60 * stageSpd; hp=(3+Math.floor(SPAWN.wave/1.5))*3 + mods.hp.orc; score=240;
+        contactDmg = 1 + mods.dmg.orc;
+      } else {
+        hp += mods.hp.goblin;
+      }
       w *= 1.75;
       h *= 1.75;
 
-      const enemy = { kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0, sleepT:0, sleepMax:0 };
+      const enemy = { kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0, sleepT:0, sleepMax:0, contactDmg };
       if (needsKeys() && !SPAWN.keyAssigned){ enemy.hasKey = true; SPAWN.keyAssigned = true; }
       enemies.push(enemy);
     }
@@ -3579,6 +3608,7 @@
       if (side === 3) { x = ARENA.x + 10; y = rand(ARENA.y + 16, ARENA.y + ARENA.h - 16); }
 
       const stageSpd = Math.pow(1.2, stage);
+      const mods = getStageEnemyModifiers(stage);
       const waveForStats = Math.max(1, SPAWN.wave || STAGE_WAVES);
       const enemy = {
         kind: 'goblin',
@@ -3590,7 +3620,7 @@
         ky: 0,
         w: ENEMY.w * 1.75,
         h: ENEMY.h * 1.75,
-        hp: 2 + Math.floor(waveForStats / 2),
+        hp: 2 + Math.floor(waveForStats / 2) + mods.hp.goblin,
         spd: ENEMY.spd * stageSpd,
         score: 50,
         t: 0,
@@ -3601,6 +3631,7 @@
         animT: 0,
         sleepT: 0,
         sleepMax: 0,
+        contactDmg: 1 + mods.dmg.goblin,
       };
       enemies.push(enemy);
       return enemy;
@@ -3626,8 +3657,9 @@
       const stageSpd = Math.pow(1.2, stage);
       const w = 22 * 1.75;
       const h = 18 * 1.75;
+      const mods = getStageEnemyModifiers(stage);
       const baseHp = Math.max(1, 1 + Math.floor(Math.max(1, SPAWN.wave) / 3));
-      const hp = baseHp * 2;
+      const hp = baseHp * 2 + mods.hp.imp;
       const enemy = {
         kind: 'imp',
         variant: 'green',
@@ -3651,7 +3683,7 @@
         animT: 0,
         sleepT: 0,
         sleepMax: 0,
-        contactDmg: 2,
+        contactDmg: 2 + mods.dmg.imp,
       };
       enemies.push(enemy);
       return enemy;


### PR DESCRIPTION
## Summary
- add a helper to calculate stage-based health and damage bonuses for Emberfall enemies
- apply the new scaling rules to standard spawns, hill giant goblins, and hunger demon minions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d60c99f98c83298e2ca4442f5e9ef3