### PR TITLE
Adjust Emberfall enemy scaling per stage

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -3539,6 +3539,31 @@
     }
 
     // Spawning
+    function getEnemyStageBonuses(){
+      const hp = { imp: 0, goblin: 0, orc: 0 };
+      const dmg = { imp: 0, goblin: 0, orc: 0 };
+      if (stage >= 1){
+        hp.imp += 1;
+        hp.goblin += 1;
+        hp.orc += 2;
+      }
+      if (stage >= 3){
+        hp.imp += 1;
+        hp.goblin += 1;
+        hp.orc += 2;
+      }
+      if (stage >= 2){
+        dmg.imp += 2;
+        dmg.goblin += 1;
+        dmg.orc += 1;
+      }
+      if (stage >= 4){
+        dmg.imp += 2;
+        dmg.goblin += 1;
+        dmg.orc += 1;
+      }
+      return { hp, dmg };
+    }
     function spawnEnemy(){
       // Spawn outside player vicinity along arena edges
       const side = Math.floor(Math.random()*4);
@@ -3561,10 +3586,15 @@
       // Make imp a bit faster than baseline and orc slower; reward orcs more
       if (kind==='imp'){ w=22; h=18; spd=130 * stageSpd; hp=Math.max(1,1+Math.floor(SPAWN.wave/3)); score=40; }
       else if (kind==='orc'){ w=ENEMY.w*2; h=ENEMY.h*2; spd=60 * stageSpd; hp=(3+Math.floor(SPAWN.wave/1.5))*3; score=240; }
+      const bonuses = getEnemyStageBonuses();
+      const hpBonus = bonuses.hp[kind] || 0;
+      const dmgBonus = bonuses.dmg[kind] || 0;
+      hp += hpBonus;
       w *= 1.75;
       h *= 1.75;
 
       const enemy = { kind, x, y, vx:0, vy:0, kx:0, ky:0, w, h, hp, spd, score, t:0, ang: Math.random()*Math.PI*2, wanderT: 0, dir:'down', frame:0, animT:0, sleepT:0, sleepMax:0 };
+      enemy.contactDmg = 1 + dmgBonus;
       if (needsKeys() && !SPAWN.keyAssigned){ enemy.hasKey = true; SPAWN.keyAssigned = true; }
       enemies.push(enemy);
     }
@@ -3580,6 +3610,9 @@
 
       const stageSpd = Math.pow(1.2, stage);
       const waveForStats = Math.max(1, SPAWN.wave || STAGE_WAVES);
+      const bonuses = getEnemyStageBonuses();
+      const goblinHpBonus = bonuses.hp.goblin || 0;
+      const goblinDmgBonus = bonuses.dmg.goblin || 0;
       const enemy = {
         kind: 'goblin',
         x,
@@ -3590,7 +3623,7 @@
         ky: 0,
         w: ENEMY.w * 1.75,
         h: ENEMY.h * 1.75,
-        hp: 2 + Math.floor(waveForStats / 2),
+        hp: 2 + Math.floor(waveForStats / 2) + goblinHpBonus,
         spd: ENEMY.spd * stageSpd,
         score: 50,
         t: 0,
@@ -3602,6 +3635,7 @@
         sleepT: 0,
         sleepMax: 0,
       };
+      enemy.contactDmg = 1 + goblinDmgBonus;
       enemies.push(enemy);
       return enemy;
     }
@@ -3627,7 +3661,8 @@
       const w = 22 * 1.75;
       const h = 18 * 1.75;
       const baseHp = Math.max(1, 1 + Math.floor(Math.max(1, SPAWN.wave) / 3));
-      const hp = baseHp * 2;
+      const bonuses = getEnemyStageBonuses();
+      const hp = baseHp * 2 + (bonuses.hp.imp || 0);
       const enemy = {
         kind: 'imp',
         variant: 'green',
@@ -3651,7 +3686,7 @@
         animT: 0,
         sleepT: 0,
         sleepMax: 0,
-        contactDmg: 2,
+        contactDmg: 2 + (bonuses.dmg.imp || 0),
       };
       enemies.push(enemy);
       return enemy;


### PR DESCRIPTION
## Summary
- add a helper to compute stage-based health and damage bonuses for Emberfall imps, goblins, and orcs
- apply the bonuses to standard spawns, hill giant goblins, and hunger demon minions so they scale through later stages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d694eb02448329938177e7613e6824