### PR TITLE
Increase Stage 3 evil fairy boss durability

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -3724,7 +3724,8 @@
         tracker.pendingAbominationType = 'abomination';
         tracker.pendingTentacleInterval = 5;
         switchMusic(BOSS_TRACKS);
-        const fairyHp = Math.max(1, Math.round(scaledHp * 0.5));
+        // Tougher Stage 3 boss: double the evil fairy's health (was scaledHp * 0.5)
+        const fairyHp = Math.max(1, Math.round(scaledHp));
         const fairySizeMult = 0.5;
         const fairy = registerBossEntity({
           kind:'boss', bossType:'evilFairy', x, y, vx:0, vy:0, kx:0, ky:0,


### PR DESCRIPTION
## Summary
- double the Stage 3 evil fairy boss health to make the encounter tougher
- document the change inline for future reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c56c7dc48329bbd4b81683f86e1f