### PR TITLE
Add art for wizard sleep and wisdom upgrades

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -3041,8 +3041,10 @@
       wizard: {
         orbs: 'assets/EG_ability_wizard_arcaneOrbs_small.png',
         nova: 'assets/EG_ability_wizard_frostNova_small.png',
+        sleep: 'assets/EG_ability_wizard_sleep_small.png',
         shards: 'assets/EG_ability_wizard_arcaneMissile_small.png',
         focus: 'assets/EG_ability_wizard_spellFocus_small.png',
+        wisdom: 'assets/EG_ability_wizard_wisdom_small.png',
       },
     };
 


### PR DESCRIPTION
## Summary
- map the wizard sleep and wisdom upgrades to their dedicated art assets so the shop displays the new visuals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6db5ed0d083299b5a825268484a8c