### PR TITLE
Associate rogue dagger storm upgrade art

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -3035,7 +3035,7 @@
         crit: 'assets/EG_ability_rogue_deadlyPrecision_small.png',
         dodge: 'assets/EG_ability_rogue_evasion_small.png',
         heart: 'assets/EG_ability_rogue_secondWind_small.png',
-        // No specific art available for Blade Storm; leave blank mapping
+        blade_storm: 'assets/EG_ability_rogue_daggerStorm_small.png',
         barbed: 'assets/EG_ability_rogue_barbedArrows_small.png',
         rapid: 'assets/EG_ability_rogue_rapidShot_small.png',
         fletching: 'assets/EG_ability_rogue_fineFletching_small.png',


### PR DESCRIPTION
## Summary
- connect the rogue's Blade Storm upgrade to the Dagger Storm art asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7fb8905408329a3c2ff6bfbcf27af