### PR TITLE
Clear hill giant goblins after defeat

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -3864,6 +3864,7 @@
         animT: 0,
         sleepT: 0,
         sleepMax: 0,
+        summonedByHillGiant: true,
       };
       applyStageEnemyBonuses('goblin', enemy);
       applyDifficultyEnemyHp(enemy);
@@ -4093,6 +4094,20 @@
     }
     function handleBossDefeat(){
       const tracker = boss;
+      if (tracker && tracker.bossType === 'hillGiant'){
+        const removal = new Set();
+        for (const e of enemies){
+          if (e && e.kind === 'goblin' && e.summonedByHillGiant){
+            removal.add(e);
+            for (let i = 0; i < 6; i++){
+              spark(e.x + rand(-6, 6), e.y + rand(-6, 6), '#ffd27f');
+            }
+          }
+        }
+        if (removal.size){
+          enemies = enemies.filter(e => !removal.has(e));
+        }
+      }
       if (tracker && tracker.nodes && typeof tracker.nodes.clear === 'function'){
         tracker.nodes.clear();
       }


### PR DESCRIPTION
## Summary
- tag goblins spawned by the hill giant as its summons
- clear any summoned goblins with a small dissolve effect when the hill giant is defeated

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db362ead588329a606fcd7142f17c9