### PR TITLE
Adjust smasher collision and platform logic

### DIFF
--- a/core-crisis/index.html
+++ b/core-crisis/index.html
@@ -1075,13 +1075,23 @@
       {
         const bottomPrev = prevY + P.h/2;
         const bottomNow = P.y + P.h/2;
+        const playerCenterX = P.x + (P.hitOffsetX || 0);
+        const playerHalfW = (P.w * (P.hitX || 1)) / 2;
+        const overlapHoriz = (centerX, halfWidth) => {
+          const left = centerX - halfWidth;
+          const right = centerX + halfWidth;
+          return (playerCenterX + playerHalfW) > left && (playerCenterX - playerHalfW) < right;
+        };
+        const canLand = (surfaceY, centerX, halfWidth) => {
+          const overlapX = overlapHoriz(centerX, halfWidth);
+          const crossingDown = (P.vy >= -20) && (bottomPrev <= surfaceY) && (bottomNow >= surfaceY - 1);
+          const stayingOn = (P.vy >= -20) && Math.abs(bottomNow - surfaceY) <= 2;
+          return overlapX && (crossingDown || stayingOn);
+        };
         let onPlat = false;
         for (const pl of platforms) {
           const platTop = pl.y - pl.h/2;
-          const overlapX = Math.abs(P.x - pl.x) * 2 < (pl.w + P.w*0.6);
-          const crossingDown = (P.vy >= -20) && (bottomPrev <= platTop) && (bottomNow >= platTop - 1);
-          const stayingOn = (P.vy >= -20) && Math.abs(bottomNow - platTop) <= 2;
-          if (overlapX && (crossingDown || stayingOn)) {
+          if (canLand(platTop, pl.x, pl.w/2)) {
             P.y = platTop - P.h/2;
             P.onGround = true;
             P.vy = 0;
@@ -1089,7 +1099,22 @@
             break;
           }
         }
-        // If not on any platform and not on ground, ensure air state until ground check below
+        if (!onPlat) {
+          for (const sm of smashers) {
+            if (sm.state !== 'down') continue;
+            const surfaceY = sm.y + sm.h * 0.25;
+            const surfaceCenterX = sm.x + (sm.hitOffsetX || 0);
+            const surfaceHalfW = (sm.w * (sm.hitX || 1)) / 2;
+            if (canLand(surfaceY, surfaceCenterX, surfaceHalfW)) {
+              P.y = surfaceY - P.h/2;
+              P.onGround = true;
+              P.vy = 0;
+              onPlat = true;
+              break;
+            }
+          }
+        }
+        // If not on any platform/smasher and not on ground, ensure air state until ground check below
         if (!onPlat && P.y < GROUND_Y - 0.5) {
           P.onGround = false;
         }
@@ -1302,7 +1327,7 @@
         const w = h * (IMG.smasher.width / IMG.smasher.height);
         const peek = 30;
         const y = -h/2 + peek;
-        smashers.push({ x, y, w, h, state: 'peek', timer: 0.9, dropSpeed: 900, hitX: 0.9, hitY: 1.0, justDropped: 0 });
+        smashers.push({ x, y, w, h, state: 'peek', timer: 0.9, dropSpeed: 900, hitX: 0.9, hitY: 1.0, justDropped: 0, prevY: y });
           smasherTimer = rand(14, 28) / difficulty; // reduced smasher spawn frequency
       }
 
@@ -1329,6 +1354,7 @@
       for (const c of coolants) { c.x = move(c.x); c.t += dt; c.y = (c.baseY ?? c.y) + Math.sin(c.t * 5.0) * 12; }
 
       for (const sm of smashers) {
+        sm.prevY = sm.y;
         sm.x = move(sm.x);
         if (sm.state === 'peek') {
           sm.timer -= dt;
@@ -1557,11 +1583,32 @@
 
         function smasherCrushesPlayer(player, smasher) {
           if (!(smasher.state === 'drop' || smasher.justDropped > 0)) return false;
-          const pb = getBounds(player);
-          const sb = getBounds(smasher);
-          if (pb.cy <= sb.cy) return false;
-          if (pb.top >= sb.bottom) return false;
-          if (pb.cx < sb.left || pb.cx > sb.right) return false;
+
+          const playerCenterX = player.x + (player.hitOffsetX || 0);
+          const playerCenterY = player.y + (player.hitOffsetY || 0);
+          const playerHitW = player.w * (player.hitX || 1);
+          const playerHitH = player.h * (player.hitY || 1);
+          const playerLeft = playerCenterX - playerHitW / 2;
+          const playerRight = playerCenterX + playerHitW / 2;
+          const playerTop = playerCenterY - playerHitH / 2;
+          const playerBottom = playerCenterY + playerHitH / 2;
+          const prevPlayerCenterY = prevY + (player.hitOffsetY || 0);
+          const prevPlayerTop = prevPlayerCenterY - playerHitH / 2;
+
+          const smCenterX = smasher.x + (smasher.hitOffsetX || 0);
+          const smHitW = smasher.w * (smasher.hitX || 1);
+          const smHalfW = smHitW / 2;
+          const damageHeight = smasher.h * 0.25;
+          const damageBottom = smasher.y + smasher.h / 2;
+          const damageTop = damageBottom - damageHeight;
+          const prevDamageBottom = (smasher.prevY ?? smasher.y) + smasher.h / 2;
+
+          if (playerRight <= smCenterX - smHalfW) return false;
+          if (playerLeft >= smCenterX + smHalfW) return false;
+          if (playerBottom <= damageTop) return false;
+          if (playerTop >= damageBottom) return false;
+          if (damageBottom <= prevDamageBottom + 0.5) return false;
+          if (prevPlayerTop < prevDamageBottom - 2) return false;
           return true;
         }
 


### PR DESCRIPTION
## Summary
- let the player treat lowered smashers as temporary platforms by checking landings on the hammer surface
- restrict smasher damage to the bottom quarter using previous-frame tracking so only descending impacts crush the player

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc039f6fb483299544aa625bb549ae