### PR TITLE
Guarantee mid bosses drop double upgrades

### DIFF
--- a/nova-striker/index.html
+++ b/nova-striker/index.html
@@ -625,6 +625,21 @@
 
     // Pickups and upgrades
     function spawnDrop(e) {
+      if (e.boss && e.type !== 'X4') {
+        const offsets = [-18, 18];
+        for (const off of offsets) {
+          drops.push({
+            x: e.x + off,
+            y: e.y,
+            vx: (Math.random()-0.5)*1.2,
+            vy: 1.6,
+            t: 0,
+            type: 'U',
+            kind: pickUpgrade()
+          });
+        }
+        return;
+      }
       // Drop chances; extra life and shield unchanged. Upgrades increased after wave 5.
       const lifeChance = e.boss ? 0.08 : 0.01;     // 8% boss, 1% normal
       // Suppress shield drops if player already has an active shield


### PR DESCRIPTION
## Summary
- ensure each non-final boss in Nova Striker drops two guaranteed upgrade pickups
- maintain existing random drop logic for all other enemies and the final boss

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc62c743788329b53ff700abeafce9