### PR TITLE
Limit hill giant goblins and enrage projectiles

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -2645,7 +2645,9 @@
     let stage = 0;
     const STAGE_WAVES = 2;
     const HUNGER_DEMON_MINION_PERIOD = 2;
-    const HILL_GIANT_GOBLIN_PERIOD = 1;
+    const HILL_GIANT_GOBLIN_LIMIT = 30;
+    const HILL_GIANT_GOBLIN_WINDOW = 10;
+    const HILL_GIANT_GOBLIN_PERIOD = HILL_GIANT_GOBLIN_WINDOW / HILL_GIANT_GOBLIN_LIMIT;
     function updateWaveLimit() {
       const cfg = STAGE_WAVE_COUNTS[stage];
       if (cfg && cfg[SPAWN.wave - 1] != null) {
@@ -3833,6 +3835,11 @@
     }
 
     function spawnHillGiantGoblin(){
+      if (boss && boss.bossType === 'hillGiant'){
+        const limit = boss.goblinSpawnLimit ?? HILL_GIANT_GOBLIN_LIMIT;
+        const spawned = boss.goblinSpawned || 0;
+        if (spawned >= limit) return null;
+      }
       const side = Math.floor(Math.random() * 4);
       let x = ARENA.x + 8;
       let y = ARENA.y + 8;
@@ -3868,6 +3875,9 @@
       };
       applyStageEnemyBonuses('goblin', enemy);
       applyDifficultyEnemyHp(enemy);
+      if (boss && boss.bossType === 'hillGiant'){
+        boss.goblinSpawned = (boss.goblinSpawned || 0) + 1;
+      }
       enemies.push(enemy);
       return enemy;
     }
@@ -4031,6 +4041,11 @@
           b.slamCd = 3;
           tracker.goblinSpawnTimer = 0;
           tracker.goblinSpawnPeriod = HILL_GIANT_GOBLIN_PERIOD;
+          tracker.goblinSpawnLimit = HILL_GIANT_GOBLIN_LIMIT;
+          tracker.goblinSpawnWindow = HILL_GIANT_GOBLIN_WINDOW;
+          tracker.goblinSpawnElapsed = 0;
+          tracker.goblinSpawned = 0;
+          tracker.goblinEnraged = false;
         }
         if (bossType === 'hungerDemon') {
           b.minionTimer = 0;
@@ -4380,6 +4395,25 @@
           if (isMuckGoat && muckResult && muckResult.defeated){
             playSfx('bossMudMonsterKilled');
             handleBossDefeat();
+          }
+          if (e.summonedByHillGiant){
+            if (boss && boss.bossType === 'hillGiant' && !boss.goblinEnraged){
+              const limit = boss.goblinSpawnLimit ?? HILL_GIANT_GOBLIN_LIMIT;
+              const spawned = boss.goblinSpawned || 0;
+              if (spawned >= limit){
+                let anyLiving = false;
+                for (const other of enemies){
+                  if (other === e) continue;
+                  if (other && other.kind === 'goblin' && other.summonedByHillGiant && other.hp > 0){
+                    anyLiving = true;
+                    break;
+                  }
+                }
+                if (!anyLiving){
+                  boss.goblinEnraged = true;
+                }
+              }
+            }
           }
         }
       } else {
@@ -4766,11 +4800,22 @@
           if (node && node.hp > 0){ hillGiantAlive = true; break; }
         }
         if (hillGiantAlive){
-          const period = boss.goblinSpawnPeriod || HILL_GIANT_GOBLIN_PERIOD;
-          boss.goblinSpawnTimer = (boss.goblinSpawnTimer || 0) + dt;
-          if (boss.goblinSpawnTimer >= period){
-            boss.goblinSpawnTimer -= period;
-            spawnHillGiantGoblin();
+          const limit = boss.goblinSpawnLimit ?? HILL_GIANT_GOBLIN_LIMIT;
+          const window = boss.goblinSpawnWindow ?? HILL_GIANT_GOBLIN_WINDOW;
+          const prevElapsed = boss.goblinSpawnElapsed || 0;
+          boss.goblinSpawnElapsed = Math.min(window, prevElapsed + dt);
+          const totalSpawned = boss.goblinSpawned || 0;
+          if (totalSpawned < limit && prevElapsed < window){
+            const period = boss.goblinSpawnPeriod || HILL_GIANT_GOBLIN_PERIOD;
+            boss.goblinSpawnTimer = (boss.goblinSpawnTimer || 0) + dt;
+            while (boss.goblinSpawnTimer >= period && (boss.goblinSpawned || 0) < limit){
+              boss.goblinSpawnTimer -= period;
+              const spawned = spawnHillGiantGoblin();
+              if (!spawned) {
+                boss.goblinSpawnTimer = 0;
+                break;
+              }
+            }
           }
         }
       }
@@ -5123,9 +5168,14 @@
                 const vy = Math.sin(e.facing)*140;
                 BOSS_PROJECTILES.push({ kind:'muck', dir: vx < 0 ? 'left' : 'right', x:e.x, y:e.y, vx, vy, life:0, ttl:3, frame:0, animT:0, scale: e.projectileScale || 1 });
               } else if (e.bossType === 'hillGiant') {
-                const vx = Math.cos(e.facing)*280;
-                const vy = Math.sin(e.facing)*280;
-                BOSS_PROJECTILES.push({ kind:'rock', dir: vx < 0 ? 'left' : 'right', x:e.x, y:e.y, vx, vy, life:0, ttl:3, frame:0, animT:0 });
+                const controller = e.bossController;
+                const enraged = controller && controller.goblinEnraged;
+                const baseSpeed = 280;
+                const speedMult = enraged ? 2 : 1;
+                const vx = Math.cos(e.facing) * baseSpeed * speedMult;
+                const vy = Math.sin(e.facing) * baseSpeed * speedMult;
+                const dmg = enraged ? 2 : 1;
+                BOSS_PROJECTILES.push({ kind:'rock', dmg, dir: vx < 0 ? 'left' : 'right', x:e.x, y:e.y, vx, vy, life:0, ttl:3, frame:0, animT:0 });
               } else {
                 BOSS_PROJECTILES.push({ x:e.x, y:e.y, vx:Math.cos(e.facing)*140, vy:Math.sin(e.facing)*140, life:0, ttl:3 });
               }


### PR DESCRIPTION
## Summary
- limit the hill giant's goblin summons to 30 over a 10 second window using tracked spawn limits
- trigger an enrage once the final summoned goblin dies to double the hill giant's projectile speed and damage

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfcc9149788329a29e365bd6baebbe