### PR TITLE
Add health regeneration to Stage 5 Beholder boss

### DIFF
--- a/emberfall-gauntlet/index.html
+++ b/emberfall-gauntlet/index.html
@@ -5123,6 +5123,18 @@
             if (e.bossType === 'beholder') e.rayT = (e.rayT || 0) + dt;
             if (e.bossType === 'beholder'){
               e.minionTimer = (e.minionTimer || 0) + dt;
+              if (stage === 4 && e.hp > 0){
+                e.beholderRegenT = (e.beholderRegenT || 0) + dt;
+                if (e.beholderRegenT >= 3){
+                  e.beholderRegenT -= 3;
+                  const regenAmount = (e.hpMax || 0) * 0.1;
+                  if (regenAmount > 0){
+                    e.hp = Math.min(e.hpMax || e.hp, e.hp + regenAmount);
+                  }
+                }
+              } else {
+                e.beholderRegenT = 0;
+              }
               if (e.minionTimer >= 5){
                 e.minionTimer = 0;
                 let babies = 0;


### PR DESCRIPTION
## Summary
- add a regeneration timer for the stage 5 beholder boss so it heals 10% of its max health every 3 seconds
- reset the timer when the beholder boss is inactive or not in the final stage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1e4b7e6648329acd7accb97840640