### PR TITLE
Add tower shooting sprite animations

### DIFF
--- a/aurora-tower-defense/index.html
+++ b/aurora-tower-defense/index.html
@@ -772,15 +772,14 @@
           if(animImg && typeof t.animStart === 'number'){
             const elapsed = state.time - t.animStart;
             if(elapsed >= 0 && elapsed <= TOWER_SHOT_ANIM_DURATION){
-              const frameCount = 4;
-              const frameHeight = animImg.height / frameCount;
-              const frameWidth = animImg.width;
-              if(frameHeight > 0 && frameWidth > 0){
-                const normalized = Math.min(1, elapsed / TOWER_SHOT_ANIM_DURATION);
-                let frameIndex = Math.floor(normalized * frameCount);
+              const frameSize = animImg.width;
+              const frameCount = frameSize > 0 ? Math.max(1, Math.floor(animImg.height / frameSize)) : 0;
+              if(frameSize > 0 && frameCount > 0){
+                const perFrame = TOWER_SHOT_ANIM_DURATION / frameCount;
+                let frameIndex = Math.floor(elapsed / perFrame);
                 if(frameIndex >= frameCount) frameIndex = frameCount - 1;
-                const sy = frameIndex * frameHeight;
-                ctx.drawImage(animImg, 0, sy, frameWidth, frameHeight, centerX - size/2, centerY - size/2, size, size);
+                const sy = frameIndex * frameSize;
+                ctx.drawImage(animImg, 0, sy, frameSize, frameSize, centerX - size/2, centerY - size/2, size, size);
               }
             }
           }


### PR DESCRIPTION
## Summary
- load the new 128x512 shooting sprite sheets for each tower type
- animate tower firing sequences with one-second pre-shot timing using the sprite frames
- reset tower timing state on placement and restart to support the new animations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e515297ca88329a9c4feae40277633