### PR TITLE
Update enemy reference sprites to walking right frames

### DIFF
--- a/aurora-tower-defense/index.html
+++ b/aurora-tower-defense/index.html
@@ -106,7 +106,12 @@
 
     .enemy-list { display: flex; flex-direction: column; gap: 10px; }
     .enemy-row { display: flex; align-items: center; gap: 12px; font-size: 12px; }
-    .enemy-row img { width: 32px; height: 32px; }
+    .enemy-row .enemy-thumb {
+      width: 128px; height: 128px;
+      background-repeat: no-repeat;
+      background-position: 0 0;
+      image-rendering: pixelated;
+    }
 
     @media (min-width: 900px) {
       .toolbar { bottom: 20px; }
@@ -188,10 +193,10 @@
     <div class="overlay" id="enemyRef">
       <h2>Enemy Reference</h2>
       <div class="enemy-list">
-        <div class="enemy-row"><img src="assets/ATD_enemy_bug_animation_walking_down_small.png" alt="Bug"><span>Bug - Balanced scout.</span></div>
-        <div class="enemy-row"><img src="assets/ATD_enemy_runner_animation_walking_right_small.png" alt="Runner"><span>Runner - Quick but fragile.</span></div>
-        <div class="enemy-row"><img src="assets/ATD_enemy_armored_animation_walking_down_small.png" alt="Armored"><span>Armored - Slow, heavily protected.</span></div>
-        <div class="enemy-row"><img src="assets/ATD_enemy_heavy_animation_walking_down_small.png" alt="Brute"><span>Brute - Titanic and tough.</span></div>
+        <div class="enemy-row"><div class="enemy-thumb" role="img" aria-label="Bug" style="background-image: url('assets/ATD_enemy_bug_animation_walking_right_small.png');"></div><span>Bug - Balanced scout.</span></div>
+        <div class="enemy-row"><div class="enemy-thumb" role="img" aria-label="Runner" style="background-image: url('assets/ATD_enemy_runner_animation_walking_right_small.png');"></div><span>Runner - Quick but fragile.</span></div>
+        <div class="enemy-row"><div class="enemy-thumb" role="img" aria-label="Armored" style="background-image: url('assets/ATD_enemy_armored_animation_walking_right_small.png');"></div><span>Armored - Slow, heavily protected.</span></div>
+        <div class="enemy-row"><div class="enemy-thumb" role="img" aria-label="Brute" style="background-image: url('assets/ATD_enemy_heavy_animation_walking_right_small.png');"></div><span>Brute - Titanic and tough.</span></div>
       </div>
       <p class="tap">Tap to close</p>
     </div>


### PR DESCRIPTION
## Summary
- display enemy reference sprites using the walking-right sheets and crop them to the first 128x128 frame for clarity

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e5efee66f48329ae2434f4bd66994c