### PR TITLE
Use core image in Aurora Tower Defense

### DIFF
--- a/aurora-tower-defense/index.html
+++ b/aurora-tower-defense/index.html
@@ -283,6 +283,7 @@
       tower_basic_idle: 'assets/ATD_tower_basic_small.png',
       tower_slow_idle: 'assets/ATD_tower_frost_small.png',
       tower_pierce_idle: 'assets/ATD_tower_piercing_small.png',
+      core: 'assets/ATD_Core.png',
       enemy_bug_walk_down: 'assets/ATD_enemy_bug_animation_walking_down_small.png',
       enemy_bug_walk_left: 'assets/ATD_enemy_bug_animation_walking_left_small.png',
       enemy_bug_walk_right: 'assets/ATD_enemy_bug_animation_walking_right_small.png',
@@ -1097,6 +1098,10 @@
       grd.addColorStop(1, 'rgba(60,200,220,0.05)');
       ctx.fillStyle = grd; ctx.beginPath(); ctx.arc(p1.x, p1.y, r, 0, Math.PI*2); ctx.fill();
       ctx.strokeStyle = '#7fffd4'; ctx.lineWidth = 2; ctx.stroke();
+      if(Images.core){
+        const coreSize = tile * 0.9;
+        ctx.drawImage(Images.core, p1.x - coreSize/2, p1.y - coreSize/2, coreSize, coreSize);
+      }
     }
 
     function drawTowers(){


### PR DESCRIPTION
## Summary
- load the Aurora core sprite asset alongside other game art
- draw the core image at the end of the path while retaining the glow effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66dc136008329a0ce1d827d145002