### PR TITLE
Remove glow behind Aurora core

### DIFF
--- a/aurora-tower-defense/index.html
+++ b/aurora-tower-defense/index.html
@@ -1090,14 +1090,8 @@
       // portal at start
       const p0 = gridToPx(path[0].x, path[0].y);
       const s = tile*0.95; ctx.drawImage(Images.portal, p0.x - s/2, p0.y - s/2, s, s);
-      // core at end (glowing circle)
+      // core at end (core image only)
       const p1 = gridToPx(path[path.length-1].x, path[path.length-1].y);
-      const r = Math.max(12, tile*0.32);
-      const grd = ctx.createRadialGradient(p1.x, p1.y, 3, p1.x, p1.y, r);
-      grd.addColorStop(0, 'rgba(160,255,240,0.95)');
-      grd.addColorStop(1, 'rgba(60,200,220,0.05)');
-      ctx.fillStyle = grd; ctx.beginPath(); ctx.arc(p1.x, p1.y, r, 0, Math.PI*2); ctx.fill();
-      ctx.strokeStyle = '#7fffd4'; ctx.lineWidth = 2; ctx.stroke();
       if(Images.core){
         const coreSize = tile * 0.9;
         ctx.drawImage(Images.core, p1.x - coreSize/2, p1.y - coreSize/2, coreSize, coreSize);


### PR DESCRIPTION
## Summary
- remove the radial gradient and outline that previously added a glow behind the Aurora core image

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e66f672a74832998ce99600613dcb2