### PR TITLE
Support panoramic 4096x256 background for level 1 (BB_bg_swamp001)

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1095,7 +1095,30 @@
       const level = levels[state.levelIndex];
       const bg = assets.backgrounds[level.background];
       if (bg) {
-        ctx.drawImage(bg, -state.cameraX * 0.25, -state.cameraY * 0.15, canvas.width + 200, canvas.height + 100);
+        const maxCameraX = Math.max(1, state.levelWidth - canvas.width);
+        const maxCameraY = Math.max(1, state.levelHeight - canvas.height + 60);
+        const cameraXPct = clamp(state.cameraX / maxCameraX, 0, 1);
+        const cameraYPct = clamp(state.cameraY / maxCameraY, 0, 1);
+
+        const targetSkyHeight = Math.max(220, Math.floor(canvas.height * 0.68));
+        let scale = targetSkyHeight / bg.height;
+        let drawWidth = bg.width * scale;
+        let drawHeight = bg.height * scale;
+
+        // Support panoramic (e.g. 4096x256) and portrait background textures.
+        // If the initial fit is too narrow, switch to width-fit and pan vertically.
+        if (drawWidth < canvas.width) {
+          scale = canvas.width / bg.width;
+          drawWidth = canvas.width;
+          drawHeight = bg.height * scale;
+        }
+
+        const maxPanX = Math.max(0, drawWidth - canvas.width);
+        const maxPanY = Math.max(0, drawHeight - targetSkyHeight);
+        const drawX = -maxPanX * cameraXPct;
+        const drawY = -maxPanY * cameraYPct - state.cameraY * 0.08;
+
+        ctx.drawImage(bg, drawX, drawY, drawWidth, drawHeight);
       }
       ctx.fillStyle = '#1e2628';
       ctx.fillRect(0, 360 - state.cameraY, canvas.width, 200);
@@ -1321,7 +1344,7 @@
       const promises = [];
 
       const backgroundKeys = {
-        'background-swamp': 'assets/background-swamp.svg',
+        'background-swamp': 'assets/BB_bg_swamp001.png',
         'background-mirewatch': 'assets/background-mirewatch.svg',
         'background-portal': 'assets/background-portal.svg',
         'background-fairy-forest': 'assets/background-fairy-forest.svg',


### PR DESCRIPTION
### Motivation
- Replace the legacy SVG for the level 1 swamp with the new PNG asset `assets/BB_bg_swamp001.png` which is a wide panoramic texture.
- Adapt background drawing so the renderer handles non-legacy dimensions (very wide or tall textures) and pans/scales correctly with the camera.

### Description
- Replaced the `background-swamp` mapping to point at `assets/BB_bg_swamp001.png` in `loadAssets()` by editing `bayou-brawlers/index.html`.
- Reworked `drawBackground()` in `bayou-brawlers/index.html` to compute camera-relative pan percentages, scale to a target sky height, fall back to a width-fit when needed, and pan X/Y within drawable bounds before calling `ctx.drawImage()`.
- Kept this change code-only and did not add or modify any binary assets.

### Testing
- Ran a PNG header probe with Python to confirm the asset dimensions are `4096 256` using the small script that reads the PNG `IHDR` and it succeeded.
- Verified the code edits with `git diff` and committed the change successfully to the current branch.
- Attempted an automated browser screenshot via Playwright to validate rendering, but the Chromium process crashed with `SIGSEGV` in this environment so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925deb1d088329a46393c52436480a)