### PR TITLE
Reduce initial enemy count and slow enemy movement in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -632,6 +632,9 @@
       boss: { hp: 200, speed: 1.2, damage: 20, range: 26, score: 350, sprite: 'boss' }
     };
 
+    const INITIAL_WAVE_ENEMY_MULTIPLIER = 0.75;
+    const ENEMY_SPEED_MULTIPLIER = 0.82;
+
     function clamp(value, min, max) {
       return Math.max(min, Math.min(max, value));
     }
@@ -675,7 +678,7 @@
         z: 0,
         hp: base.hp * (isBoss ? 1.4 : 1),
         maxHp: base.hp * (isBoss ? 1.4 : 1),
-        speed: base.speed,
+        speed: base.speed * ENEMY_SPEED_MULTIPLIER,
         damage: base.damage,
         range: base.range,
         score: base.score,
@@ -693,7 +696,10 @@
       if (!wave) return;
       state.enemies = [];
       const baseX = 320 + waveIndex * 520;
-      for (let i = 0; i < wave.count; i += 1) {
+      const spawnCount = waveIndex === 0
+        ? Math.max(2, Math.round(wave.count * INITIAL_WAVE_ENEMY_MULTIPLIER))
+        : wave.count;
+      for (let i = 0; i < spawnCount; i += 1) {
         const typeId = wave.types[i % wave.types.length];
         const enemy = createEnemy(typeId, baseX + rand(-80, 80) + i * 40, rand(220, 340));
         state.enemies.push(enemy);


### PR DESCRIPTION
### Motivation
- Soften the difficulty of the opening encounter by reducing the number of enemies that spawn in the first wave and make all enemies move slower for gentler pacing.

### Description
- Added two tunable constants: `INITIAL_WAVE_ENEMY_MULTIPLIER` and `ENEMY_SPEED_MULTIPLIER` to `bayou-brawlers/index.html` to centralize tuning.
- Updated `createEnemy` so enemy `speed` is multiplied by `ENEMY_SPEED_MULTIPLIER` when an enemy is created.
- Updated `spawnWave` so the first wave uses `Math.max(2, Math.round(wave.count * INITIAL_WAVE_ENEMY_MULTIPLIER))` while later waves keep their original counts.
- Changes are confined to `bayou-brawlers/index.html` and only affect initial-wave spawn counts and global enemy pacing.

### Testing
- Started a local server with `python3 -m http.server 8000` and used a Playwright script to load `http://127.0.0.1:8000/bayou-brawlers/index.html` and capture `artifacts/bayou-brawlers-initial-wave.png`, which completed successfully.
- Verified repository status and committed the change with `git` (commit message: "Tune Bayou Brawlers opening enemy pacing").
- No unit test suite exists for this asset; the browser load / screenshot served as the automated validation and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69926c0247c083299f3f0b71f515725f)