### PR TITLE
Limit player vertical movement to lower half of screen in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -825,6 +825,7 @@
     function updatePlayer(dt) {
       const player = state.player;
       if (!player) return;
+      const upperMoveLimit = canvas.height * 0.5;
       player.vx = 0;
       if (input.left) player.vx -= player.speed;
       if (input.right) player.vx += player.speed;
@@ -853,7 +854,7 @@
       }
 
       player.x = clamp(player.x, 40, state.levelWidth - 40);
-      player.y = clamp(player.y, 220, 340);
+      player.y = clamp(player.y, upperMoveLimit, 340);
 
       if (state.lockX !== null && player.x > state.lockX) {
         player.x = state.lockX;


### PR DESCRIPTION
### Motivation
- Allow the player to move up and down while preventing them from moving above the visible midpoint of the play area so gameplay remains grounded in the lower half of the scene.

### Description
- In `bayou-brawlers/index.html` inside the `updatePlayer` function, introduce `const upperMoveLimit = canvas.height * 0.5` and use it to replace the previous hardcoded upper clamp, changing `player.y = clamp(player.y, 220, 340)` to `player.y = clamp(player.y, upperMoveLimit, 340)`.

### Testing
- Started a local server with `python -m http.server` and loaded `bayou-brawlers/index.html`, which succeeded and served assets successfully.
- Captured a browser screenshot via a Playwright script to validate the page rendered after the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69926dbbb898832981e7b8dd63c01a09)