### PR TITLE
Reduce Bayou Brawlers player walking speed by 75%

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -634,6 +634,7 @@
 
     const INITIAL_WAVE_ENEMY_MULTIPLIER = 0.75;
     const ENEMY_SPEED_MULTIPLIER = 0.82;
+    const PLAYER_WALK_SPEED_MULTIPLIER = 0.25;
     const PLAYER_DRAW_SIZE = 56;
     const ENEMY_DRAW_SIZE = 48;
     const BOSS_DRAW_SIZE = 80;
@@ -830,11 +831,12 @@
     function updatePlayer(dt) {
       const player = state.player;
       if (!player) return;
+      const walkSpeed = player.speed * PLAYER_WALK_SPEED_MULTIPLIER;
       player.vx = 0;
-      if (input.left) player.vx -= player.speed;
-      if (input.right) player.vx += player.speed;
-      if (input.up) player.y -= player.speed * 0.6;
-      if (input.down) player.y += player.speed * 0.6;
+      if (input.left) player.vx -= walkSpeed;
+      if (input.right) player.vx += walkSpeed;
+      if (input.up) player.y -= walkSpeed * 0.6;
+      if (input.down) player.y += walkSpeed * 0.6;
       if (player.vx !== 0) player.facing = player.vx > 0 ? 1 : -1;
       player.block = input.block;
 


### PR DESCRIPTION
### Motivation
- The game background appeared to scroll too quickly while the player was walking, making movement feel too fast.
- Reduce the player's walk velocity so camera/background motion is less pronounced and walking feels more deliberate.

### Description
- Added a new constant `PLAYER_WALK_SPEED_MULTIPLIER = 0.25` in `bayou-brawlers/index.html` to represent a 75% reduction in walking speed.
- Replaced direct uses of `player.speed` in horizontal and vertical walking input handling inside `updatePlayer` with a computed `walkSpeed = player.speed * PLAYER_WALK_SPEED_MULTIPLIER` so left/right/up/down movement uses the scaled value.
- No other gameplay systems (dash, jump, enemy speeds) were changed.

### Testing
- Inspected the updated movement logic in `bayou-brawlers/index.html` to confirm `walkSpeed` is used for walk inputs and other movement mechanics remain unchanged, and this check passed.
- Launched a local server with `python3 -m http.server 4173` and ran an automated Playwright script that opened `http://127.0.0.1:4173/bayou-brawlers/index.html` and captured a screenshot to validate the page renders after the change, and the run succeeded.
- All automated checks performed (logic inspection and page rendering via Playwright) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992a68cf2848329bbf60db2064941c7)