### PR TITLE
Fix Bayou Brawlers background scroll pacing

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1199,7 +1199,9 @@
 
         const maxPanX = Math.max(0, drawWidth - canvas.width);
         const maxPanY = Math.max(0, drawHeight - targetSkyHeight);
-        const drawX = -maxPanX * cameraXPct;
+        // Keep horizontal background movement from outrunning player/camera movement
+        // on ultra-wide background textures.
+        const drawX = -Math.min(maxPanX * cameraXPct, state.cameraX);
         const drawY = -maxPanY * cameraYPct - state.cameraY * 0.08;
 
         ctx.drawImage(bg, drawX, drawY, drawWidth, drawHeight);


### PR DESCRIPTION
### Motivation
- Panoramic background textures could pan horizontally faster than the player's movement, causing the background to visually outrun the character while walking.

### Description
- Modified `bayou-brawlers/index.html` to cap the horizontal background offset by the camera X position by changing the `drawX` calculation to `-Math.min(maxPanX * cameraXPct, state.cameraX)`.
- Added a short inline comment explaining the intent of the cap for ultra-wide background textures.
- Captured a gameplay screenshot after starting a run to visually validate the background pacing change.

### Testing
- Ran `npm test -- --runInBand` and all automated test suites passed (3 suites, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937a5538908329b23db5c5fb3d5f1d)