### PR TITLE
Gate Bayou Brawlers encounters at 25% map checkpoints

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -498,6 +498,8 @@
       gameOver: false,
       victory: false,
       bossActive: false,
+      encounterActive: false,
+      encounterIndex: 0,
       ally: null,
       shake: 0,
       submitting: false
@@ -813,11 +815,18 @@
       };
     }
 
-    function spawnWave(level, waveIndex) {
+    function getEncounterThresholdX(encounterIndex) {
+      const progressPct = (encounterIndex + 1) / 4;
+      const laneStart = 40;
+      const laneEnd = state.levelWidth - 40;
+      return laneStart + ((laneEnd - laneStart) * progressPct);
+    }
+
+    function spawnWave(level, waveIndex, lockX = null) {
       const wave = level.waves[waveIndex];
       if (!wave) return;
       state.enemies = [];
-      const baseX = 320 + waveIndex * 520;
+      const baseX = (lockX ?? 320 + waveIndex * 520) + 180;
       const spawnCount = waveIndex === 0
         ? Math.max(2, Math.round(wave.count * INITIAL_WAVE_ENEMY_MULTIPLIER))
         : wave.count;
@@ -826,20 +835,21 @@
         const enemy = createEnemy(typeId, baseX + rand(-80, 80) + i * 40, rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y));
         state.enemies.push(enemy);
       }
-      state.lockX = baseX + 220;
+      state.lockX = lockX ?? baseX + 220;
       updateWaveHud();
     }
 
-    function spawnBoss(level) {
+    function spawnBoss(level, lockX = null) {
       const bossType = level.boss.type;
-      const boss = createEnemy(bossType, state.levelWidth - 220, clamp(280, getBrawlLaneMinY(), BRAWL_LANE_MAX_Y), true);
+      const bossSpawnX = lockX !== null ? lockX + 180 : state.levelWidth - 220;
+      const boss = createEnemy(bossType, bossSpawnX, clamp(280, getBrawlLaneMinY(), BRAWL_LANE_MAX_Y), true);
       boss.hp += 120;
       boss.maxHp = boss.hp;
       boss.score += 250;
       boss.name = level.boss.name;
       state.enemies = [boss];
       state.bossActive = true;
-      state.lockX = state.levelWidth - 140;
+      state.lockX = lockX ?? state.levelWidth - 140;
     }
 
     function updateWaveHud() {
@@ -1130,19 +1140,14 @@
     }
 
     function updateStageProgress() {
-      if (state.enemies.length > 0) return;
       const level = levels[state.levelIndex];
-      if (!state.bossActive) {
-        if (state.waveIndex < level.waves.length - 1) {
-          state.waveIndex += 1;
-          spawnWave(level, state.waveIndex);
-          showMessage(`${level.name}`, `Wave ${state.waveIndex + 1} incoming!`, 'Fight');
-        } else {
-          spawnBoss(level);
-          showMessage(`${level.boss.name}`, 'Boss rush! Brace for impact.', 'Engage');
-        }
-      } else {
+      const nextEncounterLockX = state.encounterIndex <= 3 ? getEncounterThresholdX(state.encounterIndex) : null;
+
+      if (state.enemies.length > 0) return;
+
+      if (state.bossActive) {
         state.bossActive = false;
+        state.encounterActive = false;
         state.lockX = null;
         if (state.levelIndex < levels.length - 1) {
           state.levelIndex += 1;
@@ -1152,19 +1157,48 @@
         } else {
           endGame(true);
         }
+        return;
+      }
+
+      if (state.encounterActive) {
+        state.encounterActive = false;
+        state.encounterIndex += 1;
+        if (state.encounterIndex <= 3) {
+          state.lockX = getEncounterThresholdX(state.encounterIndex);
+          const nextPct = (state.encounterIndex + 1) * 25;
+          showMessage(level.name, `Path clear. Push to ${nextPct}% to trigger the next encounter.`, 'Advance');
+        } else {
+          state.lockX = null;
+        }
+        return;
+      }
+
+      if (!state.player || nextEncounterLockX === null || state.player.x < nextEncounterLockX - 1) {
+        return;
+      }
+
+      if (state.encounterIndex < level.waves.length) {
+        state.waveIndex = state.encounterIndex;
+        state.encounterActive = true;
+        spawnWave(level, state.waveIndex, nextEncounterLockX);
+        showMessage(`${level.name}`, `Enemy group ${state.waveIndex + 1} attacks at ${Math.round((state.encounterIndex + 1) * 25)}%!`, 'Fight');
+      } else {
+        state.encounterActive = true;
+        spawnBoss(level, nextEncounterLockX);
+        showMessage(`${level.boss.name}`, 'Boss rush! Brace for impact.', 'Engage');
       }
     }
 
     function setupLevel() {
-      const level = levels[state.levelIndex];
       state.levelWidth = 2200 + state.levelIndex * 120;
       state.bossActive = false;
+      state.encounterActive = false;
+      state.encounterIndex = 0;
       state.enemies = [];
       state.projectiles = [];
       state.pickups = [];
       state.effects = [];
-      state.lockX = null;
-      spawnWave(level, state.waveIndex);
+      state.lockX = getEncounterThresholdX(0);
       updateWaveHud();
     }
 


### PR DESCRIPTION
### Motivation
- Enforce map-based progression so the player can only move 25% forward at a time and then trigger the next enemy group at checkpoints (25%, 50%, 75%, 100%).

### Description
- Added encounter state properties `encounterActive` and `encounterIndex` to `state` and started level movement locked to the first checkpoint by default in `setupLevel` (file: `bayou-brawlers/index.html`).
- Added `getEncounterThresholdX()` to compute checkpoint X positions and updated `spawnWave` and `spawnBoss` to accept an optional `lockX` so spawns are placed relative to checkpoints.
- Reworked `updateStageProgress()` to only spawn waves/bosses when the player reaches the next checkpoint and to advance `encounterIndex`/unlock the next 25% segment after each encounter is cleared.
- Adjusted `setupLevel()` to initialize encounter state and set `state.lockX` to the 25% checkpoint so the player must reach checkpoints to progress.

### Testing
- Ran unit tests with `npm test -- --runInBand`; all test suites passed (3 passed, 3 total).
- Attempted a Playwright screenshot to validate in-browser behavior, but the headless browser failed to load the local dev server (`ERR_EMPTY_RESPONSE`) so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69946f6faea4832992c998cedc5ca0b6)