### PR TITLE
Support tall 256×5120 swamp background (BB_bg_swamp001)

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -719,6 +719,46 @@
       return Math.random() * (max - min) + min;
     }
 
+    function normalizeBackgroundImage(img) {
+      if (!img || img.height <= img.width * 2) {
+        return img;
+      }
+
+      const rotatedCanvas = document.createElement('canvas');
+      rotatedCanvas.width = img.height;
+      rotatedCanvas.height = img.width;
+      const rotatedCtx = rotatedCanvas.getContext('2d');
+      rotatedCtx.imageSmoothingEnabled = false;
+
+      rotatedCtx.translate(rotatedCanvas.width / 2, rotatedCanvas.height / 2);
+      rotatedCtx.rotate(Math.PI / 2);
+      rotatedCtx.drawImage(img, -img.width / 2, -img.height / 2);
+
+      return rotatedCanvas;
+    }
+
+    function getTargetSkyHeight() {
+      return Math.max(220, Math.floor(canvas.height * 0.68));
+    }
+
+    function getBackgroundScale(bg) {
+      let scale = getTargetSkyHeight() / bg.height;
+      if ((bg.width * scale) < canvas.width) {
+        scale = canvas.width / bg.width;
+      }
+      return scale;
+    }
+
+    function getLevelWorldWidth(level, fallbackWidth) {
+      const bg = level ? assets.backgrounds[level.background] : null;
+      if (!bg) {
+        return fallbackWidth;
+      }
+
+      const bgWorldWidth = Math.floor(bg.width * getBackgroundScale(bg));
+      return Math.max(canvas.width + 640, bgWorldWidth + 420, fallbackWidth);
+    }
+
     function getBackgroundDrawMetrics(level = levels[state.levelIndex]) {
       const bg = level ? assets.backgrounds[level.background] : null;
       if (!bg) {
@@ -729,17 +769,11 @@
       const maxCameraY = Math.max(1, state.levelHeight - canvas.height + 60);
       const cameraXPct = clamp(state.cameraX / maxCameraX, 0, 1);
       const cameraYPct = clamp(state.cameraY / maxCameraY, 0, 1);
-      const targetSkyHeight = Math.max(220, Math.floor(canvas.height * 0.68));
+      const targetSkyHeight = getTargetSkyHeight();
 
-      let scale = targetSkyHeight / bg.height;
-      let drawWidth = bg.width * scale;
-      let drawHeight = bg.height * scale;
-
-      if (drawWidth < canvas.width) {
-        scale = canvas.width / bg.width;
-        drawWidth = canvas.width;
-        drawHeight = bg.height * scale;
-      }
+      const scale = getBackgroundScale(bg);
+      const drawWidth = bg.width * scale;
+      const drawHeight = bg.height * scale;
 
       const maxPanX = Math.max(0, drawWidth - canvas.width);
       const maxPanY = Math.max(0, drawHeight - targetSkyHeight);
@@ -1157,7 +1191,8 @@
 
     function setupLevel() {
       const level = levels[state.levelIndex];
-      state.levelWidth = 2200 + state.levelIndex * 120;
+      const defaultLevelWidth = 2200 + state.levelIndex * 120;
+      state.levelWidth = getLevelWorldWidth(level, defaultLevelWidth);
       state.bossActive = false;
       state.enemies = [];
       state.projectiles = [];
@@ -1557,7 +1592,7 @@
       };
 
       Object.entries(backgroundKeys).forEach(([key, src]) => {
-        promises.push(loadImage(src).then(img => { assets.backgrounds[key] = img; }));
+        promises.push(loadImage(src).then(img => { assets.backgrounds[key] = normalizeBackgroundImage(img); }));
       });
 
       const characterSprites = {


### PR DESCRIPTION
### Motivation
- The level-1 swamp background asset `BB_bg_swamp001.png` is a very tall image (256×5120) and needs to be usable in-game without changing binary assets.
- Background rendering, scaling, and level width calculations must adapt to non-standard background dimensions so camera panning and brawl lane positioning remain correct.

### Description
- Added `normalizeBackgroundImage` which detects unusually tall background images and rotates them into a landscape canvas for in-game rendering without modifying the original asset.
- Introduced helper functions `getTargetSkyHeight`, `getBackgroundScale`, and `getLevelWorldWidth` and refactored `getBackgroundDrawMetrics` to use them for consistent scaling and panning logic.
- Updated `setupLevel` to compute `state.levelWidth` via `getLevelWorldWidth` so horizontal camera/travel space accounts for scaled background width.
- Switched background loading to pass loaded images through `normalizeBackgroundImage` when populating `assets.backgrounds` so the swamp background is normalized at load time.

### Testing
- Ran the project test suite with `npm test -- --runInBand` and all tests passed.
- Performed an automated browser verification using Playwright against the served page and captured a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699474f04658832993ba8063b5f939d5)