### PR TITLE
Replace wave-clear popups with right-side flashing continue arrow

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -500,7 +500,8 @@
       bossActive: false,
       ally: null,
       shake: 0,
-      submitting: false
+      submitting: false,
+      continueArrowTimer: 0
     };
 
     const input = {
@@ -1170,7 +1171,7 @@
         if (state.waveIndex < level.waves.length - 1) {
           state.waveIndex += 1;
           spawnWave(level, state.waveIndex);
-          showMessage(`${level.name}`, `Wave ${state.waveIndex + 1} incoming!`, 'Fight');
+          state.continueArrowTimer = 300;
         } else {
           spawnBoss(level);
           showMessage(`${level.boss.name}`, 'Boss rush! Brace for impact.', 'Engage');
@@ -1363,9 +1364,37 @@
         }
       });
 
+      drawContinueArrow();
+
       if (state.shake > 0) {
         ctx.restore();
       }
+    }
+
+    function drawContinueArrow() {
+      if (state.continueArrowTimer <= 0) return;
+      const alpha = 0.25 + (((Math.sin(performance.now() / 350) + 1) / 2) * 0.75);
+      const arrowX = canvas.width - 28;
+      const arrowY = canvas.height / 2;
+
+      ctx.save();
+      ctx.globalAlpha = alpha;
+      ctx.fillStyle = '#ffd65c';
+      ctx.strokeStyle = '#0f1319';
+      ctx.lineWidth = 3;
+
+      ctx.beginPath();
+      ctx.moveTo(arrowX - 30, arrowY - 24);
+      ctx.lineTo(arrowX + 18, arrowY - 24);
+      ctx.lineTo(arrowX + 18, arrowY - 36);
+      ctx.lineTo(arrowX + 44, arrowY);
+      ctx.lineTo(arrowX + 18, arrowY + 36);
+      ctx.lineTo(arrowX + 18, arrowY + 24);
+      ctx.lineTo(arrowX - 30, arrowY + 24);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+      ctx.restore();
     }
 
     function updateCamera() {
@@ -1387,6 +1416,7 @@
       updateEffects();
       updateAlly();
       updateStageProgress();
+      state.continueArrowTimer = Math.max(0, state.continueArrowTimer - 1);
       updateCamera();
       draw();
 


### PR DESCRIPTION
### Motivation
- Remove the interruptive inter-wave modal that paused gameplay when a normal enemy wave was defeated and instead provide a subtle in-game cue to indicate progression direction. 
- Give players a non-modal visual hint to continue rightward without changing boss or stage-transition overlays.

### Description
- Added a `continueArrowTimer` field to the global `state` and set it in `updateStageProgress` when a non-boss wave completes instead of calling the modal `showMessage`. 
- Implemented `drawContinueArrow()` and invoke it from the main `draw()` loop to render a slowly flashing right-side arrow on the canvas. 
- Decrement the `continueArrowTimer` inside the `gameLoop` so the arrow automatically fades after a short duration. 
- Left boss spawn and stage-cleared modals unchanged so important transitions still pause gameplay.

### Testing
- Ran unit tests with `npm test -- --runInBand`, which passed (3 test suites, 6 tests). 
- Automated browser validation via a Playwright script that served the site, started a game, forced the arrow timer, and captured a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947b2e1ed88329ace417940967195f)