### PR TITLE
Trigger Bayou Brawlers waves by map progress (10%–90%) and flash arrow after 5s idle

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -501,7 +501,9 @@
       ally: null,
       shake: 0,
       submitting: false,
-      continueArrowTimer: 0
+      continueArrowTimer: 0,
+      progressIdleMs: 0,
+      furthestPlayerX: 40
     };
 
     const input = {
@@ -706,6 +708,9 @@
 
     const INITIAL_WAVE_ENEMY_MULTIPLIER = 0.75;
     const ENEMY_SPEED_MULTIPLIER = 0.82;
+    const REGULAR_WAVE_TRIGGER_PERCENTAGES = [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80];
+    const BOSS_WAVE_TRIGGER_PERCENTAGE = 0.90;
+    const CONTINUE_ARROW_IDLE_MS = 5000;
     const PLAYER_DRAW_SIZE = 56;
     const ENEMY_DRAW_SIZE = 48;
     const BOSS_DRAW_SIZE = 80;
@@ -848,11 +853,25 @@
       };
     }
 
-    function spawnWave(level, waveIndex) {
-      const wave = level.waves[waveIndex];
-      if (!wave) return;
+    function getProgressXForPercentage(percentage) {
+      const minX = 40;
+      const maxX = state.levelWidth - 40;
+      return minX + ((maxX - minX) * percentage);
+    }
+
+    function getRegularWaveConfig(level, waveIndex) {
+      const patternWave = level.waves[waveIndex % level.waves.length];
+      const cycle = Math.floor(waveIndex / level.waves.length);
+      return {
+        types: patternWave.types,
+        count: patternWave.count + cycle
+      };
+    }
+
+    function spawnWave(level, waveIndex, triggerX) {
+      const wave = getRegularWaveConfig(level, waveIndex);
       state.enemies = [];
-      const baseX = 320 + waveIndex * 520;
+      const baseX = clamp(triggerX + 220, 320, state.levelWidth - 220);
       const spawnCount = waveIndex === 0
         ? Math.max(2, Math.round(wave.count * INITIAL_WAVE_ENEMY_MULTIPLIER))
         : wave.count;
@@ -862,6 +881,8 @@
         state.enemies.push(enemy);
       }
       state.lockX = baseX + 220;
+      state.progressIdleMs = 0;
+      state.continueArrowTimer = 0;
       updateWaveHud();
     }
 
@@ -875,11 +896,50 @@
       state.enemies = [boss];
       state.bossActive = true;
       state.lockX = state.levelWidth - 140;
+      state.progressIdleMs = 0;
+      state.continueArrowTimer = 0;
+      state.waveIndex = REGULAR_WAVE_TRIGGER_PERCENTAGES.length;
+      updateWaveHud();
     }
 
     function updateWaveHud() {
-      document.getElementById('wave').textContent = String(state.waveIndex + 1);
+      document.getElementById('wave').textContent = String(Math.max(0, state.waveIndex + 1));
       document.getElementById('level').textContent = String(state.levelIndex + 1);
+    }
+
+    function updateContinueArrow(dt) {
+      const player = state.player;
+      if (!player) return;
+
+      if (state.enemies.length > 0 || state.bossActive) {
+        state.progressIdleMs = 0;
+        state.continueArrowTimer = 0;
+        state.furthestPlayerX = Math.max(state.furthestPlayerX, player.x);
+        return;
+      }
+
+      const nextProgressPercentage = state.waveIndex < (REGULAR_WAVE_TRIGGER_PERCENTAGES.length - 1)
+        ? REGULAR_WAVE_TRIGGER_PERCENTAGES[state.waveIndex + 1]
+        : BOSS_WAVE_TRIGGER_PERCENTAGE;
+      const nextTriggerX = getProgressXForPercentage(nextProgressPercentage);
+
+      if (player.x >= nextTriggerX - 1) {
+        state.progressIdleMs = 0;
+        state.continueArrowTimer = 0;
+        state.furthestPlayerX = Math.max(state.furthestPlayerX, player.x);
+        return;
+      }
+
+      if (player.x > state.furthestPlayerX + 0.5) {
+        state.furthestPlayerX = player.x;
+        state.progressIdleMs = 0;
+        state.continueArrowTimer = 0;
+      } else {
+        state.progressIdleMs += dt;
+        if (state.progressIdleMs >= CONTINUE_ARROW_IDLE_MS) {
+          state.continueArrowTimer = 1;
+        }
+      }
     }
 
     function addScore(amount) {
@@ -1167,12 +1227,16 @@
     function updateStageProgress() {
       if (state.enemies.length > 0) return;
       const level = levels[state.levelIndex];
+      const bossTriggerX = getProgressXForPercentage(BOSS_WAVE_TRIGGER_PERCENTAGE);
       if (!state.bossActive) {
-        if (state.waveIndex < level.waves.length - 1) {
-          state.waveIndex += 1;
-          spawnWave(level, state.waveIndex);
-          state.continueArrowTimer = 300;
-        } else {
+        if (state.waveIndex < (REGULAR_WAVE_TRIGGER_PERCENTAGES.length - 1)) {
+          const nextWaveIndex = state.waveIndex + 1;
+          const nextTriggerX = getProgressXForPercentage(REGULAR_WAVE_TRIGGER_PERCENTAGES[nextWaveIndex]);
+          if (state.player.x >= nextTriggerX) {
+            state.waveIndex = nextWaveIndex;
+            spawnWave(level, state.waveIndex, nextTriggerX);
+          }
+        } else if (state.player.x >= bossTriggerX) {
           spawnBoss(level);
           showMessage(`${level.boss.name}`, 'Boss rush! Brace for impact.', 'Engage');
         }
@@ -1200,7 +1264,10 @@
       state.pickups = [];
       state.effects = [];
       state.lockX = null;
-      spawnWave(level, state.waveIndex);
+      state.waveIndex = -1;
+      state.progressIdleMs = 0;
+      state.continueArrowTimer = 0;
+      state.furthestPlayerX = state.player ? state.player.x : 40;
       updateWaveHud();
     }
 
@@ -1416,7 +1483,7 @@
       updateEffects();
       updateAlly();
       updateStageProgress();
-      state.continueArrowTimer = Math.max(0, state.continueArrowTimer - 1);
+      updateContinueArrow(dt);
       updateCamera();
       draw();
 


### PR DESCRIPTION
### Motivation
- Make enemy waves distance-driven so encounters occur as the player moves across the level rather than immediately chaining to the next wave. 
- Provide a total of 9 waves per stage (8 regular + 1 boss) and place them at explicit map-progress checkpoints to match design (10%...80% regular, 90% boss). 
- Give players feedback when they stall by flashing the continue arrow after 5 seconds of no forward progress so they know to advance. 

### Description
- Added new state fields `progressIdleMs` and `furthestPlayerX` and new constants `REGULAR_WAVE_TRIGGER_PERCENTAGES`, `BOSS_WAVE_TRIGGER_PERCENTAGE`, and `CONTINUE_ARROW_IDLE_MS` in `bayou-brawlers/index.html`. 
- Introduced helper functions `getProgressXForPercentage()` and `getRegularWaveConfig()` and updated `spawnWave()` to accept a `triggerX` and spawn enemies near that checkpoint. 
- Reworked `updateStageProgress()` to evaluate `state.player.x` against percentage-derived trigger Xs to advance `state.waveIndex` and to spawn the boss at 90% instead of auto-advancing immediately. 
- Implemented `updateContinueArrow(dt)` to track idle forward progress and start the yellow arrow flashing when the player hasn't advanced for 5 seconds, and wired it into `gameLoop()`; wave/boss spawns now reset the idle timer and arrow. 

### Testing
- Ran a JavaScript syntax check on the extracted inline script with `node --check /tmp/bayou.js`, which succeeded. 
- Attempted to capture a browser render via Playwright to validate the visual arrow behavior, but the scripted screenshot attempt failed due to local server/file access in the environment (rendering step did not complete). 
- Confirmed the updated logic compiles in place and the new helpers are exercised by `setupLevel()` / `updateStageProgress()` in runtime flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a5520f2c8329b346c8605ec32a09)