### PR TITLE
Bayou Brawlers: allow melee strikes to hit overlapping enemies

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -982,7 +982,7 @@
       const damage = baseDamage * player.power;
       state.enemies.forEach(enemy => {
         if (enemy.hp <= 0) return;
-        if (rectOverlap(hitbox, enemy)) {
+        if (rectOverlap(hitbox, enemy) || playerBodyOverlap(player, enemy)) {
           enemy.hp -= damage;
           enemy.stun = Math.max(enemy.stun, stun);
           enemy.x += player.facing * knockback;
@@ -993,6 +993,27 @@
           }
         }
       });
+    }
+
+    function playerBodyOverlap(player, enemy) {
+      const playerBody = {
+        x: player.x - 16,
+        y: player.y - 32,
+        width: 32,
+        height: 40
+      };
+      const enemyBody = {
+        x: enemy.x - 16,
+        y: enemy.y - 32,
+        width: 32,
+        height: 40
+      };
+      return (
+        playerBody.x < enemyBody.x + enemyBody.width &&
+        playerBody.x + playerBody.width > enemyBody.x &&
+        playerBody.y < enemyBody.y + enemyBody.height &&
+        playerBody.y + playerBody.height > enemyBody.y
+      );
     }
 
     function rectOverlap(hitbox, enemy) {


### PR DESCRIPTION
### Motivation
- Melee attacks could miss enemies that are standing directly on top of the player because the attack only checked a directional strike hitbox; the intent is to make point-blank attacks register regardless of facing.

### Description
- Updated `doAttack` to register a hit when `rectOverlap(hitbox, enemy)` is true or when the new `playerBodyOverlap(player, enemy)` reports body-box intersection.
- Added `playerBodyOverlap(player, enemy)` which compares player and enemy body rectangles using the same dimensions used elsewhere for enemies to keep behavior consistent.
- Left damage, stun, knockback, score, and pickup logic unchanged.
- Modified file: `bayou-brawlers/index.html` (insertion of overlap check and helper).

### Testing
- Ran `git diff --check` on the working tree and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995fd0bae3c8329a379e8482e43b1d3)