### PR TITLE
Fix Bayou Brawlers continue arrow clipping at right edge

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1451,7 +1451,7 @@
     function drawContinueArrow() {
       if (state.continueArrowTimer <= 0) return;
       const alpha = 0.25 + (((Math.sin(performance.now() / 350) + 1) / 2) * 0.75);
-      const arrowX = canvas.width - 28;
+      const arrowX = canvas.width - 52;
       const arrowY = canvas.height / 2;
 
       ctx.save();


### PR DESCRIPTION
### Motivation
- The continue/continue-arrow HUD indicator was rendering too far right so the flashing yellow arrow tip could be clipped by the canvas edge and needed to be shifted left for full visibility.

### Description
- Shifted the arrow anchor in `bayou-brawlers/index.html` by changing `arrowX` from `canvas.width - 28` to `canvas.width - 52` so the arrow appears further left and its tip is no longer cut off.

### Testing
- Ran a project-wide search with `rg -n "bayou|brawler|arrow|yellow|flash|flashing" .` and inspected the resulting diff with `git diff` to confirm only the intended change was made, which succeeded.
- Served the site with `python3 -m http.server 8000` and captured a screenshot using a Playwright script to verify the arrow position visually, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699640eb3bc0832981a118318d71ceeb)