### PR TITLE
Replace Lantern Seer with Billy Boxby and stabilize player animations

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -606,15 +606,16 @@
         }
       },
       {
-        id: 'lantern-seer',
-        name: 'Lantern Seer',
-        portrait: 'assets/char-lantern-seer.svg',
-        sprite: 'assets/char-lantern-seer.svg',
+        id: 'billy-boxby',
+        name: 'Billy Boxby',
+        portrait: 'assets/BB_profile_billyBoxby.png',
+        sprite: 'billy-boxby',
+        renderScale: 0.75,
         stats: { speed: 3.0, power: 1.05, range: 50, durability: 115 },
         moves: {
-          fast: 'Lantern jab',
-          power: 'Spectral swing',
-          special: 'Summon wisp ally'
+          fast: 'Boxing jab',
+          power: 'Heavy crate smash',
+          special: 'Summon helper ally'
         },
         special: (player) => {
           state.ally = { x: player.x, y: player.y - 20, timer: 360 };
@@ -719,6 +720,15 @@
     const BOSS_DRAW_SIZE = 80;
     const BRAWL_LANE_MIN_Y = Math.floor(canvas.height * 0.5);
     const BRAWL_LANE_MAX_Y = canvas.height - 44;
+    const MOVE_EPSILON = 0.05;
+    const SPRITE_FRAME_SIZE = 256;
+
+    const PLAYER_ANIM_FPS = {
+      walk: 10,
+      attack: 14,
+      hurt: 12,
+      death: 8
+    };
 
     function clamp(value, min, max) {
       return Math.max(min, Math.min(max, value));
@@ -726,6 +736,36 @@
 
     function rand(min, max) {
       return Math.random() * (max - min) + min;
+    }
+
+    function buildFrameRects(img, frameCount) {
+      const frameRects = [];
+      const columns = Math.max(1, Math.floor(img.width / SPRITE_FRAME_SIZE));
+      const rows = Math.max(1, Math.floor(img.height / SPRITE_FRAME_SIZE));
+      const isVertical = rows >= frameCount && columns === 1;
+      const isHorizontal = columns >= frameCount && rows === 1;
+
+      if (isVertical) {
+        for (let i = 0; i < frameCount; i += 1) {
+          frameRects.push({ x: 0, y: i * SPRITE_FRAME_SIZE, width: SPRITE_FRAME_SIZE, height: SPRITE_FRAME_SIZE });
+        }
+        return frameRects;
+      }
+
+      if (isHorizontal) {
+        for (let i = 0; i < frameCount; i += 1) {
+          frameRects.push({ x: i * SPRITE_FRAME_SIZE, y: 0, width: SPRITE_FRAME_SIZE, height: SPRITE_FRAME_SIZE });
+        }
+        return frameRects;
+      }
+
+      for (let row = 0; row < rows && frameRects.length < frameCount; row += 1) {
+        for (let col = 0; col < columns && frameRects.length < frameCount; col += 1) {
+          frameRects.push({ x: col * SPRITE_FRAME_SIZE, y: row * SPRITE_FRAME_SIZE, width: SPRITE_FRAME_SIZE, height: SPRITE_FRAME_SIZE });
+        }
+      }
+
+      return frameRects;
     }
 
     function normalizeBackgroundImage(img) {
@@ -822,10 +862,96 @@
         specialCooldown: 0,
         jumpCooldown: 0,
         block: false,
+        isMoving: false,
         shieldTimer: 0,
         dashTimer: 0,
+        renderScale: charData.renderScale || 1,
+        animation: {
+          state: 'idle',
+          facing: 'right',
+          frameIndex: 0,
+          elapsedMs: 0,
+          complete: false
+        },
+        animationSignals: {
+          attack: false,
+          hurt: false
+        },
         charData
       };
+    }
+
+    function getPlayerAnimTrack(player, stateName, facingName) {
+      const bundle = assets.characters[player.charData.sprite];
+      if (!bundle || !bundle.tracks) return null;
+      const stateTracks = bundle.tracks[stateName];
+      if (!stateTracks) return null;
+      return stateTracks[facingName];
+    }
+
+    function updatePlayerAnimation(player, dt) {
+      const anim = player.animation;
+      const facingName = player.facing >= 0 ? 'right' : 'left';
+      let nextState = 'idle';
+
+      if (player.hp <= 0) {
+        nextState = 'death';
+      } else if ((anim.state === 'hurt' && !anim.complete) || player.animationSignals.hurt) {
+        nextState = 'hurt';
+        player.animationSignals.hurt = false;
+      } else if ((anim.state === 'attack' && !anim.complete) || player.animationSignals.attack) {
+        nextState = 'attack';
+        player.animationSignals.attack = false;
+      } else if (player.isMoving) {
+        nextState = 'walk';
+      }
+
+      const stateChanged = anim.state !== nextState;
+      const facingChanged = anim.facing !== facingName;
+      if (stateChanged) {
+        anim.state = nextState;
+        anim.frameIndex = 0;
+        anim.elapsedMs = 0;
+        anim.complete = false;
+      } else if (facingChanged) {
+        const fromTrack = getPlayerAnimTrack(player, anim.state, anim.facing);
+        const toTrack = getPlayerAnimTrack(player, anim.state, facingName);
+        if (fromTrack && toTrack && fromTrack.frames.length > 1 && toTrack.frames.length > 1) {
+          const progress = anim.frameIndex / (fromTrack.frames.length - 1);
+          anim.frameIndex = Math.round(progress * (toTrack.frames.length - 1));
+        }
+      }
+
+      anim.facing = facingName;
+
+      const track = getPlayerAnimTrack(player, anim.state, anim.facing);
+      if (!track || track.frames.length <= 1) {
+        anim.frameIndex = 0;
+        anim.elapsedMs = 0;
+        anim.complete = true;
+        return;
+      }
+
+      if (anim.complete && !track.loop) return;
+
+      const frameTime = 1000 / track.fps;
+      anim.elapsedMs += dt;
+      while (anim.elapsedMs >= frameTime) {
+        anim.elapsedMs -= frameTime;
+        if (track.loop) {
+          anim.frameIndex = (anim.frameIndex + 1) % track.frames.length;
+          continue;
+        }
+        if (anim.frameIndex < track.frames.length - 1) {
+          anim.frameIndex += 1;
+        }
+        if (anim.frameIndex >= track.frames.length - 1) {
+          anim.frameIndex = track.frames.length - 1;
+          anim.complete = true;
+          anim.elapsedMs = 0;
+          break;
+        }
+      }
     }
 
     function createEnemy(typeId, x, y, isBoss = false) {
@@ -917,6 +1043,7 @@
         finalAmount *= 0.45;
       }
       player.hp = clamp(player.hp - finalAmount, 0, player.maxHp);
+      player.animationSignals.hurt = true;
       state.shake = 6;
       updateHpBar();
       if (player.hp <= 0) {
@@ -960,14 +1087,17 @@
       if (!player) return;
       if (input.fast && player.attackCooldown <= 0) {
         player.attackCooldown = 22;
+        player.animationSignals.attack = true;
         doAttack(player, 12, player.range, 18);
       }
       if (input.power && player.powerCooldown <= 0) {
         player.powerCooldown = 45;
+        player.animationSignals.attack = true;
         doAttack(player, 24, player.range + 16, 30, 28);
       }
       if (input.special && player.specialCooldown <= 0) {
         player.specialCooldown = 240;
+        player.animationSignals.attack = true;
         player.charData.special(player);
       }
     }
@@ -1026,10 +1156,13 @@
       const player = state.player;
       if (!player) return;
       player.vx = 0;
+      let moveY = 0;
       if (input.left) player.vx -= player.speed;
       if (input.right) player.vx += player.speed;
-      if (input.up) player.y -= player.speed * 0.6;
-      if (input.down) player.y += player.speed * 0.6;
+      if (input.up) moveY -= player.speed * 0.6;
+      if (input.down) moveY += player.speed * 0.6;
+      player.y += moveY;
+      player.isMoving = Math.hypot(player.vx, moveY) > MOVE_EPSILON;
       if (player.vx !== 0) player.facing = player.vx > 0 ? 1 : -1;
       player.block = input.block;
 
@@ -1081,6 +1214,7 @@
       player.specialCooldown = Math.max(0, player.specialCooldown - 1);
       player.jumpCooldown = Math.max(0, player.jumpCooldown - 1);
       player.shieldTimer = Math.max(0, player.shieldTimer - 1);
+      updatePlayerAnimation(player, dt);
 
       document.getElementById('specialReady').textContent = player.specialCooldown <= 0 ? 'Ready' : `${Math.ceil(player.specialCooldown / 60)}s`;
     }
@@ -1353,6 +1487,25 @@
     function drawEntity(entity, size, colorOverride) {
       const x = entity.x - state.cameraX;
       const y = entity.y - state.cameraY - 32 - entity.z;
+      if (entity.animation && entity.charData) {
+        const track = getPlayerAnimTrack(entity, entity.animation.state, entity.animation.facing);
+        if (track && track.img) {
+          const frame = track.frames[entity.animation.frameIndex] || track.frames[0];
+          const drawSize = size * (entity.renderScale || 1);
+          ctx.drawImage(
+            track.img,
+            frame.x,
+            frame.y,
+            frame.width,
+            frame.height,
+            x - drawSize / 2,
+            y,
+            drawSize,
+            drawSize
+          );
+          return;
+        }
+      }
       if (entity.sprite) {
         ctx.drawImage(entity.sprite, x - size / 2, y, size, size);
       } else {
@@ -1706,13 +1859,36 @@
         'assets/char-bayou-bruiser.svg': 'assets/char-bayou-bruiser.svg',
         'assets/char-fume-alchemist.svg': 'assets/char-fume-alchemist.svg',
         'assets/char-grove-sentinel.svg': 'assets/char-grove-sentinel.svg',
-        'assets/char-clockwire-duelist.svg': 'assets/char-clockwire-duelist.svg',
-        'assets/char-lantern-seer.svg': 'assets/char-lantern-seer.svg'
+        'assets/char-clockwire-duelist.svg': 'assets/char-clockwire-duelist.svg'
       };
 
       Object.entries(characterSprites).forEach(([key, src]) => {
         promises.push(loadImage(src).then(img => { assets.characters[key] = img; }));
       });
+
+      const billySpriteSheets = {
+        idle: { right: ['assets/BB_billyBoxby_right.png', 1], left: ['assets/BB_billyBoxby_left.png', 1], fps: 0, loop: false },
+        walk: { right: ['assets/BB_billyBoxby_walking_right.png', 4], left: ['assets/BB_billyBoxby_walking_left.png', 4], fps: PLAYER_ANIM_FPS.walk, loop: true },
+        hurt: { right: ['assets/BB_billyBoxby_damaged_right.png', 4], left: ['assets/BB_billyBoxby_damaged_left.png', 4], fps: PLAYER_ANIM_FPS.hurt, loop: false },
+        attack: { right: ['assets/BB_billyBoxby_attack_heavy_right.png', 7], left: ['assets/BB_billyBoxby_attack_heavy_left.png', 7], fps: PLAYER_ANIM_FPS.attack, loop: false },
+        death: { right: ['assets/BB_billyBoxby_killed_right.png', 5], left: ['assets/BB_billyBoxby_killed_left.png', 5], fps: PLAYER_ANIM_FPS.death, loop: false }
+      };
+
+      const billyTracks = { idle: {}, walk: {}, hurt: {}, attack: {}, death: {} };
+      Object.entries(billySpriteSheets).forEach(([stateName, config]) => {
+        ['right', 'left'].forEach((facingName) => {
+          const [src, frameCount] = config[facingName];
+          promises.push(loadImage(src).then((img) => {
+            billyTracks[stateName][facingName] = {
+              img,
+              frames: buildFrameRects(img, frameCount),
+              fps: config.fps,
+              loop: config.loop
+            };
+          }));
+        });
+      });
+      assets.characters['billy-boxby'] = { tracks: billyTracks };
 
       const enemySprites = {
         'enemy-goblin': 'assets/enemy-goblin.svg',


### PR DESCRIPTION
### Motivation
- Replace the Lantern Seer playable character with Billy Boxby and use the provided Billy PNG assets for all player tracks. 
- Fix visual flashing and frame-sampling bugs by preventing per-frame recreation/reset of animations and by building correct frame rects from sprite sheets. 
- Keep gameplay (movement, collision, speeds) unchanged while adjusting only render scale and animation playback behavior.

### Description
- Replaced the Lantern Seer roster entry with `Billy Boxby`, using `assets/BB_profile_billyBoxby.png` for the selection thumbnail and a `renderScale` of `0.75` for in-game rendering.  (Updated `bayou-brawlers/index.html`.)
- Added a frame-rect builder `buildFrameRects(img, frameCount)` that detects vertical/horizontal sheet layouts and generates safe 256×256 frame rects to prevent out-of-bounds sampling. 
- Implemented a persistent player animation controller: players now carry `animation` and `animationSignals`, animations advance by accumulated `dt` using per-track `fps`, only reset on true state changes, preserve normalized progress when swapping left/right tracks, and respect priority `death > hurt > attack > walk > idle` with one-shot tracks freezing on their last frame. 
- Hooked Billy tracks into asset loading (idle/walk/hurt/attack/death, left/right) using the new builder and updated `drawEntity` to sample per-track frames when available, falling back to the legacy sprite behavior otherwise. 
- Added a stable `isMoving` test (epsilon on vx/vertical movement) and emit `attack`/`hurt` animation signals so state transitions don't flicker or restart each frame.

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all test suites passed. 
- Attempted a visual smoke-test by starting a local `python -m http.server` and capturing a Playwright screenshot, but the headless-browser run could not access the served page in this environment (network/file access errors), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69973b3a2ff08329996f3bae39d64c20)