### PR TITLE
Scale Bayou Brawlers player display and hitbox by 4x

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -715,9 +715,12 @@
     const TOTAL_WAVE_COUNT = 9;
     const WAVE_TRIGGER_PCTS = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
     const IDLE_ARROW_DELAY_FRAMES = 300;
-    const PLAYER_DRAW_SIZE = 56;
+    const PLAYER_SCALE_MULTIPLIER = 4;
+    const PLAYER_DRAW_SIZE = 56 * PLAYER_SCALE_MULTIPLIER;
     const ENEMY_DRAW_SIZE = 48;
     const BOSS_DRAW_SIZE = 80;
+    const PLAYER_HITBOX_WIDTH = 32 * PLAYER_SCALE_MULTIPLIER;
+    const PLAYER_HITBOX_HEIGHT = 40 * PLAYER_SCALE_MULTIPLIER;
     const BRAWL_LANE_MIN_Y = Math.floor(canvas.height * 0.5);
     const BRAWL_LANE_MAX_Y = canvas.height - 44;
     const MOVE_EPSILON = 0.05;
@@ -1127,10 +1130,10 @@
 
     function playerBodyOverlap(player, enemy) {
       const playerBody = {
-        x: player.x - 16,
-        y: player.y - 32,
-        width: 32,
-        height: 40
+        x: player.x - (PLAYER_HITBOX_WIDTH / 2),
+        y: player.y - PLAYER_HITBOX_HEIGHT,
+        width: PLAYER_HITBOX_WIDTH,
+        height: PLAYER_HITBOX_HEIGHT
       };
       const enemyBody = {
         x: enemy.x - 16,
@@ -1293,7 +1296,7 @@
               }
             }
           });
-        } else if (player && Math.abs(projectile.x - player.x) < 20 && Math.abs(projectile.y - player.y) < 24) {
+        } else if (player && Math.abs(projectile.x - player.x) < (PLAYER_HITBOX_WIDTH / 2) && Math.abs(projectile.y - player.y) < (PLAYER_HITBOX_HEIGHT * 0.6)) {
           damagePlayer(projectile.damage);
           projectile.life = 0;
         }


### PR DESCRIPTION
### Motivation
- Make the player character visually larger in-game and ensure collision/hit detection matches the new size by applying a single scale factor to render and hitbox dimensions.

### Description
- Introduced `PLAYER_SCALE_MULTIPLIER = 4` and applied it to `PLAYER_DRAW_SIZE` so the player sprite is rendered 4x larger.
- Added `PLAYER_HITBOX_WIDTH` and `PLAYER_HITBOX_HEIGHT` derived from the same multiplier to centralize player collision dimensions.
- Replaced hard-coded player body rectangle in `playerBodyOverlap` with multiplier-based hitbox values.
- Updated projectile vs player collision check in `updateProjectiles` to use the enlarged hitbox dimensions so incoming projectiles hit the scaled player correctly.

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all Jest suites passed (`3 passed, 3 total`).
- Attempted an automated Playwright render/screenshot to validate the visual change, but the headless Chromium run crashed in this environment (SIGSEGV) so no screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69973ffa5c948329a3455780f9aa31a8)