### PR TITLE
fix(bayou-brawlers): use attack animation for bramble drone boss

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -991,6 +991,7 @@
         } : null,
         cooldown: rand(40, 80),
         windup: 0,
+        attackAnimActive: false,
         stun: 0,
         ranged: base.ranged || false,
         isBoss,
@@ -1039,7 +1040,12 @@
       if (!enemy.animation) return;
       const anim = enemy.animation;
       const facingName = enemy.facing >= 0 ? 'right' : 'left';
-      const nextState = enemy.windup > 0 ? 'attack' : (enemy.isMoving ? 'walk' : 'idle');
+      let nextState = enemy.isMoving ? 'walk' : 'idle';
+
+      if ((anim.state === 'attack' && !anim.complete) || enemy.attackAnimActive || enemy.windup > 0) {
+        nextState = 'attack';
+        enemy.attackAnimActive = false;
+      }
 
       if (anim.state !== nextState) {
         anim.state = nextState;
@@ -1364,6 +1370,7 @@
         } else {
           if (enemy.windup <= 0 && enemy.cooldown <= 0) {
             enemy.windup = 18;
+            enemy.attackAnimActive = true;
           }
         }
 

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -991,7 +991,7 @@
         } : null,
         cooldown: rand(40, 80),
         windup: 0,
-        attackAnimActive: false,
+        attackAnimTimer: 0,
         stun: 0,
         ranged: base.ranged || false,
         isBoss,
@@ -1042,9 +1042,8 @@
       const facingName = enemy.facing >= 0 ? 'right' : 'left';
       let nextState = enemy.isMoving ? 'walk' : 'idle';
 
-      if ((anim.state === 'attack' && !anim.complete) || enemy.attackAnimActive || enemy.windup > 0) {
+      if ((anim.state === 'attack' && !anim.complete) || enemy.attackAnimTimer > 0 || enemy.windup > 0) {
         nextState = 'attack';
-        enemy.attackAnimActive = false;
       }
 
       if (anim.state !== nextState) {
@@ -1370,7 +1369,7 @@
         } else {
           if (enemy.windup <= 0 && enemy.cooldown <= 0) {
             enemy.windup = 18;
-            enemy.attackAnimActive = true;
+            enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 18);
           }
         }
 
@@ -1396,6 +1395,10 @@
           }
         } else {
           enemy.cooldown = Math.max(0, enemy.cooldown - 1);
+        }
+
+        if (enemy.attackAnimTimer > 0) {
+          enemy.attackAnimTimer -= 1;
         }
 
         const verticalBounds = getEnemyVerticalBounds(enemy);


### PR DESCRIPTION
### Motivation
- Fix the Bramble Drone boss showing the walking frames during an attack by ensuring the attack sprite (`BB_brambleDrone_attack_left/right.png`) is played while the attack is active or winding up.

### Description
- Added an `attackAnimActive` flag to enemy state and updated `updateEnemyAnimation` to prioritize the `attack` state when the attack is active, the attack track is still playing, or `windup > 0`, and set `attackAnimActive` when an enemy begins windup in `bayou-brawlers/index.html`.

### Testing
- Ran `npm test -- --runInBand` and all test suites passed (3 suites, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b39fb5fc8329a75295879d05e841)