### PR TITLE
Fix Bayou Brawlers hitbox alignment for Billy Boxby and Bramble Drone boss

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -723,6 +723,9 @@
     const BOSS_DRAW_SIZE = 80;
     const PLAYER_HITBOX_WIDTH = 32 * PLAYER_SCALE_MULTIPLIER;
     const PLAYER_HITBOX_HEIGHT = 40 * PLAYER_SCALE_MULTIPLIER;
+    const BILLY_BOXBY_HITBOX_WIDTH_RATIO = 0.57;
+    const BILLY_BOXBY_HITBOX_TOP_RATIO = 1 / 3;
+    const BILLY_BOXBY_HITBOX_HEIGHT_RATIO = 2 / 3;
     const BRAMBLE_DRONE_BOSS_SCALE_MULTIPLIER = 4;
     const BRAMBLE_DRONE_BOSS_HITBOX_SCALE_MULTIPLIER = 4;
     const BRAMBLE_DRONE_BOSS_ANIM_FPS_MULTIPLIER = 1;
@@ -1001,6 +1004,16 @@
     }
 
     function getEnemyHitbox(enemy) {
+      if (enemy.isBoss && enemy.type === 'bramble-drone') {
+        const drawSize = BOSS_DRAW_SIZE * (enemy.renderScale || 1);
+        return {
+          x: enemy.x - (drawSize / 2),
+          y: enemy.y - 32,
+          width: drawSize,
+          height: drawSize
+        };
+      }
+
       const scale = enemy.hitboxScale || 1;
       const width = 32 * scale;
       const height = 40 * scale;
@@ -1245,27 +1258,54 @@
     }
 
     function playerBodyOverlap(player, enemy) {
-      const playerBody = {
+      const playerBody = getPlayerHitbox(player);
+      const enemyBody = getEnemyHitbox(enemy);
+      return rectsOverlap(playerBody, enemyBody);
+    }
+
+    function rectOverlap(hitbox, enemy) {
+      const enemyBody = getEnemyHitbox(enemy);
+      return rectsOverlap(hitbox, enemyBody);
+    }
+
+    function rectsOverlap(rectA, rectB) {
+      return rectA.x < rectB.x + rectB.width
+        && rectA.x + rectA.width > rectB.x
+        && rectA.y < rectB.y + rectB.height
+        && rectA.y + rectA.height > rectB.y;
+    }
+
+    function getPlayerHitbox(player) {
+      if (player.charData && player.charData.id === 'billy-boxby') {
+        const drawSize = PLAYER_DRAW_SIZE * (player.renderScale || 1);
+        const width = drawSize * BILLY_BOXBY_HITBOX_WIDTH_RATIO;
+        const hitboxTop = (player.y - 32 - player.z) + (drawSize * BILLY_BOXBY_HITBOX_TOP_RATIO);
+        return {
+          x: player.x - (width / 2),
+          y: hitboxTop,
+          width,
+          height: drawSize * BILLY_BOXBY_HITBOX_HEIGHT_RATIO
+        };
+      }
+
+      return {
         x: player.x - (PLAYER_HITBOX_WIDTH / 2),
         y: player.y - PLAYER_HITBOX_HEIGHT,
         width: PLAYER_HITBOX_WIDTH,
         height: PLAYER_HITBOX_HEIGHT
       };
-      const enemyBody = getEnemyHitbox(enemy);
-      return (
-        playerBody.x < enemyBody.x + enemyBody.width &&
-        playerBody.x + playerBody.width > enemyBody.x &&
-        playerBody.y < enemyBody.y + enemyBody.height &&
-        playerBody.y + playerBody.height > enemyBody.y
-      );
     }
 
-    function rectOverlap(hitbox, enemy) {
+    function enemyCanHitPlayer(enemy, player, rangePadding = 10) {
       const enemyBody = getEnemyHitbox(enemy);
-      return hitbox.x < enemyBody.x + enemyBody.width
-        && hitbox.x + hitbox.width > enemyBody.x
-        && hitbox.y < enemyBody.y + enemyBody.height
-        && hitbox.y + hitbox.height > enemyBody.y;
+      const playerBody = getPlayerHitbox(player);
+      const attackBounds = {
+        x: enemyBody.x - enemy.range - rangePadding,
+        y: enemyBody.y - enemy.range - rangePadding,
+        width: enemyBody.width + ((enemy.range + rangePadding) * 2),
+        height: enemyBody.height + ((enemy.range + rangePadding) * 2)
+      };
+      return rectsOverlap(playerBody, attackBounds);
     }
 
     function updatePlayer(dt) {
@@ -1387,7 +1427,7 @@
                 color: '#ff7b7b'
               });
             } else {
-              if (distance < enemy.range + 10) {
+              if (enemyCanHitPlayer(enemy, player)) {
                 damagePlayer(enemy.damage);
               }
             }
@@ -1435,9 +1475,17 @@
               }
             }
           });
-        } else if (player && Math.abs(projectile.x - player.x) < (PLAYER_HITBOX_WIDTH / 2) && Math.abs(projectile.y - player.y) < (PLAYER_HITBOX_HEIGHT * 0.6)) {
-          damagePlayer(projectile.damage);
-          projectile.life = 0;
+        } else if (player) {
+          const playerBody = getPlayerHitbox(player);
+          if (
+            projectile.x > playerBody.x &&
+            projectile.x < playerBody.x + playerBody.width &&
+            projectile.y > playerBody.y &&
+            projectile.y < playerBody.y + playerBody.height
+          ) {
+            damagePlayer(projectile.damage);
+            projectile.life = 0;
+          }
         }
       });
       state.projectiles = state.projectiles.filter(projectile => projectile.life > 0);


### PR DESCRIPTION
### Motivation
- Billy Boxby’s sprite occupies the lower two-thirds of his frames so his collision box should be limited to that area to avoid unfair hits and missed interactions.
- The Bramble Drone boss renders at full-frame size so its hitbox must cover the entire sprite so it can damage the player when adjacent or on top instead of only near the top of the image.

### Description
- Added Billy-specific hitbox constants (`BILLY_BOXBY_HITBOX_*`) and a new `getPlayerHitbox(player)` that returns a reduced hitbox for the `billy-boxby` character and the default hitbox for others in `bayou-brawlers/index.html`.
- Updated `getEnemyHitbox(enemy)` to return the full rendered sprite bounds for an enemy that is the Bramble Drone boss (when `enemy.isBoss && enemy.type === 'bramble-drone'`).
- Introduced shared rectangle helpers: `rectsOverlap(rectA, rectB)`, and refactored `rectOverlap` and `playerBodyOverlap` to use these helpers for consistent collision logic.
- Replaced the previous center-distance check for melee attacks with `enemyCanHitPlayer(enemy, player)` which builds an attack bounds box using the enemy body plus its `range` and a padding, and used it in the enemy melee damage path so large bosses can hit when adjacent or on top.
- Changed hostile projectile vs player collision to test against the active `getPlayerHitbox(player)` (so Billy’s custom hitbox is respected).
- All changes are contained in `bayou-brawlers/index.html`.

### Testing
- Ran the project test suite with `npm test -- --runInBand` and all automated tests passed (`3` test suites, `6` tests total).
- Verified there are no failing Jest snapshots and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699859aac4508329b5b79c7825e79e9e)