### PR TITLE
Clamp Bayou Brawlers entities to play-screen vertical bounds

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -851,6 +851,19 @@
       return BRAWL_LANE_MIN_Y;
     }
 
+    function getEntityMaxYForDrawSize(drawSize) {
+      return canvas.height - Math.max(0, drawSize - 32);
+    }
+
+    function getPlayerVerticalBounds(player) {
+      const drawSize = PLAYER_DRAW_SIZE * (player.renderScale || 1);
+      const minY = getBrawlLaneMinY();
+      return {
+        minY,
+        maxY: Math.max(minY, Math.min(BRAWL_LANE_MAX_Y, getEntityMaxYForDrawSize(drawSize)))
+      };
+    }
+
     function createPlayer(charData) {
       return {
         name: charData.name,
@@ -1013,16 +1026,11 @@
     }
 
     function getEnemyVerticalBounds(enemy) {
-      if (!(enemy.isBoss && enemy.type === 'bramble-drone')) {
-        return {
-          minY: getBrawlLaneMinY(),
-          maxY: BRAWL_LANE_MAX_Y
-        };
-      }
-
-      const drawSize = BOSS_DRAW_SIZE * (enemy.renderScale || 1);
-      const minY = 32;
-      const maxY = canvas.height - drawSize + 32;
+      const drawSize = (enemy.isBoss ? BOSS_DRAW_SIZE : ENEMY_DRAW_SIZE) * (enemy.renderScale || 1);
+      const minY = enemy.isBoss && enemy.type === 'bramble-drone' ? 32 : getBrawlLaneMinY();
+      const maxY = enemy.isBoss && enemy.type === 'bramble-drone'
+        ? getEntityMaxYForDrawSize(drawSize)
+        : Math.min(BRAWL_LANE_MAX_Y, getEntityMaxYForDrawSize(drawSize));
       return {
         minY,
         maxY: Math.max(minY, maxY)
@@ -1306,7 +1314,8 @@
       }
 
       player.x = clamp(player.x, 40, state.levelWidth - 40);
-      player.y = clamp(player.y, getBrawlLaneMinY(), BRAWL_LANE_MAX_Y);
+      const playerVerticalBounds = getPlayerVerticalBounds(player);
+      player.y = clamp(player.y, playerVerticalBounds.minY, playerVerticalBounds.maxY);
       player.isMoving = Math.hypot(player.x - prevX, player.y - prevY) > MOVE_EPSILON;
 
       if (state.lockX !== null && player.x > state.lockX) {


### PR DESCRIPTION
### Motivation
- The player character and some enemies could move or be rendered below the visible play area, causing sprites to slip off-screen and break visual/interaction expectations.
- Vertical clamping must account for sprite draw size and per-entity scale so large bosses or scaled sprites cannot escape the bottom of the screen.

### Description
- Added `getEntityMaxYForDrawSize(drawSize)` to compute the maximum allowed world Y for an entity based on its rendered draw size.
- Added `getPlayerVerticalBounds(player)` which derives per-player `minY`/`maxY` using `PLAYER_DRAW_SIZE` and `renderScale` so the player stays on-screen.
- Reworked `getEnemyVerticalBounds(enemy)` to compute `drawSize` from `ENEMY_DRAW_SIZE`/`BOSS_DRAW_SIZE` and `renderScale`, clamping regular enemies and bosses to visible bounds while preserving the bramble-drone boss upper-lane behavior.
- Updated `updatePlayer` to use the new player vertical bounds when clamping `player.y` so the player can no longer move below the play screen.

### Testing
- Served the project locally with `python3 -m http.server 4173` and verified the game page responded successfully.
- Automated browser check using Playwright loaded `http://127.0.0.1:4173/bayou-brawlers/index.html` and produced a screenshot confirming the page rendered with the updated clamping logic.
- Verified the code changes via `git diff -- bayou-brawlers/index.html` to ensure the intended edits were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69987b8cfca48329b8d32d489968398d)