### PR TITLE
Scale Choking Blossom (swamp) by 2x

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -726,6 +726,7 @@
     const BRAMBLE_DRONE_BOSS_SCALE_MULTIPLIER = 4;
     const BRAMBLE_DRONE_BOSS_HITBOX_SCALE_MULTIPLIER = 4;
     const BRAMBLE_DRONE_BOSS_ANIM_FPS_MULTIPLIER = 1;
+    const CHOKING_BLOSSOM_SCALE_MULTIPLIER = 2;
     const ENEMY_FACING_DEADZONE_X = 6;
     const BRAWL_LANE_MIN_Y = Math.floor(canvas.height * 0.5);
     const BRAWL_LANE_MAX_Y = canvas.height - 44;
@@ -981,6 +982,7 @@
       const base = enemyTypes[typeId];
       const animationTracks = assets.enemyAnimations[typeId] || null;
       const isBrambleDroneBoss = isBoss && typeId === 'bramble-drone';
+      const isChokingBlossom = typeId === 'swamp';
       return {
         type: typeId,
         x,
@@ -1008,8 +1010,12 @@
         stun: 0,
         ranged: base.ranged || false,
         isBoss,
-        renderScale: isBrambleDroneBoss ? BRAMBLE_DRONE_BOSS_SCALE_MULTIPLIER : 1,
-        hitboxScale: isBrambleDroneBoss ? BRAMBLE_DRONE_BOSS_HITBOX_SCALE_MULTIPLIER : 1
+        renderScale: isBrambleDroneBoss
+          ? BRAMBLE_DRONE_BOSS_SCALE_MULTIPLIER
+          : (isChokingBlossom ? CHOKING_BLOSSOM_SCALE_MULTIPLIER : 1),
+        hitboxScale: isBrambleDroneBoss
+          ? BRAMBLE_DRONE_BOSS_HITBOX_SCALE_MULTIPLIER
+          : (isChokingBlossom ? CHOKING_BLOSSOM_SCALE_MULTIPLIER : 1)
       };
     }
 


### PR DESCRIPTION
### Motivation
- The Choking Blossom enemy (internal type `swamp`) should appear and collide at twice its previous visual size to match design intent. 
- Apply a dedicated scale multiplier so the change is explicit and easy to adjust later.

### Description
- Added a `CHOKING_BLOSSOM_SCALE_MULTIPLIER` constant set to `2` in `bayou-brawlers/index.html`.
- Detect `isChokingBlossom` when `typeId === 'swamp'` in `createEnemy()`.
- Apply the multiplier to both `renderScale` and `hitboxScale` for Choking Blossom while preserving the existing Bramble Drone boss scaling logic.

### Testing
- Verified code locations and references with a code search using `rg` and inspected the modified regions; the search completed successfully.
- Launched a local server with `python3 -m http.server 4173` and confirmed the game assets loaded successfully.
- Captured a Playwright screenshot of `http://127.0.0.1:4173/bayou-brawlers/index.html` to visually validate the change, and the script ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998eba7ce24832982384e412984b7ad)