### PR TITLE
Adjust hitboxes for Bramble Drone, Billy Boxby, and Choking Blossom

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1020,6 +1020,29 @@
     }
 
     function getEnemyHitbox(enemy) {
+      const drawSize = (enemy.isBoss ? BOSS_DRAW_SIZE : ENEMY_DRAW_SIZE) * (enemy.renderScale || 1);
+
+      if (enemy.isBoss && enemy.type === 'bramble-drone') {
+        return {
+          x: enemy.x - (drawSize / 2),
+          y: enemy.y - 32,
+          width: drawSize,
+          height: drawSize
+        };
+      }
+
+      if (enemy.type === 'swamp') {
+        const hitboxSize = drawSize * (2 / 3);
+        const imageTop = enemy.y - 32;
+        const lowerThirdCenterY = imageTop + (drawSize * (5 / 6));
+        return {
+          x: enemy.x - (hitboxSize / 2),
+          y: lowerThirdCenterY - (hitboxSize / 2),
+          width: hitboxSize,
+          height: hitboxSize
+        };
+      }
+
       const scale = enemy.hitboxScale || 1;
       const width = 32 * scale;
       const height = 40 * scale;
@@ -1028,6 +1051,26 @@
         y: enemy.y - (32 * scale),
         width,
         height
+      };
+    }
+
+    function getPlayerHitbox(player) {
+      if (player?.charData?.id === 'billy-boxby') {
+        const drawSize = PLAYER_DRAW_SIZE * (player.renderScale || 1);
+        const hitboxSize = drawSize * (2 / 3);
+        return {
+          x: player.x - (hitboxSize / 2),
+          y: player.y - (hitboxSize / 2),
+          width: hitboxSize,
+          height: hitboxSize
+        };
+      }
+
+      return {
+        x: player.x - (PLAYER_HITBOX_WIDTH / 2),
+        y: player.y - PLAYER_HITBOX_HEIGHT,
+        width: PLAYER_HITBOX_WIDTH,
+        height: PLAYER_HITBOX_HEIGHT
       };
     }
 
@@ -1259,12 +1302,7 @@
     }
 
     function playerBodyOverlap(player, enemy) {
-      const playerBody = {
-        x: player.x - (PLAYER_HITBOX_WIDTH / 2),
-        y: player.y - PLAYER_HITBOX_HEIGHT,
-        width: PLAYER_HITBOX_WIDTH,
-        height: PLAYER_HITBOX_HEIGHT
-      };
+      const playerBody = getPlayerHitbox(player);
       const enemyBody = getEnemyHitbox(enemy);
       return (
         playerBody.x < enemyBody.x + enemyBody.width &&
@@ -1450,9 +1488,17 @@
               }
             }
           });
-        } else if (player && Math.abs(projectile.x - player.x) < (PLAYER_HITBOX_WIDTH / 2) && Math.abs(projectile.y - player.y) < (PLAYER_HITBOX_HEIGHT * 0.6)) {
-          damagePlayer(projectile.damage);
-          projectile.life = 0;
+        } else if (player) {
+          const playerBody = getPlayerHitbox(player);
+          if (
+            projectile.x > playerBody.x &&
+            projectile.x < playerBody.x + playerBody.width &&
+            projectile.y > playerBody.y &&
+            projectile.y < playerBody.y + playerBody.height
+          ) {
+            damagePlayer(projectile.damage);
+            projectile.life = 0;
+          }
         }
       });
       state.projectiles = state.projectiles.filter(projectile => projectile.life > 0);


### PR DESCRIPTION
### Motivation
- Align collision hitboxes with the visual idle sprites so boss and specific characters feel fair and consistent during combat.
- Make Billy Boxby and Choking Blossom use smaller, centered hitboxes matching design notes (Billy = 2/3 idle image, centered on lower edge; Choking Blossom = centered around lower 1/3 of idle image). 

### Description
- Reworked `getEnemyHitbox(enemy)` to compute a `drawSize` and return a full-image hitbox for the Bramble Drone boss when `enemy.type === 'bramble-drone'` and `enemy.isBoss`.
- Added a special-case in `getEnemyHitbox` for `enemy.type === 'swamp'` (Choking Blossom) to return a hitbox equal to `2/3 * drawSize` and positioned around the lower-third area of the sprite.
- Introduced `getPlayerHitbox(player)` helper and gave Billy Boxby (`charData.id === 'billy-boxby'`) a hitbox of `2/3 * PLAYER_DRAW_SIZE` centered on the lower-middle anchor.
- Switched `playerBodyOverlap` and hostile projectile-vs-player collision checks to use `getPlayerHitbox(player)` for consistent hit detection across attacks and projectiles.

### Testing
- Parsed all inline JavaScript blocks in `bayou-brawlers/index.html` with Node using a small script that extracts `<script>` blocks and runs `new Function(...)`, which succeeded and reported 4 parsed inline script blocks.
- Performed a quick smoke validation by loading and scanning the modified lines in `index.html` to ensure the new helpers and conditionals are present (no runtime exceptions reported by the inline-parse check).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998eed89e1883299b455427d3ed8402)