### PR TITLE
Fix Billy Boxby pickup collision and enemy targeting

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1015,7 +1015,8 @@
           : (isChokingBlossom ? CHOKING_BLOSSOM_SCALE_MULTIPLIER : 1),
         hitboxScale: isBrambleDroneBoss
           ? BRAMBLE_DRONE_BOSS_HITBOX_SCALE_MULTIPLIER
-          : (isChokingBlossom ? CHOKING_BLOSSOM_SCALE_MULTIPLIER : 1)
+          : (isChokingBlossom ? CHOKING_BLOSSOM_SCALE_MULTIPLIER : 1),
+        targetBodyAimBias: rand(35, 85) / 100
       };
     }
 
@@ -1072,6 +1073,24 @@
         width: PLAYER_HITBOX_WIDTH,
         height: PLAYER_HITBOX_HEIGHT
       };
+    }
+
+    function rectsOverlap(a, b) {
+      return a.x < b.x + b.width
+        && a.x + a.width > b.x
+        && a.y < b.y + b.height
+        && a.y + a.height > b.y;
+    }
+
+    function getEnemyAimTargetY(enemy, player) {
+      const playerBody = getPlayerHitbox(player);
+      const enemyBody = getEnemyHitbox(enemy);
+      const playerArea = playerBody.width * playerBody.height;
+      const enemyArea = enemyBody.width * enemyBody.height;
+
+      if (enemyArea < playerArea * 0.5) return playerBody.y + (playerBody.height * 0.82);
+      if (enemyArea > playerArea * 1.5) return playerBody.y + (playerBody.height * 0.2);
+      return playerBody.y + (playerBody.height * enemy.targetBodyAimBias);
     }
 
     function getEnemyVerticalBounds(enemy) {
@@ -1314,10 +1333,7 @@
 
     function rectOverlap(hitbox, enemy) {
       const enemyBody = getEnemyHitbox(enemy);
-      return hitbox.x < enemyBody.x + enemyBody.width
-        && hitbox.x + hitbox.width > enemyBody.x
-        && hitbox.y < enemyBody.y + enemyBody.height
-        && hitbox.y + hitbox.height > enemyBody.y;
+      return rectsOverlap(hitbox, enemyBody);
     }
 
     function updatePlayer(dt) {
@@ -1404,7 +1420,8 @@
           return;
         }
         const dx = player.x - enemy.x;
-        const dy = player.y - enemy.y;
+        const targetY = getEnemyAimTargetY(enemy, player);
+        const dy = targetY - enemy.y;
         const distance = Math.hypot(dx, dy);
         enemy.isMoving = false;
         if (Math.abs(dx) > ENEMY_FACING_DEADZONE_X) {
@@ -1506,9 +1523,16 @@
 
     function updatePickups() {
       const player = state.player;
+      const playerBody = getPlayerHitbox(player);
       state.pickups.forEach(pickup => {
         pickup.timer -= 1;
-        if (Math.abs(player.x - pickup.x) < 30 && Math.abs(player.y - pickup.y) < 26) {
+        const pickupBody = {
+          x: pickup.x - 10,
+          y: pickup.y - 12,
+          width: 20,
+          height: 20
+        };
+        if (rectsOverlap(playerBody, pickupBody)) {
           player.hp = clamp(player.hp + 25, 0, player.maxHp);
           updateHpBar();
           addScore(40);

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1075,6 +1075,21 @@
       };
     }
 
+    function getPlayerPickupHitbox(player) {
+      const body = getPlayerHitbox(player);
+      const drawSize = PLAYER_DRAW_SIZE * (player?.renderScale || 1);
+      const spriteTop = player.y - 32;
+      const spriteBottom = spriteTop + drawSize;
+      const bodyBottom = body.y + body.height;
+      if (bodyBottom >= spriteBottom) return body;
+      return {
+        x: body.x,
+        y: body.y,
+        width: body.width,
+        height: body.height + (spriteBottom - bodyBottom)
+      };
+    }
+
     function rectsOverlap(a, b) {
       return a.x < b.x + b.width
         && a.x + a.width > b.x
@@ -1523,7 +1538,7 @@
 
     function updatePickups() {
       const player = state.player;
-      const playerBody = getPlayerHitbox(player);
+      const playerBody = getPlayerPickupHitbox(player);
       state.pickups.forEach(pickup => {
         pickup.timer -= 1;
         const pickupBody = {


### PR DESCRIPTION
### Motivation
- Billy Boxby only collected health pickups when they were near the top of his sprite and enemies unnaturally homed in on his head, both of which broke expected collision/AI behavior. 
- The intent is to make pickups register on any overlap with Billy’s hitbox and to make enemy aim more natural based on relative hitbox sizes.

### Description
- Added a reusable rectangle intersection helper `rectsOverlap(a, b)` and replaced ad-hoc hit checks with it for consistent collision logic.  
- Introduced `targetBodyAimBias` on enemies (randomized per enemy) and a `getEnemyAimTargetY(enemy, player)` helper to compute a vertical aim point based on enemy vs player hitbox area.  
- When updating enemy steering, replaced the previous head-focused delta with a `targetY` from `getEnemyAimTargetY(...)` so enemies aim at feet/lower-body for small enemies, head/upper-body for much larger enemies, and varied body positions for similarly sized enemies.  
- Reworked pickup collection in `updatePickups()` to build a pickup bounding rect and check overlap against Billy’s hitbox so pickups register when touching any part of his body.

### Testing
- Ran targeted searches with `rg` to confirm the new symbols `rectsOverlap`, `getEnemyAimTargetY`, `targetBodyAimBias`, and updated `updatePickups` exist in `bayou-brawlers/index.html` (succeeded).  
- Inspected the modified ranges of `bayou-brawlers/index.html` with `sed`/`nl` to confirm the helper functions and replacements were applied (succeeded).  
- Applied the patch and verified the modified file shows the intended insertions and replacements via a file diff inspection (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f6c3d478832997e2290e8f2a8943)