### PR TITLE
Fix Bayou Brawlers bramble drone melee contact detection

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1105,6 +1105,25 @@
         && a.y + a.height > b.y;
     }
 
+    function rectDistance(a, b) {
+      const dx = Math.max(a.x - (b.x + b.width), b.x - (a.x + a.width), 0);
+      const dy = Math.max(a.y - (b.y + b.height), b.y - (a.y + a.height), 0);
+      return Math.hypot(dx, dy);
+    }
+
+    function enemyCanMeleeHitPlayer(enemy, player, fallbackDistance) {
+      if (!enemy || !player || enemy.ranged) return false;
+
+      if (enemy.isBoss && enemy.type === 'bramble-drone') {
+        const enemyBody = getEnemyHitbox(enemy);
+        const playerBody = getPlayerHitbox(player);
+        const contactPadding = 6;
+        return rectDistance(enemyBody, playerBody) <= contactPadding;
+      }
+
+      return fallbackDistance < enemy.range + 10;
+    }
+
     function getEnemyAimTargetY(enemy, player) {
       const playerBody = getPlayerHitbox(player);
       const enemyBody = getEnemyHitbox(enemy);
@@ -1480,7 +1499,7 @@
                 color: '#ff7b7b'
               });
             } else {
-              if (distance < enemy.range + 10) {
+              if (enemyCanMeleeHitPlayer(enemy, player, distance)) {
                 damagePlayer(enemy.damage);
               }
             }


### PR DESCRIPTION
### Motivation
- Players could walk through the bottom of the Bramble Drone boss sprite without taking damage because melee resolution used a center/distance fallback rather than the actual hitboxes. 
- The change ensures the Bramble Drone damages the player when the enemy and player hitboxes are touching or adjacent, matching visible overlap.

### Description
- Added a `rectDistance` helper that computes edge-to-edge distance between two axis-aligned hitboxes. 
- Added `enemyCanMeleeHitPlayer(enemy, player, fallbackDistance)` to centralize melee contact logic and special-case the Bramble Drone boss to use hitbox proximity with a small `contactPadding`. 
- Replaced the melee-range check used when an enemy windup completes with a call to `enemyCanMeleeHitPlayer` so Bramble Drone boss melee hits are triggered by hitbox contact. 
- All changes are in `bayou-brawlers/index.html`.

### Testing
- Ran the automated test suite with `npm test -- --runInBand` and all Jest suites passed. 
- Test result: 3 test suites passed, 6 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69992d0747c48329a2e1adafcb9f649c)