### PR TITLE
Adjust hitbox centers and edge-contact collision rules for Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1028,13 +1028,19 @@
       };
     }
 
+    function getSpriteLowerCenterY(worldY, drawSize) {
+      const imageTop = worldY - 32;
+      return imageTop + (drawSize * 0.75);
+    }
+
     function getEnemyHitbox(enemy) {
       const drawSize = (enemy.isBoss ? BOSS_DRAW_SIZE : ENEMY_DRAW_SIZE) * (enemy.renderScale || 1);
 
       if (enemy.isBoss && enemy.type === 'bramble-drone') {
+        const centerY = getSpriteLowerCenterY(enemy.y, drawSize);
         return {
           x: enemy.x - (drawSize / 2),
-          y: enemy.y - 32,
+          y: centerY - (drawSize / 2),
           width: drawSize,
           height: drawSize
         };
@@ -1067,9 +1073,10 @@
       if (player?.charData?.id === 'billy-boxby') {
         const drawSize = PLAYER_DRAW_SIZE * (player.renderScale || 1);
         const hitboxSize = drawSize * (2 / 3);
+        const centerY = getSpriteLowerCenterY(player.y, drawSize);
         return {
           x: player.x - (hitboxSize / 2),
-          y: player.y - (hitboxSize / 2),
+          y: centerY - (hitboxSize / 2),
           width: hitboxSize,
           height: hitboxSize
         };
@@ -1099,10 +1106,10 @@
     }
 
     function rectsOverlap(a, b) {
-      return a.x < b.x + b.width
-        && a.x + a.width > b.x
-        && a.y < b.y + b.height
-        && a.y + a.height > b.y;
+      return a.x <= b.x + b.width
+        && a.x + a.width >= b.x
+        && a.y <= b.y + b.height
+        && a.y + a.height >= b.y;
     }
 
     function getEnemyAimTargetY(enemy, player) {
@@ -1480,7 +1487,7 @@
                 color: '#ff7b7b'
               });
             } else {
-              if (distance < enemy.range + 10) {
+              if (rectsOverlap(getPlayerHitbox(player), getEnemyHitbox(enemy))) {
                 damagePlayer(enemy.damage);
               }
             }

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1037,7 +1037,7 @@
       const drawSize = (enemy.isBoss ? BOSS_DRAW_SIZE : ENEMY_DRAW_SIZE) * (enemy.renderScale || 1);
 
       if (enemy.isBoss && enemy.type === 'bramble-drone') {
-        const centerY = getSpriteLowerCenterY(enemy.y, drawSize);
+        const centerY = getSpriteLowerCenterY(enemy.y, drawSize, 0.58);
         return {
           x: enemy.x - (drawSize / 2),
           y: centerY - (drawSize / 2),
@@ -1073,7 +1073,7 @@
       if (player?.charData?.id === 'billy-boxby') {
         const drawSize = PLAYER_DRAW_SIZE * (player.renderScale || 1);
         const hitboxSize = drawSize * (2 / 3);
-        const centerY = getSpriteLowerCenterY(player.y, drawSize, 0.72);
+        const centerY = getSpriteLowerCenterY(player.y, drawSize, 0.6);
         return {
           x: player.x - (hitboxSize / 2),
           y: centerY - (hitboxSize / 2),
@@ -1489,8 +1489,7 @@
             } else {
               const playerBody = getPlayerHitbox(player);
               const enemyBody = getEnemyHitbox(enemy);
-              const closeEnoughForMelee = Math.hypot(player.x - enemy.x, player.y - enemy.y) <= enemy.range + 10;
-              if (closeEnoughForMelee && rectsOverlap(playerBody, enemyBody)) {
+              if (rectsOverlap(playerBody, enemyBody)) {
                 damagePlayer(enemy.damage);
               }
             }

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1028,9 +1028,9 @@
       };
     }
 
-    function getSpriteLowerCenterY(worldY, drawSize) {
+    function getSpriteLowerCenterY(worldY, drawSize, centerRatio = 0.75) {
       const imageTop = worldY - 32;
-      return imageTop + (drawSize * 0.75);
+      return imageTop + (drawSize * centerRatio);
     }
 
     function getEnemyHitbox(enemy) {
@@ -1073,7 +1073,7 @@
       if (player?.charData?.id === 'billy-boxby') {
         const drawSize = PLAYER_DRAW_SIZE * (player.renderScale || 1);
         const hitboxSize = drawSize * (2 / 3);
-        const centerY = getSpriteLowerCenterY(player.y, drawSize);
+        const centerY = getSpriteLowerCenterY(player.y, drawSize, 0.72);
         return {
           x: player.x - (hitboxSize / 2),
           y: centerY - (hitboxSize / 2),
@@ -1487,7 +1487,10 @@
                 color: '#ff7b7b'
               });
             } else {
-              if (rectsOverlap(getPlayerHitbox(player), getEnemyHitbox(enemy))) {
+              const playerBody = getPlayerHitbox(player);
+              const enemyBody = getEnemyHitbox(enemy);
+              const closeEnoughForMelee = Math.hypot(player.x - enemy.x, player.y - enemy.y) <= enemy.range + 10;
+              if (closeEnoughForMelee && rectsOverlap(playerBody, enemyBody)) {
                 damagePlayer(enemy.damage);
               }
             }


### PR DESCRIPTION
### Motivation
- Align hitboxes with the lower body region for characters so collisions better match sprite geometry. 
- Make any contact between hitboxes, including edge-to-edge contact, count as a hit to ensure consistent hit registration. 
- Ensure enemy melee attacks rely on actual hitbox contact rather than a loose distance threshold so contact-based hits are symmetric.

### Description
- Added a helper `getSpriteLowerCenterY(worldY, drawSize)` and used it to lower the center anchor for the Bramble Drone boss in `getEnemyHitbox` and for Billy Boxby in `getPlayerHitbox` in `bayou-brawlers/index.html`.
- Modified `rectsOverlap` to use `<=` / `>=` comparisons so edge-to-edge contact returns true for overlap.
- Replaced the enemy melee distance fallback check (`distance < enemy.range + 10`) with a direct hitbox check `rectsOverlap(getPlayerHitbox(player), getEnemyHitbox(enemy))` so melee damage requires hitbox contact.

### Testing
- Ran `git diff --check` which returned no issues (success).
- Ran `git status --short` to confirm working tree state (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69997d73ec5083298be0c787e618a1a2)