### PR TITLE
Double Bramble Drone boss melee reach in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1513,7 +1513,8 @@
                 color: '#ff7b7b'
               });
             } else {
-              const forwardReach = enemy.range + 10;
+              const attackReachMultiplier = (enemy.isBoss && enemy.type === 'bramble-drone') ? 2 : 1;
+              const forwardReach = ((enemy.range + 10) * attackReachMultiplier);
               const meleeZone = {
                 x: enemy.facing >= 0 ? enemyBody.x : enemyBody.x - forwardReach,
                 y: enemyBody.y,


### PR DESCRIPTION
### Motivation
- The Bramble Drone stage boss should have increased melee reach so its attack distance is more threatening during boss fights.

### Description
- Modified melee attack resolution in `bayou-brawlers/index.html` to apply an `attackReachMultiplier` when `enemy.isBoss && enemy.type === 'bramble-drone'`.
- Computed `forwardReach` as `((enemy.range + 10) * attackReachMultiplier)` so only the Bramble Drone boss uses a 2x forward reach while keeping other enemies unchanged.

### Testing
- Inspected the changed lines in `bayou-brawlers/index.html` to confirm the new `attackReachMultiplier` and adjusted `forwardReach` calculation are present and correctly applied.
- Printed the surrounding file region with `nl -ba bayou-brawlers/index.html | sed -n '1506,1524p'` to verify the `meleeZone` construction uses the multiplied reach, and the check with `rectsOverlap` remains unchanged; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ad181dfa88329a4623073d2881af2)