### PR TITLE
Allow limited forward movement after wave spawn in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -722,6 +722,7 @@
     const REGULAR_WAVE_COUNT = 8;
     const TOTAL_WAVE_COUNT = 9;
     const WAVE_TRIGGER_PCTS = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
+    const WAVE_LOCK_FORWARD_ALLOWANCE = 160;
     const IDLE_ARROW_DELAY_FRAMES = 300;
     const PLAYER_SCALE_MULTIPLIER = 4;
     const PLAYER_DRAW_SIZE = 56 * PLAYER_SCALE_MULTIPLIER;
@@ -1217,6 +1218,10 @@
       return clamp(40 + ((state.levelWidth - 80) * pct), 40, state.levelWidth - 40);
     }
 
+    function getWaveLockX(waveIndex) {
+      return clamp(getWaveTriggerX(waveIndex) + WAVE_LOCK_FORWARD_ALLOWANCE, 40, state.levelWidth - 40);
+    }
+
     function getRegularWave(level, waveIndex) {
       const baseWave = level.waves[waveIndex % level.waves.length];
       const cycle = Math.floor(waveIndex / level.waves.length);
@@ -1242,7 +1247,7 @@
       }
       state.waveIndex = waveIndex;
       state.waveActive = true;
-      state.lockX = waveLockX;
+      state.lockX = getWaveLockX(waveIndex);
       updateWaveHud();
     }
 
@@ -1259,7 +1264,7 @@
       state.waveIndex = REGULAR_WAVE_COUNT;
       state.waveActive = true;
       state.bossActive = true;
-      state.lockX = getWaveTriggerX(REGULAR_WAVE_COUNT);
+      state.lockX = getWaveLockX(REGULAR_WAVE_COUNT);
       updateWaveHud();
     }
 


### PR DESCRIPTION
### Motivation
- When a wave spawns the player was immediately clamped to the exact trigger X which prevented seeing parts of the stage (notably the Stage 1 Bramble Drone boss area), so the lock should still prevent skipping the encounter but allow a short forward move after the wave appears.

### Description
- Add a `WAVE_LOCK_FORWARD_ALLOWANCE` constant to define how far ahead the lock can be placed relative to the trigger point.
- Add `getWaveLockX(waveIndex)` which returns `getWaveTriggerX(waveIndex) + WAVE_LOCK_FORWARD_ALLOWANCE` clamped to level bounds.
- Use `getWaveLockX(...)` when setting `state.lockX` in both `spawnWave` and `spawnBoss` so regular waves and boss waves allow the brief forward movement.

### Testing
- Started a local static server with `python3 -m http.server 4173` which succeeded. (succeeded)
- Ran a Playwright script to load `http://127.0.0.1:4173/bayou-brawlers/index.html` and capture a screenshot to verify the game loaded and the scene rendered; the first Playwright attempt timed out but a second run successfully produced a screenshot artifact. (one run failed, second run succeeded)
- Reviewed the modified `bayou-brawlers/index.html` diff to confirm `state.lockX` assignments and clamping now use `getWaveLockX(...)`. (inspection succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b063d249c83298037075301e05023)