### PR TITLE
Allow forward reveal during waves in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1212,9 +1212,27 @@
       }
     }
 
-    function getWaveTriggerX(waveIndex) {
+    function getWaveTriggerXForLevelWidth(waveIndex, levelWidth) {
       const pct = WAVE_TRIGGER_PCTS[waveIndex] || 0.9;
-      return clamp(40 + ((state.levelWidth - 80) * pct), 40, state.levelWidth - 40);
+      return clamp(40 + ((levelWidth - 80) * pct), 40, levelWidth - 40);
+    }
+
+    function getWaveTriggerX(waveIndex) {
+      return getWaveTriggerXForLevelWidth(waveIndex, state.levelWidth);
+    }
+
+    function getWaveForwardRevealDistance() {
+      const stageOne = levels[0];
+      const stageOneDefaultWidth = 2200;
+      const stageOneLevelWidth = getLevelWorldWidth(stageOne, stageOneDefaultWidth);
+      const stageOneBossTriggerX = getWaveTriggerXForLevelWidth(REGULAR_WAVE_COUNT, stageOneLevelWidth);
+      return Math.max(0, (stageOneLevelWidth - 40) - stageOneBossTriggerX);
+    }
+
+    function getWaveLockX(waveIndex) {
+      const triggerX = getWaveTriggerX(waveIndex);
+      const revealDistance = getWaveForwardRevealDistance();
+      return clamp(triggerX + revealDistance, triggerX, state.levelWidth - 40);
     }
 
     function getRegularWave(level, waveIndex) {
@@ -1229,7 +1247,7 @@
     function spawnWave(level, waveIndex) {
       const wave = getRegularWave(level, waveIndex);
       if (!wave) return;
-      const waveLockX = getWaveTriggerX(waveIndex);
+      const waveLockX = getWaveLockX(waveIndex);
       state.enemies = [];
       const baseX = clamp(waveLockX + 180, waveLockX + 80, state.levelWidth - 160);
       const spawnCount = waveIndex === 0
@@ -1259,7 +1277,7 @@
       state.waveIndex = REGULAR_WAVE_COUNT;
       state.waveActive = true;
       state.bossActive = true;
-      state.lockX = getWaveTriggerX(REGULAR_WAVE_COUNT);
+      state.lockX = getWaveLockX(REGULAR_WAVE_COUNT);
       updateWaveHud();
     }
 


### PR DESCRIPTION
### Motivation
- Players were prevented from moving past the wave spawn point and could not see the rest of the background when the final/ boss wave (stage 1 Bramble Drone) spawned. This change lets the player walk a short distance forward after a wave appears so the background to the right becomes visible. 

### Description
- Add `getWaveTriggerXForLevelWidth(waveIndex, levelWidth)` and a wrapper `getWaveTriggerX(waveIndex)` so trigger calculations can be computed against an explicit level width. 
- Introduce `getWaveForwardRevealDistance()` that computes the extra forward reveal distance as the gap between the stage 1 boss trigger and the stage 1 level right edge, and expose `getWaveLockX(waveIndex)` to apply that reveal distance when computing a wave lock. 
- Replace direct uses of the old trigger-based lock with `getWaveLockX` in `spawnWave` and `spawnBoss` so waves still block progress but allow the additional forward reveal distance.

### Testing
- Ran the test suite with `npm test -- --runInBand` and all tests passed (`3` test suites, `6` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0b7ab7ac8329a62de94e7c2cadfc)