### PR TITLE
Bayou Brawlers: show boss HP bars only and render them below sprites

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1878,14 +1878,18 @@
         drawEntity(entity, size);
       });
 
-      state.enemies.forEach(enemy => {
-        const barWidth = enemy.isBoss ? 70 : 40;
-        const hpPct = enemy.hp / enemy.maxHp;
-        ctx.fillStyle = 'rgba(0,0,0,0.5)';
-        ctx.fillRect(enemy.x - state.cameraX - barWidth / 2, enemy.y - state.cameraY - 44, barWidth, 6);
-        ctx.fillStyle = '#ff7b7b';
-        ctx.fillRect(enemy.x - state.cameraX - barWidth / 2, enemy.y - state.cameraY - 44, barWidth * hpPct, 6);
-      });
+      state.enemies
+        .filter(enemy => enemy.isBoss && enemy.hp > 0)
+        .forEach(enemy => {
+          const barWidth = 70;
+          const hpPct = enemy.hp / enemy.maxHp;
+          const barY = enemy.y - state.cameraY + 8;
+
+          ctx.fillStyle = 'rgba(0,0,0,0.5)';
+          ctx.fillRect(enemy.x - state.cameraX - barWidth / 2, barY, barWidth, 6);
+          ctx.fillStyle = '#ff7b7b';
+          ctx.fillRect(enemy.x - state.cameraX - barWidth / 2, barY, barWidth * hpPct, 6);
+        });
 
       if (showCollisionDebug) {
         ctx.save();


### PR DESCRIPTION
### Motivation
- Reduce UI clutter by hiding health bars for regular enemies while keeping boss HP visible for player feedback.
- Position boss health bars below the boss sprite to avoid overlapping the sprite and to improve visual clarity.

### Description
- Updated the main render loop in `bayou-brawlers/index.html` to only draw HP bars for enemies where `enemy.isBoss` and `enemy.hp > 0` instead of for every enemy.
- Replaced the old world-space Y offset (`-44`) with a new `barY = enemy.y - state.cameraY + 8` so boss bars render below the boss sprite.
- Fixed the boss bar drawing to use a fixed `barWidth = 70` and the same background and fill behavior (`ctx.fillRect`) while preserving the existing color/style.

### Testing
- Ran a local static server with `python -m http.server 4173` and loaded `http://127.0.0.1:4173/bayou-brawlers/` using a Playwright script to exercise the updated render path, which completed successfully.
- Captured a screenshot via Playwright (`artifacts/bayou-brawlers-healthbar-change.png`) to verify visual results, and the script ran without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0d9e72f48329a0faf24f232faf2c)