### PR TITLE
Use directional fallback for missing Bayou Brawlers left-facing sprites

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2387,10 +2387,10 @@
 
       const billySpriteSheets = {
         idle: { right: ['assets/BB_billyBoxby_right.png', 1], left: ['assets/BB_billyBoxby_left.png', 1], fps: 0, loop: false },
-        walk: { right: ['assets/BB_billyBoxby_walking_right.png', 4], left: ['assets/BB_billyBoxby_walking_left.png', 4], fps: PLAYER_ANIM_FPS.walk, loop: true },
-        hurt: { right: ['assets/BB_billyBoxby_damaged_right.png', 4], left: ['assets/BB_billyBoxby_damaged_left.png', 4], fps: PLAYER_ANIM_FPS.hurt, loop: false },
-        attack: { right: ['assets/BB_billyBoxby_attack_heavy_right.png', 7], left: ['assets/BB_billyBoxby_attack_heavy_left.png', 7], fps: PLAYER_ANIM_FPS.attack, loop: false },
-        death: { right: ['assets/BB_billyBoxby_killed_right.png', 5], left: ['assets/BB_billyBoxby_killed_left.png', 5], fps: PLAYER_ANIM_FPS.death, loop: false }
+        walk: { right: ['assets/BB_billyBoxby_walking_right.png', 4], fps: PLAYER_ANIM_FPS.walk, loop: true },
+        hurt: { right: ['assets/BB_billyBoxby_damaged_right.png', 4], fps: PLAYER_ANIM_FPS.hurt, loop: false },
+        attack: { right: ['assets/BB_billyBoxby_attack_heavy_right.png', 7], fps: PLAYER_ANIM_FPS.attack, loop: false },
+        death: { right: ['assets/BB_billyBoxby_killed_right.png', 5], fps: PLAYER_ANIM_FPS.death, loop: false }
       };
 
       promises.push(createDirectionalAnimationTracks(billySpriteSheets, ({ stateName, facingName, img, frames }) => {
@@ -2403,10 +2403,10 @@
 
       const brambleDroneSpriteSheets = {
         idle: { right: ['assets/BB_brambleDrone_right.png', 1], left: ['assets/BB_brambleDrone_left.png', 1], fps: 0, loop: false },
-        walk: { right: ['assets/BB_brambleDrone_walking_right.png', 8], left: ['assets/BB_brambleDrone_walking_left.png', 8], fps: 10, loop: true },
-        hurt: { right: ['assets/BB_brambleDrone_damaged_right.png', 5], left: ['assets/BB_brambleDrone_damaged_left.png', 5], fps: 12, loop: false },
-        attack: { right: ['assets/BB_brambleDrone_attack_right.png', 7], left: ['assets/BB_brambleDrone_attack_left.png', 7], fps: 14, loop: false },
-        death: { right: ['assets/BB_brambleDrone_killed_right.png', 6], left: ['assets/BB_brambleDrone_killed_left.png', 6], fps: 8, loop: false }
+        walk: { right: ['assets/BB_brambleDrone_walking_right.png', 8], fps: 10, loop: true },
+        hurt: { right: ['assets/BB_brambleDrone_damaged_right.png', 5], fps: 12, loop: false },
+        attack: { right: ['assets/BB_brambleDrone_attack_right.png', 7], fps: 14, loop: false },
+        death: { right: ['assets/BB_brambleDrone_killed_right.png', 6], fps: 8, loop: false }
       };
 
       promises.push(createDirectionalAnimationTracks(brambleDroneSpriteSheets, ({ stateName, facingName, img, frames }) => {
@@ -2420,10 +2420,10 @@
 
       const chokingBlossomSpriteSheets = {
         idle: { right: ['assets/BB_chokingBlossom_right.png', 1], left: ['assets/BB_chokingBlossom_left.png', 1], fps: 0, loop: false },
-        walk: { right: ['assets/BB_chokingBlossom_walking_right.png', 8], left: ['assets/BB_chokingBlossom_walking_left.png', 8], fps: 10, loop: true },
-        hurt: { right: ['assets/BB_chokingBlossom_damaged_right.png', 5], left: ['assets/BB_chokingBlossom_damaged_left.png', 5], fps: 12, loop: false },
-        attack: { right: ['assets/BB_chokingBlossom_attack_right.png', 7], left: ['assets/BB_chokingBlossom_attack_left.png', 7], fps: 14, loop: false },
-        death: { right: ['assets/BB_chokingBlossom_killed_right.png', 6], left: ['assets/BB_chokingBlossom_killed_left.png', 6], fps: 8, loop: false }
+        walk: { right: ['assets/BB_chokingBlossom_walking_right.png', 8], fps: 10, loop: true },
+        hurt: { right: ['assets/BB_chokingBlossom_damaged_right.png', 5], fps: 12, loop: false },
+        attack: { right: ['assets/BB_chokingBlossom_attack_right.png', 7], fps: 14, loop: false },
+        death: { right: ['assets/BB_chokingBlossom_killed_right.png', 6], fps: 8, loop: false }
       };
 
       promises.push(createDirectionalAnimationTracks(chokingBlossomSpriteSheets, ({ stateName, facingName, img, frames }) => {


### PR DESCRIPTION
### Motivation
- Some left-facing Bayou Brawlers animation files were removed to save space, so sprite configs must stop hard-referencing deleted files and instead use the engine's directional fallback.

### Description
- Removed explicit `left` entries for `walk`, `hurt`, `attack`, and `death` states in the Billy Boxby, Bramble Drone, and Choking Blossom sprite-sheet configs so only `right` is referenced for those states.
- Kept existing `left` entries where left-facing assets still exist (for `idle`).
- The change relies on the existing `createDirectionalAnimationTracks` logic to synthesize or flip missing facings at runtime using `inferDirectionalSourcePath` and horizontal-flip fallback.
- No other gameplay or rendering code was modified.

### Testing
- Ran a quick regex check with `python` to verify there are no remaining `BB_*.png` references pointing to missing files, and the script reported no missing BB PNG refs.
- Served the site locally with `python -m http.server 4173` and confirmed the Bayou Brawlers page loaded without missing-asset 404s per server logs.
- Captured a Playwright screenshot of `http://127.0.0.1:4173/bayou-brawlers/index.html` to validate asset loading and runtime behavior, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b43f51b04832997461ef71fea7190)