### PR TITLE
Update Bayou Brawlers to use new 128px uploaded character art

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -735,7 +735,7 @@
     const BRAWL_LANE_MIN_Y = Math.floor(canvas.height * 0.5);
     const BRAWL_LANE_MAX_Y = canvas.height - 44;
     const MOVE_EPSILON = 0.05;
-    const SPRITE_FRAME_SIZE = 256;
+    const SPRITE_FRAME_SIZE = 128;
 
     const PLAYER_ANIM_FPS = {
       walk: 10,
@@ -2386,10 +2386,10 @@
       });
 
       const billySpriteSheets = {
-        idle: { right: ['assets/BB_billyBoxby_right.png', 1], left: ['assets/BB_billyBoxby_left.png', 1], fps: 0, loop: false },
+        idle: { right: ['assets/BB_billyBoxby_right.png', 1], fps: 0, loop: false },
         walk: { right: ['assets/BB_billyBoxby_walking_right.png', 4], fps: PLAYER_ANIM_FPS.walk, loop: true },
         hurt: { right: ['assets/BB_billyBoxby_damaged_right.png', 4], fps: PLAYER_ANIM_FPS.hurt, loop: false },
-        attack: { right: ['assets/BB_billyBoxby_attack_heavy_right.png', 7], fps: PLAYER_ANIM_FPS.attack, loop: false },
+        attack: { right: ['assets/BB_billyBoxby_attack_right.png', 7], fps: PLAYER_ANIM_FPS.attack, loop: false },
         death: { right: ['assets/BB_billyBoxby_killed_right.png', 5], fps: PLAYER_ANIM_FPS.death, loop: false }
       };
 
@@ -2402,11 +2402,11 @@
       }));
 
       const brambleDroneSpriteSheets = {
-        idle: { right: ['assets/BB_brambleDrone_right.png', 1], left: ['assets/BB_brambleDrone_left.png', 1], fps: 0, loop: false },
-        walk: { right: ['assets/BB_brambleDrone_walking_right.png', 8], fps: 10, loop: true },
-        hurt: { right: ['assets/BB_brambleDrone_damaged_right.png', 5], fps: 12, loop: false },
-        attack: { right: ['assets/BB_brambleDrone_attack_right.png', 7], fps: 14, loop: false },
-        death: { right: ['assets/BB_brambleDrone_killed_right.png', 6], fps: 8, loop: false }
+        idle: { right: ['assets/BB_greenFairy_right.png', 1], fps: 0, loop: false },
+        walk: { right: ['assets/BB_greenFairy_walking_right.png', 8], fps: 10, loop: true },
+        hurt: { right: ['assets/BB_greenFairy_damaged_right.png', 5], fps: 12, loop: false },
+        attack: { right: ['assets/BB_greenFairy_attack_right.png', 7], fps: 14, loop: false },
+        death: { right: ['assets/BB_greenFairy_killed_right.png', 6], fps: 8, loop: false }
       };
 
       promises.push(createDirectionalAnimationTracks(brambleDroneSpriteSheets, ({ stateName, facingName, img, frames }) => {
@@ -2419,11 +2419,11 @@
       }));
 
       const chokingBlossomSpriteSheets = {
-        idle: { right: ['assets/BB_chokingBlossom_right.png', 1], left: ['assets/BB_chokingBlossom_left.png', 1], fps: 0, loop: false },
-        walk: { right: ['assets/BB_chokingBlossom_walking_right.png', 8], fps: 10, loop: true },
-        hurt: { right: ['assets/BB_chokingBlossom_damaged_right.png', 5], fps: 12, loop: false },
-        attack: { right: ['assets/BB_chokingBlossom_attack_right.png', 7], fps: 14, loop: false },
-        death: { right: ['assets/BB_chokingBlossom_killed_right.png', 6], fps: 8, loop: false }
+        idle: { right: ['assets/BB_oldManCroc_right.png', 1], fps: 0, loop: false },
+        walk: { right: ['assets/BB_oldManCroc_walking_right.png', 8], fps: 10, loop: true },
+        hurt: { right: ['assets/BB_oldManCroc_damaged_right.png', 5], fps: 12, loop: false },
+        attack: { right: ['assets/BB_oldManCroc_attack_right.png', 7], fps: 14, loop: false },
+        death: { right: ['assets/BB_oldManCroc_killed_right.png', 6], fps: 8, loop: false }
       };
 
       promises.push(createDirectionalAnimationTracks(chokingBlossomSpriteSheets, ({ stateName, facingName, img, frames }) => {


### PR DESCRIPTION
### Motivation
- New uploaded Bayou Brawlers PNGs are half-size (128px frames) and use slightly different filenames, so the game must parse frames and reference assets appropriately.
- Avoid changing any binary assets; update only the runtime references and slicing logic so the engine uses the new sheets.

### Description
- Changed sprite frame parsing from `SPRITE_FRAME_SIZE = 256` to `SPRITE_FRAME_SIZE = 128` in `bayou-brawlers/index.html` so the engine slices the new half-size sheets correctly.
- Updated Billy Boxby attack sheet reference to the new filename `assets/BB_billyBoxby_attack_right.png` and removed an explicit `left` idle reference so the engine can infer/mirror left-facing frames.
- Remapped the bramble-drone animation configuration to use the new `BB_greenFairy_*` PNG assets and remapped choking-blossom to use the `BB_oldManCroc_*` PNG assets while preserving physics/profile wiring.
- Kept all gameplay logic intact and relied on the existing directional mirroring behavior when left-facing PNGs are not provided.

### Testing
- Ran a quick asset existence check with a Python script that scanned `bayou-brawlers/index.html` for `BB_*.png` references and confirmed none were missing, which succeeded.
- Served the site locally with `python -m http.server 4173 --directory /workspace/ai-game-of-the-day` and loaded `bayou-brawlers/index.html` in a headless browser to capture a screenshot and confirm the updated sprite requests returned HTTP 200, which succeeded.
- Committed the change and opened a PR with the updated `bayou-brawlers/index.html` modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6a045188832989aa132336f0a68d)