### PR TITLE
Double Choking Blossom scale and add dedicated physics profile

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -780,7 +780,8 @@
     const BRAMBLE_DRONE_BOSS_SCALE_MULTIPLIER = 4;
     const BRAMBLE_DRONE_BOSS_ANIM_FPS_MULTIPLIER = 1;
     const DEFAULT_PLAYER_RENDER_SCALE = 0.75;
-    const CHOKING_BLOSSOM_SCALE_MULTIPLIER = ((PLAYER_DRAW_SIZE * DEFAULT_PLAYER_RENDER_SCALE) * 0.5) / ENEMY_DRAW_SIZE;
+    const SWAMP_SCALE_MULTIPLIER = ((PLAYER_DRAW_SIZE * DEFAULT_PLAYER_RENDER_SCALE) * 0.5) / ENEMY_DRAW_SIZE;
+    const CHOKING_BLOSSOM_SCALE_MULTIPLIER = SWAMP_SCALE_MULTIPLIER * 2;
     const PHYSICS_HITBOX_PADDING = 3;
     const ENEMY_FACING_DEADZONE_X = 6;
     const BRAWL_LANE_MIN_Y = Math.floor(canvas.height * 0.5);
@@ -828,7 +829,8 @@
       const enemyBaseSize = isBoss ? BOSS_DRAW_SIZE : ENEMY_DRAW_SIZE;
       const asPlayerSizeRatio = (ratio) => (playerSize * ratio) / enemyBaseSize;
 
-      if (typeId === 'choking-blossom' || typeId === 'swamp') return asPlayerSizeRatio(0.5);
+      if (typeId === 'choking-blossom') return asPlayerSizeRatio(1);
+      if (typeId === 'swamp') return asPlayerSizeRatio(0.5);
       if (typeId === 'daphodilus') return asPlayerSizeRatio(1);
 
       if (typeId === 'bramble-drone') {
@@ -1342,7 +1344,7 @@
         ranged: base.ranged || false,
         isBoss,
         renderScale: getEnemyRenderScale(typeId, stage, isBoss),
-        physicsProfileId: isBrambleDroneBoss ? 'enemy-bramble-drone-boss' : `enemy-${typeId === 'choking-blossom' ? 'swamp' : typeId}`,
+        physicsProfileId: isBrambleDroneBoss ? 'enemy-bramble-drone-boss' : `enemy-${typeId}`,
         targetBodyAimBias: rand(35, 85) / 100,
         invulnFrames: options.invulnFrames || 0,
         spawnFadeFrames: options.spawnFadeFrames || 0,
@@ -2868,6 +2870,17 @@
       const enemySpriteSheets = {
         swamp: {
           profileId: 'enemy-swamp',
+          sizeMultiplier: SWAMP_SCALE_MULTIPLIER,
+          states: {
+            idle: { left: ['assets/animation_chokingBlossom_red_controlSquare_left.png', 1], fps: 0, loop: false },
+            walk: { left: ['assets/animation_chokingBlossom_red_walking_left.png', 8], fps: 10, loop: true },
+            hurt: { left: ['assets/animation_chokingBlossom_red_damaged_left.png', 5], fps: 12, loop: false },
+            attack: { left: ['assets/animation_chokingBlossom_red_attack_left.png', 7], fps: 14, loop: false },
+            death: { left: ['assets/animation_chokingBlossom_red_killed_left.png', 6], fps: 8, loop: false }
+          }
+        },
+        'choking-blossom': {
+          profileId: 'enemy-choking-blossom',
           sizeMultiplier: CHOKING_BLOSSOM_SCALE_MULTIPLIER,
           states: {
             idle: { left: ['assets/animation_chokingBlossom_red_controlSquare_left.png', 1], fps: 0, loop: false },


### PR DESCRIPTION
### Motivation
- Make the Choking Blossom visually twice as large while ensuring its collision/hitbox geometry (hotboxes, physics profile) scales with the new sprite so gameplay collisions remain correct.

### Description
- Introduced `SWAMP_SCALE_MULTIPLIER` and set `CHOKING_BLOSSOM_SCALE_MULTIPLIER = SWAMP_SCALE_MULTIPLIER * 2` to double the Choking Blossom render size.
- Updated `getEnemyRenderScale` so `choking-blossom` uses `asPlayerSizeRatio(1)` while `swamp` remains `0.5` so only Choking Blossom is enlarged.
- Added a dedicated enemy sprite/physics entry for `'choking-blossom'` with `profileId: 'enemy-choking-blossom'` and changed spawn logic to use `enemy-${typeId}` for `physicsProfileId` (with existing bramble-boss override preserved).
- Kept `swamp` sprites but ensured it uses `SWAMP_SCALE_MULTIPLIER` so swamp enemies keep their original sizing.

### Testing
- Ran unit tests with `npm test -- --runInBand`, which passed (all test suites succeeded).
- Executed an automated Playwright script that loaded `bayou-brawlers/index.html`, spawned a `choking-blossom`, and produced a screenshot artifact confirming the change (script completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e96e6c108832999a82dee14ef1434)