### PR TITLE
Make boss encounter notification an auto-dismissing popup

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -198,6 +198,39 @@
       padding: 20px;
     }
     .overlay.show { display: flex; }
+    .boss-popup {
+      position: fixed;
+      top: 118px;
+      left: 50%;
+      transform: translate(-50%, -8px);
+      width: min(560px, calc(100vw - 28px));
+      padding: 16px 20px;
+      border-radius: 14px;
+      border: 2px solid rgba(245, 196, 103, 0.82);
+      background: linear-gradient(180deg, rgba(24, 28, 42, 0.97), rgba(15, 18, 30, 0.94));
+      box-shadow: 0 16px 34px rgba(0, 0, 0, 0.48), 0 0 20px rgba(245, 196, 103, 0.2);
+      color: var(--text);
+      text-align: center;
+      z-index: 9;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 220ms ease, transform 220ms ease;
+    }
+    .boss-popup.show {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+    .boss-popup h2 {
+      margin: 0 0 6px;
+      font-size: 19px;
+      color: var(--gold);
+      letter-spacing: 0.6px;
+    }
+    .boss-popup p {
+      margin: 0;
+      color: #d5deff;
+      font-size: 13px;
+    }
     .character-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
@@ -423,6 +456,11 @@
       <canvas id="game" width="960" height="540"></canvas>
     </div>
 
+    <div class="boss-popup" id="bossPopup" role="status" aria-live="assertive" aria-atomic="true">
+      <h2 id="bossPopupTitle">Boss Incoming!</h2>
+      <p id="bossPopupBody">Brace for impact.</p>
+    </div>
+
     <div class="controls" id="mobileControls">
       <div class="dpad">
         <button class="pad-btn pad-spacer" aria-hidden="true"></button>
@@ -515,6 +553,8 @@
       commandBuffTimer: 0,
       chokeHoldOwnerId: null
     };
+
+    let bossPopupTimeout = null;
 
     const input = {
       left: false,
@@ -2106,7 +2146,7 @@
             spawnWave(level, state.nextWaveToSpawn);
           } else {
             spawnBoss(level);
-            showMessage(`${level.boss.name}`, 'Boss rush! Brace for impact.', 'Engage');
+            showBossPopup(`${level.boss.name}`, 'Boss rush! Brace for impact.');
           }
           state.nextWaveToSpawn += 1;
         }
@@ -2169,6 +2209,20 @@
       btn.textContent = buttonText;
       overlay.classList.add('show');
       state.running = false;
+    }
+
+    function showBossPopup(title, body, durationMs = 2800) {
+      const popup = document.getElementById('bossPopup');
+      document.getElementById('bossPopupTitle').textContent = title;
+      document.getElementById('bossPopupBody').textContent = body;
+      popup.classList.add('show');
+      if (bossPopupTimeout) {
+        clearTimeout(bossPopupTimeout);
+      }
+      bossPopupTimeout = setTimeout(() => {
+        popup.classList.remove('show');
+        bossPopupTimeout = null;
+      }, durationMs);
     }
 
     async function submitScore() {


### PR DESCRIPTION
### Motivation
- Replace the blocking, click-to-continue boss message with a brief, non-interactive popup so boss spawns don't interrupt gameplay input.

### Description
- Added a new styled popup element (`#bossPopup`) to `bayou-brawlers/index.html` and supporting CSS under `.boss-popup` for a centered, non-interactive banner with fade/translate transitions.  
- Added `let bossPopupTimeout` state and implemented `showBossPopup(title, body, durationMs = 2800)` which updates the popup text, shows the banner, and auto-hides it after a configurable timeout while clearing any previous timeout when retriggered.  
- Wired the boss-wave trigger to call `showBossPopup(...)` instead of the modal `showMessage(...)`, so boss notices appear briefly and do not require user clicks.  
- Included ARIA attributes (`role="status" aria-live="assertive" aria-atomic="true"`) to ensure the popup is announced to assistive technologies.

### Testing
- Ran a code search to verify the new symbols are present with `rg -n "boss-popup|bossPopup|showBossPopup|Boss rush"` and found expected occurrences. (success)
- Served the site locally with a simple HTTP server and visually inspected the page to confirm the popup DOM/CSS insertion. (success)
- Executed an automated Playwright script to trigger `showBossPopup(...)` and capture a screenshot showing the rendered popup. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f233933f48329a2a6d9055ff13048)