### PR TITLE
Reduce initial Bramble Drone spawn size by 25% in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -874,7 +874,7 @@
       if (typeId === 'daphodilus') return asPlayerSizeRatio(1);
 
       if (typeId === 'bramble-drone') {
-        if (stage === 3) return asPlayerSizeRatio(2);
+        if (stage === 3) return asPlayerSizeRatio(1.5);
         if (stage === 2) return asPlayerSizeRatio(1);
         return asPlayerSizeRatio(0.5);
       }


### PR DESCRIPTION
### Motivation
- Reduce the visual size of the initial (stage 3) bramble drone spawn to lower early-game pressure while keeping stage 1 and stage 2 sizes unchanged.

### Description
- Adjusted `getEnemyRenderScale` for `bramble-drone` so stage 3 uses `asPlayerSizeRatio(1.5)` instead of `asPlayerSizeRatio(2)`, leaving stage 2 as `asPlayerSizeRatio(1)` and stage 1 as `asPlayerSizeRatio(0.5)`.

### Testing
- Launched a local dev server with `python3 -m http.server` and ran a Playwright script to load `bayou-brawlers/index.html` and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06cb495dc8329bade4a4df00304f1)