### PR TITLE
Reduce initial stage sizes for bramble-drone and vicious-vercosus by 25%

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -874,13 +874,13 @@
       if (typeId === 'daphodilus') return asPlayerSizeRatio(1);
 
       if (typeId === 'bramble-drone') {
-        if (stage === 3) return asPlayerSizeRatio(2);
+        if (stage === 3) return asPlayerSizeRatio(1.5);
         if (stage === 2) return asPlayerSizeRatio(1);
         return asPlayerSizeRatio(0.5);
       }
 
       if (typeId === 'vicious-vercosus') {
-        if (stage === 3) return asPlayerSizeRatio(3);
+        if (stage === 3) return asPlayerSizeRatio(2.25);
         if (stage === 2) return asPlayerSizeRatio(2);
         return asPlayerSizeRatio(1);
       }


### PR DESCRIPTION
### Motivation
- Reduce the visual/spawn footprint of the initial (stage 3) bramble-drone and the initial final-boss vicious-vercosus so their stage-3 appearances are 25% smaller while keeping stage 1 and stage 2 sizes unchanged.

### Description
- Updated `getEnemyRenderScale` in `bayou-brawlers/index.html` to return `asPlayerSizeRatio(1.5)` for `bramble-drone` stage 3 (was `2`) and `asPlayerSizeRatio(2.25)` for `vicious-vercosus` stage 3 (was `3`), leaving stage 2 and stage 1 branches intact.

### Testing
- Ran `git diff --check` which reported no formatting issues; launched a local dev server with `python3 -m http.server 4173` and captured a Playwright screenshot of the updated page, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07a1625508329b27ca342ac094311)