### PR TITLE
Fix Delving Daphodilus dig-down animation not playing

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1855,7 +1855,13 @@
 
         if (enemy.type === 'daphodilus') {
           enemy.burrowCooldown = Math.max(0, enemy.burrowCooldown - 1);
-          if (enemy.aiState === 'Underground') {
+          if (enemy.aiState === 'DigStart') {
+            enemy.untargetable = true;
+            enemy.aiTimer += 1;
+            if (enemy.aiTimer > 15) {
+              setEnemyState(enemy, 'Underground');
+            }
+          } else if (enemy.aiState === 'Underground') {
             enemy.untargetable = true;
             enemy.aiTimer += 1;
             if (enemy.aiTimer > rand(48, 72)) {
@@ -1885,7 +1891,7 @@
               enemy.isMoving = true;
             }
             if (distance > 150 && distance < 350 && enemy.burrowCooldown <= 0 && enemy.noDigUntil <= 0 && canGoUnderground()) {
-              setEnemyState(enemy, 'Underground');
+              setEnemyState(enemy, 'DigStart');
               enemy.aiTimer = 0;
               const preferBehindX = player.x - (player.facing >= 0 ? 70 : -70);
               const fallbackX = player.x + (player.facing >= 0 ? 70 : -70);


### PR DESCRIPTION
### Motivation
- The daphodilus burrow animation (`animation_delvingDaphodilus_red_digDown_left.png`) was not visible because the AI immediately entered the `Underground` state before the dig-down animation could play.

### Description
- Added a short `DigStart` AI phase for the `daphodilus` enemy in `bayou-brawlers/index.html` that marks the enemy `untargetable` and advances an `aiTimer` so the dig-down animation has time to play before going fully underground.
- Changed the burrow trigger to set `DigStart` (instead of directly `Underground`) and added a 15-frame transition from `DigStart` -> `Underground` to preserve the existing underground/emerge flow.
- Preserved all existing `Underground` and `Emerge` behavior and target positioning when the enemy submerges and resurfaces.

### Testing
- Ran unit tests with `npm test -- --runInBand` (Jest) and all test suites passed.
- Served the project locally with `python3 -m http.server 4173` and confirmed the Bayou Brawlers page loads.
- Executed a Playwright check to load `http://127.0.0.1:4173/bayou-brawlers/` and captured a screenshot to validate assets and page rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a092e6f754832981aaa9fcdd8ad163)