### PR TITLE
Restrict Bayou Brawlers level 1 enemies to daphodilus & choking-blossom

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -719,9 +719,9 @@
 
     const levels = [
       { id: 'swamp', name: 'The Swamp', background: 'background-swamp', waves: [
-        { types: ['goblin', 'swamp'], count: 4 },
-        { types: ['swamp', 'thug'], count: 5 },
-        { types: ['goblin', 'swamp'], count: 6 }
+        { types: ['daphodilus', 'choking-blossom'], count: 4 },
+        { types: ['choking-blossom', 'daphodilus'], count: 5 },
+        { types: ['daphodilus', 'choking-blossom'], count: 6 }
       ], boss: { name: 'Mud Monster', type: 'mud-monster' } },
       { id: 'mirewatch', name: 'Mirewatch (Town)', background: 'background-mirewatch', waves: [
         { types: ['thug'], count: 5 },
@@ -1529,7 +1529,7 @@
       if (level.id === 'swamp') {
         const script = [
           [{ type: 'daphodilus', delay: 0 }, { type: 'daphodilus', delay: 120 }],
-          [{ type: 'daphodilus', delay: 0 }, { type: 'goblin', delay: 10 }],
+          [{ type: 'daphodilus', delay: 0 }, { type: 'choking-blossom', delay: 10 }],
           [{ type: 'choking-blossom', delay: 0 }, { type: 'daphodilus', delay: 180 }],
           [{ type: 'choking-blossom', delay: 0 }, { type: 'choking-blossom', delay: 8 }, { type: 'daphodilus', delay: 240 }],
           [{ type: 'choking-blossom', delay: 0 }, { type: 'daphodilus', delay: 0 }, { type: 'daphodilus', delay: 240 }],


### PR DESCRIPTION
### Motivation
- Limit level 1 (swamp) encounters so only delving `daphodilus`, `choking-blossom`, and the `mud-monster` boss appear; no skill was used because this is a direct content edit.

### Description
- Update `bayou-brawlers/index.html` to replace the `swamp` waves with only `daphodilus` and `choking-blossom` entries and change the scripted swamp wave that previously spawned a `goblin` to spawn a `choking-blossom` instead.

### Testing
- Verified the edits with `git diff -- bayou-brawlers/index.html`, inspected the `spawnWave` script via a short Python snippet, and printed relevant lines with `nl`/`sed` to confirm only `daphodilus`, `choking-blossom`, and boss `mud-monster` are present, and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a47c5ee60083299b08b76ff749d5b6)