### PR TITLE
bayou-brawlers: hold enemy killed frame for 4 seconds

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -840,7 +840,7 @@
     const STAGED_ENEMY_TYPES = new Set();
     const CHOKING_HOLD_FRAMES = 60;
     const ROOT_SNARE_FRAMES = 90;
-    const ENEMY_DEATH_HOLD_FRAMES = 120;
+    const ENEMY_DEATH_HOLD_FRAMES = 240;
 
     function debugLog(channel, ...args) {
       if (state.debug && state.debug[channel]) {


### PR DESCRIPTION
### Motivation
- Make the final frame of enemy killed animations stay on-screen longer so the death pose/feedback is clearer (increase from ~2s to ~4s).

### Description
- Update `ENEMY_DEATH_HOLD_FRAMES` in `bayou-brawlers/index.html` from `120` to `240` to double the death-frame hold duration (assumes 60 FPS, so 240 frames ≈ 4s).

### Testing
- Served the game locally with `python3 -m http.server 4173` and ran a Playwright script to load `/bayou-brawlers/index.html` and capture a screenshot, which completed successfully and produced `artifacts/bayou-brawlers-death-hold.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48eab464c8329b9f0faac253f1538)