### PR TITLE
Fix Bayou Brawlers bottom movement boundary

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -824,7 +824,8 @@
     const PHYSICS_HITBOX_PADDING = 3;
     const ENEMY_FACING_DEADZONE_X = 6;
     const BRAWL_LANE_MIN_Y = Math.floor(canvas.height * 0.5);
-    const BRAWL_LANE_MAX_Y = canvas.height - 44;
+    const BRAWL_LANE_BOTTOM_PADDING = 12;
+    const BRAWL_LANE_MAX_Y = canvas.height - BRAWL_LANE_BOTTOM_PADDING;
     const MOVE_EPSILON = 0.05;
     const SPRITE_FRAME_SIZE = 128;
 


### PR DESCRIPTION
### Motivation
- Allow player characters to move farther down the play area by replacing a hardcoded bottom clamp with a named padding constant so the lane bottom is easier to reason about and tune.

### Description
- Replaced `const BRAWL_LANE_MAX_Y = canvas.height - 44;` with a named constant `const BRAWL_LANE_BOTTOM_PADDING = 12;` and `const BRAWL_LANE_MAX_Y = canvas.height - BRAWL_LANE_BOTTOM_PADDING;` in `bayou-brawlers/index.html`.

### Testing
- Confirmed the change via code diff and file inspection of `bayou-brawlers/index.html` and committed the update; attempted to run an automated Playwright script against a local HTTP server to verify gameplay but Chromium crashed with a `SIGSEGV` in this environment, so no runtime screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c8d3aef08329a2bab88386331611)