### PR TITLE
Use BB_bg_mirewatch001.png for Bayou Brawlers level 2 background

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2883,7 +2883,7 @@
 
       const backgroundKeys = {
         'background-swamp': 'assets/BB_bg_swamp001.png',
-        'background-mirewatch': 'assets/background-mirewatch.svg',
+        'background-mirewatch': 'assets/BB_bg_mirewatch001.png',
         'background-portal': 'assets/background-portal.svg',
         'background-fairy-forest': 'assets/background-fairy-forest.svg',
         'background-world-tree-ruins': 'assets/background-world-tree-ruins.svg',


### PR DESCRIPTION
### Motivation
- Make level 2 (`mirewatch`) use the same image-based background approach as level 1 by switching to the `BB_bg_mirewatch001.png` asset so background loading/normalization is consistent.

### Description
- Replaced the `background-mirewatch` mapping in `bayou-brawlers/index.html` from `'assets/background-mirewatch.svg'` to `'assets/BB_bg_mirewatch001.png'`.

### Testing
- Ran `rg` to confirm the mapping change, served the site with `python3 -m http.server`, executed a Playwright script that loaded `bayou-brawlers/index.html` and saved `artifacts/mirewatch-level2-background.png` which shows the new `assets/BB_bg_mirewatch001.png` being requested, and verified the diff with `git diff`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f3588e0c8329ab0a04f4ab2a4604)