### PR TITLE
Balance Bayou Brawlers XP curve to hit level 10 by end of stage 6

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -853,7 +853,9 @@
     const MAX_LEVEL = 10;
     const SPECIAL_COST = 50;
     const SUPER_COST = 100;
-    const XP_TABLE = [0, 60, 140, 260, 420, 620, 860, 1160, 1540, 2050];
+    // XP required to advance from the current level to the next one.
+    // Tuned so a full-clear run lands around level 10 by the end of stage 6.
+    const XP_TABLE = [140, 220, 320, 450, 620, 850, 1120, 1460, 1820];
     const XP_BY_TIER = { small: 14, medium: 24, elite: 45, boss: 100 };
     const MAGIC_BY_TIER = { small: 5, medium: 8, elite: 12, boss: 15 };
     const SAVE_SLOT_KEY = `${GAME_ID}:slot:default:progress`;


### PR DESCRIPTION
### Motivation
- Slow early-level progression so players arrive at level 10 by the end of stage 6 and avoid advancing too quickly across early stages.

### Description
- Updated the XP thresholds in `bayou-brawlers/index.html` by replacing the `XP_TABLE` values and adding an inline comment describing the stage-6 level-10 tuning.

### Testing
- Ran a small automated sanity script (Python) that simulates XP accumulation using the stage wave compositions and `XP_BY_TIER` and confirmed the player reaches level 10 at the end of stage 6 (script output indicated stage 6 -> level 10).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a72da146c08329a26ebdd1be565d34)