### PR TITLE
Add projectile, AOE and directional melee attack behaviors for Bayou Brawlers characters

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1851,11 +1851,42 @@
         x: owner.x + dir * 20,
         y: owner.y - 10,
         vx: dir * speed,
+        vy: 0,
         damage,
         friendly,
         life: 180,
-        color
+        color,
+        tracking: false,
+        turnRate: 0,
+        ownerId: owner?.charData?.id || null,
+        trailEvery: 0
       });
+    }
+
+    function spawnPlayerAttackProjectile(player, heavy, tuning) {
+      const id = player.charData.id;
+      const paletteByCharacter = {
+        'billy-boxby': '#ffd27a',
+        'rustbucket': '#ffb871',
+        'shunky-rooster': '#ff6f6f'
+      };
+      const speedBonus = heavy ? 2.2 : 0;
+      const projectile = {
+        x: player.x + player.facing * 26,
+        y: player.y - 36,
+        vx: player.facing * (9.5 + speedBonus),
+        vy: heavy ? -0.12 : 0,
+        damage: (heavy ? tuning.heavy : tuning.light) * player.power * getDamageMultiplier(player),
+        friendly: true,
+        life: heavy ? 110 : 90,
+        color: paletteByCharacter[id] || '#f5d07a',
+        tracking: true,
+        turnRate: heavy ? 0.18 : 0.12,
+        ownerId: id,
+        trailEvery: 3,
+        burstRadius: heavy ? 18 : 12
+      };
+      state.projectiles.push(projectile);
     }
 
     function spawnShockwave(x, y, radius, damage, knockback, stun) {
@@ -1957,6 +1988,17 @@
     }
 
     function doAttack(player, heavy, isAir, tuning) {
+      const characterId = player.charData.id;
+      const rangedAttackers = new Set(['rustbucket', 'shunky-rooster', 'billy-boxby']);
+      const aoeAttackers = new Set(['green-fairy', 'scarlett-glumpkin']);
+      const brutalDirectionalAttackers = new Set(['old-man-croc', 'possumatli', 'grimma-the-feared']);
+
+      if (rangedAttackers.has(characterId)) {
+        spawnPlayerAttackProjectile(player, heavy, tuning);
+        state.effects.push({ x: player.x + player.facing * 22, y: player.y - 44, timer: 14, type: 'projectile-muzzle', color: heavy ? '#fff2a8' : '#ffd27a' });
+        return;
+      }
+
       const isFinisher = !heavy && !isAir && hasLevel(player, 6) && player.comboHits >= 3;
       const base = heavy ? tuning.heavy : tuning.light;
       const dmg = base * player.power * getDamageMultiplier(player) * (isFinisher ? 1.4 : 1);
@@ -1965,6 +2007,58 @@
       const stun = heavy ? 26 : (isFinisher ? 32 : 14);
       const h = isAir ? 56 : 40;
       const hitbox = { x: player.x + player.facing * range - (player.facing < 0 ? 28 : 0), y: player.y - (isAir ? 76 : 58), width: 38, height: h };
+
+      if (aoeAttackers.has(characterId)) {
+        const weakAoeDamage = dmg * 0.65;
+        const weakAoeRadius = heavy ? 90 : 72;
+        let hitCount = 0;
+        state.enemies.forEach(enemy => {
+          if (enemy.hp <= 0) return;
+          const distance = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+          if (distance <= weakAoeRadius) {
+            damageEnemy(enemy, weakAoeDamage, Math.max(8, stun * 0.5));
+            enemy.x += Math.sign(enemy.x - player.x || 1) * (heavy ? 10 : 6);
+            applyCharacterOnHitStatus(player, enemy, heavy);
+            hitCount += 1;
+          }
+        });
+        if (hitCount > 0) {
+          player.comboHits += hitCount;
+          player.comboTimer = 120;
+        }
+        for (let i = 0; i < 10; i += 1) {
+          state.effects.push({
+            x: player.x + rand(-48, 48),
+            y: player.y - 24 + rand(-30, 20),
+            timer: 10 + rand(0, 10),
+            type: 'sprinkle',
+            color: characterId === 'green-fairy' ? 'rgba(122,255,156,0.9)' : 'rgba(255,143,214,0.9)'
+          });
+        }
+        return;
+      }
+
+      if (brutalDirectionalAttackers.has(characterId)) {
+        hitbox.width = heavy ? 46 : 40;
+        hitbox.height = heavy ? h + 8 : h;
+        const frontDamage = dmg * (heavy ? 1.7 : 1.5);
+        let hitCount = 0;
+        state.enemies.forEach(enemy => {
+          if (enemy.hp <= 0) return;
+          if (rectOverlap(hitbox, enemy)) {
+            damageEnemy(enemy, frontDamage, stun + 8);
+            enemy.x += player.facing * (knockback + 10);
+            applyCharacterOnHitStatus(player, enemy, heavy);
+            hitCount += 1;
+          }
+        });
+        if (hitCount > 0) {
+          player.comboHits += hitCount;
+          player.comboTimer = 120;
+        }
+        state.effects.push({ x: player.x + player.facing * 46, y: player.y - 58, timer: heavy ? 16 : 12, type: 'heavy-hit' });
+        return;
+      }
 
       let hitCount = 0;
       state.enemies.forEach(enemy => {
@@ -2341,8 +2435,26 @@
     function updateProjectiles() {
       const player = state.player;
       state.projectiles.forEach(projectile => {
+        if (projectile.friendly && projectile.tracking) {
+          const target = state.enemies
+            .filter(enemy => enemy.hp > 0)
+            .sort((a, b) => Math.hypot(a.x - projectile.x, a.y - projectile.y) - Math.hypot(b.x - projectile.x, b.y - projectile.y))[0];
+          if (target) {
+            const dx = target.x - projectile.x;
+            const dy = target.y - projectile.y;
+            projectile.vy += Math.sign(dy) * projectile.turnRate;
+            projectile.vx += Math.sign(dx) * projectile.turnRate * 0.35;
+            projectile.vx = clamp(projectile.vx, -14, 14);
+            projectile.vy = clamp(projectile.vy, -4.2, 4.2);
+          }
+        }
         projectile.x += projectile.vx;
+        projectile.y += projectile.vy || 0;
         projectile.life -= 1;
+
+        if (projectile.trailEvery && projectile.life % projectile.trailEvery === 0) {
+          state.effects.push({ x: projectile.x, y: projectile.y, timer: 10, type: 'projectile-trail', color: projectile.color });
+        }
 
         if (projectile.friendly) {
           state.enemies.forEach(enemy => {
@@ -2355,6 +2467,7 @@
               projectile.y < enemyBody.y + enemyBody.height
             ) {
               damageEnemy(enemy, projectile.damage, 20);
+              state.effects.push({ x: projectile.x, y: projectile.y, timer: 16, radius: projectile.burstRadius || 12, type: 'projectile-burst', color: projectile.color });
               projectile.life = 0;
             }
           });
@@ -2823,6 +2936,24 @@
         if (effect.type === 'levelup') {
           ctx.fillStyle = 'rgba(255,215,0,0.9)';
           ctx.fillRect(effect.x - state.cameraX - 8, effect.y - state.cameraY - 8, 16, 16);
+        }
+        if (effect.type === 'projectile-trail') {
+          ctx.fillStyle = effect.color || 'rgba(255,255,200,0.7)';
+          ctx.fillRect(effect.x - state.cameraX - 2, effect.y - state.cameraY - 2, 4, 4);
+        }
+        if (effect.type === 'projectile-muzzle') {
+          ctx.fillStyle = effect.color || 'rgba(255,255,180,0.9)';
+          ctx.fillRect(effect.x - state.cameraX - 6, effect.y - state.cameraY - 6, 12, 12);
+        }
+        if (effect.type === 'projectile-burst') {
+          ctx.strokeStyle = effect.color || 'rgba(255,205,150,0.9)';
+          ctx.beginPath();
+          ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY, effect.radius * (effect.timer / 16), 0, Math.PI * 2);
+          ctx.stroke();
+        }
+        if (effect.type === 'sprinkle') {
+          ctx.fillStyle = effect.color || 'rgba(200,255,220,0.9)';
+          ctx.fillRect(effect.x - state.cameraX - 2, effect.y - state.cameraY - 2, 3, 3);
         }
       });
 


### PR DESCRIPTION
### Motivation
- Provide ranged projectile attacks for characters who should throw/have projectiles so their basic attacks can be fired and tracked.
- Give a few characters weak area-effect basic attacks so their hits affect enemies around them with visual clues.
- Make some characters perform stronger, directional melee attacks that only hit in front for clearer role differentiation.

### Description
- Added projectile metadata and defaults in `spawnProjectile` and introduced `spawnPlayerAttackProjectile` to create player-fired projectiles with homing/trail/burst properties. (file: `bayou-brawlers/index.html`)
- Extended `doAttack` to branch by character class sets so `rustbucket`, `shunky-rooster`, and `billy-boxby` spawn projectiles; `green-fairy` and `scarlett-glumpkin` perform small-radius AOE hits with sprinkle VFX; and `old-man-croc`, `possumatli`, and `grimma-the-feared` perform amplified, frontal-only melee hits. (file: `bayou-brawlers/index.html`)
- Implemented homing/tracking adjustments in `updateProjectiles` and added projectile-related effects (`projectile-trail`, `projectile-muzzle`, `projectile-burst`) and simple sprinkle particles to the renderer so new attacks are visually represented. (file: `bayou-brawlers/index.html`)
- Kept existing attack flow and tuning logic but altered hit application and effects so the new behaviors integrate with `damageEnemy`, status application, and combo logic. (file: `bayou-brawlers/index.html`)

### Testing
- Ran unit tests with `npm test -- --runInBand` and all test suites passed. 
- Served the game locally with `python3 -m http.server 4173 --directory /workspace/ai-game-of-the-day` and validated runtime behavior by running an automated Playwright interaction that started a run and captured a screenshot artifact. 
- Verified the new projectile and effect visuals in the captured gameplay screenshot produced during the browser validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83b52bb6483299346449b854c1ed9)