### PR TITLE
Adjust Bayou Brawlers player spawn to lower-left corner

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1307,11 +1307,13 @@
     }
 
     function createPlayer(charData) {
+      const startX = 40;
+      const startY = BRAWL_LANE_MAX_Y;
       return {
         name: charData.name,
         sprite: assets.characters[charData.sprite],
-        x: 80,
-        y: 280,
+        x: startX,
+        y: startY,
         z: 0,
         vx: 0,
         vz: 0,


### PR DESCRIPTION
### Motivation
- Players should begin each run positioned at the far lower-left of the playable lane instead of at the previous fixed coordinates to match intended level entry behavior.

### Description
- In `bayou-brawlers/index.html` the `createPlayer` initializer now defines `startX = 40` and `startY = BRAWL_LANE_MAX_Y` and uses them for the player's `x` and `y` coordinates.
- The previous hardcoded `x: 80, y: 280` values were replaced with `x: startX, y: startY` in the returned player object.
- No other movement bounds, camera logic, or gameplay mechanics were changed.

### Testing
- Started a local server with `python3 -m http.server 4173` and it served the site successfully.
- Ran a Playwright script to load `http://127.0.0.1:4173/bayou-brawlers/index.html`, select a character, click `#startBtn`, and capture a screenshot, which completed successfully.
- Used `rg` to inspect the code and confirm `createPlayer` was updated, which returned the expected changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e4d64acc8329ab24fb8edf952a85)