### PR TITLE
Bayou Brawlers: enlarge continue-arrow tip and delay flashing by ~2s

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2298,7 +2298,7 @@
         if (canPromptForward && Math.abs(player.vx) < 0.01) {
           state.idleFrames += 1;
           if (state.idleFrames > IDLE_ARROW_DELAY_FRAMES) {
-            state.continueArrowTimer = 1;
+            state.continueArrowTimer += 1;
           }
         } else {
           state.idleFrames = 0;
@@ -3137,7 +3137,10 @@
 
     function drawContinueArrow() {
       if (state.continueArrowTimer <= 0) return;
-      const alpha = 0.25 + (((Math.sin(performance.now() / 350) + 1) / 2) * 0.75);
+      const shouldFlash = state.continueArrowTimer > 120;
+      const alpha = shouldFlash
+        ? 0.25 + (((Math.sin(performance.now() / 350) + 1) / 2) * 0.75)
+        : 1;
       const arrowX = canvas.width - 52;
       const arrowY = canvas.height / 2;
 
@@ -3150,9 +3153,9 @@
       ctx.beginPath();
       ctx.moveTo(arrowX - 30, arrowY - 24);
       ctx.lineTo(arrowX + 18, arrowY - 24);
-      ctx.lineTo(arrowX + 18, arrowY - 36);
-      ctx.lineTo(arrowX + 44, arrowY);
-      ctx.lineTo(arrowX + 18, arrowY + 36);
+      ctx.lineTo(arrowX + 18, arrowY - 40);
+      ctx.lineTo(arrowX + 52, arrowY);
+      ctx.lineTo(arrowX + 18, arrowY + 40);
       ctx.lineTo(arrowX + 18, arrowY + 24);
       ctx.lineTo(arrowX - 30, arrowY + 24);
       ctx.closePath();


### PR DESCRIPTION
### Motivation
- The continue-arrow should present a larger pointy tip and only begin pulsing after about 2 seconds of being visible so it is less visually aggressive initially.
- The arrow should remain solid for the first visible period and then start flashing, enabling a staged visual prompt to the player.

### Description
- Changed idle prompt accumulation so `state.continueArrowTimer` now increments (`+= 1`) each frame after the idle delay instead of being pinned to `1`, enabling timed stages of visibility. 
- Updated `drawContinueArrow()` to compute `shouldFlash` as `state.continueArrowTimer > 120` (≈ 2s at 60fps) and only apply the pulsing alpha when `shouldFlash` is true, otherwise the arrow is drawn fully opaque. 
- Enlarged the arrow head by adjusting the tip geometry coordinates (extends the tip outward and taller via the `lineTo` points), making the pointy front more prominent. 

### Testing
- Inspected the change with `git diff -- bayou-brawlers/index.html` and confirmed the modified lines in `drawContinueArrow()` and the idle accumulation logic were applied (succeeded). 
- Attempted to run a local `python3 -m http.server` and capture a screenshot with a Playwright script to validate in-browser behavior, but loading the page failed in this environment due to local server/file access limitations (failed). 
- Verified the patched file was written to disk and the updated `bayou-brawlers/index.html` contains the new logic (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ea95d9a08329afcc936b0f861ddc)