### PR TITLE
Remove unused magic HUD bar in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -450,9 +450,6 @@
       <div class="chip" style="display:flex; gap:6px; align-items:center;">HP
         <div class="hp-bar"><div class="hp-fill" id="hpFill"></div></div>
       </div>
-      <div class="chip" style="display:flex; gap:6px; align-items:center;">Magic
-        <div class="hp-bar"><div class="hp-fill" id="magicFill" style="background:linear-gradient(90deg,#5ef1ff,#7a95ff)"></div></div>
-      </div>
       <div class="chip">Ability: <span id="specialReady">Locked</span></div>
     </div>
 
@@ -1777,7 +1774,7 @@
     function updateMagicHud(player) {
       if (!player) return;
       const fill = document.getElementById('magicFill');
-      fill.style.width = `${player.magic}%`;
+      if (fill) fill.style.width = `${player.magic}%`;
       const ready = document.getElementById('specialReady');
       if (!hasLevel(player, 3)) ready.textContent = 'Locked';
       else if (player.magic >= SUPER_COST && hasLevel(player, 5)) ready.textContent = 'Super Ready';


### PR DESCRIPTION
### Motivation
- The green "Magic" bar in the Bayou Brawlers HUD was unused and visually confusing, so remove it and ensure the HUD update logic won't error when the element is absent.

### Description
- Removed the `Magic` HUD chip/`magicFill` markup from `bayou-brawlers/index.html` and added a guard in `updateMagicHud` (`if (fill) fill.style.width = ...`) to avoid null-reference errors when the element is missing.

### Testing
- Ran `git diff --check` (no issues) and served the game locally, and a Playwright (Firefox) screenshot confirmed the magic bar is gone while `updateMagicHud` continues to update ability text; a Playwright Chromium run crashed in this environment but did not affect the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa1e9b8f648329bfbcfff399adc67f)