### PR TITLE
Prevent delving daphodilus burrow/respawn loop near top of lane

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2437,6 +2437,8 @@
             if (enemy.aiTimer > rand(48, 72)) {
               enemy.untargetable = false;
               enemy.x = clamp(enemy.targetX || enemy.x, state.cameraX + 40, state.cameraX + canvas.width - 40);
+              const verticalBounds = getEnemyVerticalBounds(enemy);
+              enemy.y = clamp(enemy.targetY || enemy.y, verticalBounds.minY, verticalBounds.maxY);
               if (Math.abs(enemy.x - player.x) < 40) {
                 enemy.x += enemy.facing >= 0 ? 40 : -40;
               }
@@ -2460,7 +2462,8 @@
               enemy.y += Math.sign(dy) * enemy.speed * 0.4;
               enemy.isMoving = true;
             }
-            if (distance > 150 && distance < 350 && enemy.burrowCooldown <= 0 && enemy.noDigUntil <= 0 && canGoUnderground()) {
+            const verticalGap = Math.abs(player.y - enemy.y);
+            if (distance > 150 && distance < 350 && verticalGap < 110 && enemy.burrowCooldown <= 0 && enemy.noDigUntil <= 0 && canGoUnderground()) {
               setEnemyState(enemy, 'DigStart');
               enemy.aiTimer = 0;
               const preferBehindX = player.x - (player.facing >= 0 ? 70 : -70);
@@ -2469,6 +2472,8 @@
               if (Math.abs(enemy.targetX - player.x) < 40) {
                 enemy.targetX = clamp(fallbackX, state.cameraX + 30, state.cameraX + canvas.width - 30);
               }
+              const verticalBounds = getEnemyVerticalBounds(enemy);
+              enemy.targetY = clamp(player.y + rand(-18, 18), verticalBounds.minY, verticalBounds.maxY);
             } else if (distance <= enemy.range && enemy.cooldown <= 0) {
               enemy.windup = 10;
               enemy.attackAnimTimer = 14;


### PR DESCRIPTION
### Motivation

- Fix a bug where delving daphodilus could repeatedly surface and re-burrow when positioned toward the top of the play area above the player, causing a visible respawn loop.

### Description

- Prevent daphodilus from initiating a burrow when their vertical separation from the player is large by requiring `verticalGap < 110` before entering `DigStart`.
- Record a clamped `enemy.targetY` near the player when a burrow starts so the enemy has a stable vertical resurfacing target.
- On emerge, restore `enemy.y` from `enemy.targetY` (clamped via `getEnemyVerticalBounds`) so they resurface in-lane instead of at an out-of-bounds/top position.
- Changes are limited to Bayou Brawlers enemy AI logic in `bayou-brawlers/index.html` around the daphodilus state transitions.

### Testing

- Ran a whitespace/patch shape check with `git diff --check`, which passed.
- Verified repository status with `git status --short` and committed the change with `git commit`, both of which succeeded.
- Confirmed the source file was patched (`patched` output from the apply script) and the resulting `git diff` shows only the intended edits to `bayou-brawlers/index.html`.}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab187e98648329a7a049c3324f34a0)