### PR TITLE
Add mud-splash particle effect when Mud Monster is hit

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1869,18 +1869,18 @@
       enemy.hurtTimer = Math.max(enemy.hurtTimer, 12);
       state.effects.push({ x: enemy.x, y: enemy.y, timer: 16, type: 'hit' });
       if (enemy.type === 'mud-monster') {
-        const splashCount = 6;
+        const splashCount = 18;
         for (let i = 0; i < splashCount; i += 1) {
-          const angle = rand(-Math.PI * 0.9, -Math.PI * 0.1);
-          const speed = rand(1.2, 3.4);
+          const angle = rand(-Math.PI * 0.98, -Math.PI * 0.02);
+          const speed = rand(2.2, 6.2);
           state.effects.push({
-            x: enemy.x + rand(-18, 18),
-            y: enemy.y - 24 + rand(-8, 6),
+            x: enemy.x + rand(-60, 60),
+            y: enemy.y - 34 + rand(-34, 24),
             vx: Math.cos(angle) * speed,
             vy: Math.sin(angle) * speed,
-            gravity: rand(0.1, 0.18),
-            size: rand(4, 9),
-            timer: 24,
+            gravity: rand(0.14, 0.26),
+            size: rand(9, 18),
+            timer: 34,
             type: 'mud-splash'
           });
         }
@@ -3180,10 +3180,14 @@
           ctx.fillRect(effect.x - state.cameraX - 6, effect.y - state.cameraY - 6, 12, 12);
         }
         if (effect.type === 'mud-splash') {
-          const alpha = clamp(effect.timer / 24, 0, 1);
-          const drawSize = effect.size * (0.7 + alpha * 0.5);
-          ctx.fillStyle = `rgba(94, 64, 40, ${0.45 + (alpha * 0.45)})`;
-          ctx.fillRect(effect.x - state.cameraX - drawSize / 2, effect.y - state.cameraY - drawSize / 2, drawSize, drawSize);
+          const alpha = clamp(effect.timer / 34, 0, 1);
+          const drawSize = effect.size * (0.9 + alpha * 0.9);
+          const drawX = effect.x - state.cameraX;
+          const drawY = effect.y - state.cameraY;
+          ctx.fillStyle = `rgba(94, 64, 40, ${0.5 + (alpha * 0.4)})`;
+          ctx.beginPath();
+          ctx.ellipse(drawX, drawY, drawSize * 0.65, drawSize * 0.45, 0, 0, Math.PI * 2);
+          ctx.fill();
         }
         if (effect.type === 'flash-cone') {
           const maxTimer = effect.maxTimer || 12;

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1868,6 +1868,23 @@
       enemy.stun = Math.max(enemy.stun, stun);
       enemy.hurtTimer = Math.max(enemy.hurtTimer, 12);
       state.effects.push({ x: enemy.x, y: enemy.y, timer: 16, type: 'hit' });
+      if (enemy.type === 'mud-monster') {
+        const splashCount = 6;
+        for (let i = 0; i < splashCount; i += 1) {
+          const angle = rand(-Math.PI * 0.9, -Math.PI * 0.1);
+          const speed = rand(1.2, 3.4);
+          state.effects.push({
+            x: enemy.x + rand(-18, 18),
+            y: enemy.y - 24 + rand(-8, 6),
+            vx: Math.cos(angle) * speed,
+            vy: Math.sin(angle) * speed,
+            gravity: rand(0.1, 0.18),
+            size: rand(4, 9),
+            timer: 24,
+            type: 'mud-splash'
+          });
+        }
+      }
       if (enemy.hp <= 0) {
         enemy.hp = 0;
         enemy.hurtTimer = 0;
@@ -2654,6 +2671,12 @@
     function updateEffects() {
       state.effects.forEach(effect => {
         effect.timer -= 1;
+        if (effect.type === 'mud-splash') {
+          effect.x += effect.vx;
+          effect.y += effect.vy;
+          effect.vy += effect.gravity;
+          effect.vx *= 0.96;
+        }
         if (['shock', 'root', 'beam', 'root-poison'].includes(effect.type) && (effect.timer % (effect.type === 'beam' ? 8 : 18) === 0)) {
           state.enemies.forEach(enemy => {
             const distance = Math.hypot(enemy.x - effect.x, enemy.y - effect.y);
@@ -3155,6 +3178,12 @@
         if (effect.type === 'projectile-muzzle') {
           ctx.fillStyle = effect.color || 'rgba(255,255,180,0.9)';
           ctx.fillRect(effect.x - state.cameraX - 6, effect.y - state.cameraY - 6, 12, 12);
+        }
+        if (effect.type === 'mud-splash') {
+          const alpha = clamp(effect.timer / 24, 0, 1);
+          const drawSize = effect.size * (0.7 + alpha * 0.5);
+          ctx.fillStyle = `rgba(94, 64, 40, ${0.45 + (alpha * 0.45)})`;
+          ctx.fillRect(effect.x - state.cameraX - drawSize / 2, effect.y - state.cameraY - drawSize / 2, drawSize, drawSize);
         }
         if (effect.type === 'flash-cone') {
           const maxTimer = effect.maxTimer || 12;


### PR DESCRIPTION
### Motivation
- Give the `mud-monster` a visible, satisfying hit response by spawning a burst of mud particles when it takes damage so players get clearer feedback during combat.

### Description
- Added a Mud Monster-specific particle spawn in `damageEnemy` that creates multiple `mud-splash` effects with randomized angle, speed, size, gravity, and lifetime in `bayou-brawlers/index.html`.
- Simulated `mud-splash` motion in the main effects update loop by integrating `vx`/`vy`, applying gravity and slight drag in `updateEffects`.
- Rendered `mud-splash` particles inside the effects draw loop so each splash fades and scales over its lifetime using a brown RGBA fill.

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all Jest suites passed (3 suites, 6 tests) successfully.
- Automated browser smoke test executed via the headless Playwright script which loaded `bayou-brawlers/index.html`, started a run, and produced a screenshot artifact showing the mud splash effect (script run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab1e7e2c7083299962dfac518f5758)