### PR TITLE
Use Mirewatch PNG background for stage 2

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3684,7 +3684,7 @@
 
       const backgroundKeys = {
         'background-swamp': 'assets/BB_bg_swamp001.png',
-        'background-mirewatch': 'assets/background-mirewatch.svg',
+        'background-mirewatch': 'assets/BB_bg_mirewatch001.png',
         'background-portal': 'assets/background-portal.svg',
         'background-fairy-forest': 'assets/background-fairy-forest.svg',
         'background-world-tree-ruins': 'assets/background-world-tree-ruins.svg',


### PR DESCRIPTION
### Motivation
- Make the Mirewatch (stage 2) background use the same dedicated PNG asset approach as stage 1 so raster background is loaded consistently at runtime.

### Description
- Updated the background mapping in `bayou-brawlers/index.html` inside `loadAssets()` to point `'background-mirewatch'` to `assets/BB_bg_mirewatch001.png` instead of the SVG (`background-mirewatch.svg`).

### Testing
- Started a local static server with `python3 -m http.server 4173` and ran an automated Playwright script to load `http://127.0.0.1:4173/bayou-brawlers/` and capture a screenshot; the script executed and produced `artifacts/bayou-brawlers-stage2-bg.png` (succeeded). 
- Confirmed via the browser automation network logs that `assets/BB_bg_mirewatch001.png` was requested (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab4bcc0ca48329a3508a4413667125)