### PR TITLE
Fix Bayou Brawlers wave lock to ignore lingering death frames

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2873,7 +2873,8 @@
           return;
         }
 
-        if (state.enemies.length > 0 || state.spawnQueue.length > 0) return;
+        const hasLivingEnemies = state.enemies.some(enemy => enemy.hp > 0);
+        if (hasLivingEnemies || state.spawnQueue.length > 0) return;
 
         state.waveActive = false;
         state.lockX = null;


### PR DESCRIPTION
### Motivation
- The stage progression logic blocked player forward movement while enemy objects remained in `state.enemies` for their lingering death frames (`deathHoldFrames`), even after their `hp` reached `0`, preventing the player from continuing once the last enemy was killed.

### Description
- Update `bayou-brawlers/index.html` in the stage progression (`updateStageProgress`) to check for living enemies using `state.enemies.some(enemy => enemy.hp > 0)` and only keep the wave lock when there are truly living enemies or queued spawns, replacing the previous `state.enemies.length` check.

### Testing
- Ran `npm test -- --runInBand` with Jest and all test suites passed (`3` suites, `6` tests, all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad22e5808c83298315ab963fe29fc2)