### PR TITLE
Slow down Bayou Brawlers mud monster damaged animation

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3964,7 +3964,7 @@
           states: {
             idle: { left: ['assets/animation_mudMonster_red_walking_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_mudMonster_red_walking_left.png', 8], fps: 10, loop: true },
-            hurt: { left: ['assets/animation_mudMonster_red_damaged_left.png', 5], fps: 12, loop: false },
+            hurt: { left: ['assets/animation_mudMonster_red_damaged_left.png', 5], fps: 8, loop: false },
             attack: { left: ['assets/animation_mudMonster_red_attack_left.png', 7], fps: 14, loop: false },
             death: { left: ['assets/animation_mudMonster_red_killed_left.png', 6], fps: 8, loop: false }
           }
@@ -4063,7 +4063,7 @@
           states: {
             idle: { left: ['assets/animation_mudMonster_red_walking_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_mudMonster_red_walking_left.png', 8], fps: 10, loop: true },
-            hurt: { left: ['assets/animation_mudMonster_red_damaged_left.png', 5], fps: 12, loop: false },
+            hurt: { left: ['assets/animation_mudMonster_red_damaged_left.png', 5], fps: 8, loop: false },
             attack: { left: ['assets/animation_mudMonster_red_attack_left.png', 7], fps: 14, loop: false },
             death: { left: ['assets/animation_mudMonster_red_killed_left.png', 6], fps: 8, loop: false }
           }


### PR DESCRIPTION
### Motivation
- Make the mud monster's damaged (hurt) animation play more slowly so the damage reaction is more readable and consistent across variants.

### Description
- Lowered the `hurt` animation `fps` for the `mud-monster` and `boss` sprite states from `12` to `8` in `bayou-brawlers/index.html`.

### Testing
- Started a local server and captured `http://127.0.0.1:8000/bayou-brawlers/index.html` with Playwright and inspected the git diff to confirm only the two `fps` values were changed (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada118cfb08329816962b11eaa58b4)