### PR TITLE
Double Mud Monster damaged animation duration and adjust FPS

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1880,7 +1880,8 @@
       if (!enemy || enemy.hp <= 0 || enemy.invulnFrames > 0 || enemy.untargetable) return;
       enemy.hp -= amount;
       enemy.stun = Math.max(enemy.stun, stun);
-      enemy.hurtTimer = Math.max(enemy.hurtTimer, 12);
+      const hurtDurationFrames = enemy.type === 'mud-monster' && enemy.isBoss ? 24 : 12;
+      enemy.hurtTimer = Math.max(enemy.hurtTimer, hurtDurationFrames);
       state.effects.push({ x: enemy.x, y: enemy.y, timer: 16, type: 'hit' });
       if (enemy.type === 'mud-monster') {
         const splashCount = 18;
@@ -3964,7 +3965,7 @@
           states: {
             idle: { left: ['assets/animation_mudMonster_red_walking_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_mudMonster_red_walking_left.png', 8], fps: 10, loop: true },
-            hurt: { left: ['assets/animation_mudMonster_red_damaged_left.png', 5], fps: 12, loop: false },
+            hurt: { left: ['assets/animation_mudMonster_red_damaged_left.png', 5], fps: 10, loop: false },
             attack: { left: ['assets/animation_mudMonster_red_attack_left.png', 7], fps: 14, loop: false },
             death: { left: ['assets/animation_mudMonster_red_killed_left.png', 6], fps: 8, loop: false }
           }
@@ -4063,7 +4064,7 @@
           states: {
             idle: { left: ['assets/animation_mudMonster_red_walking_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_mudMonster_red_walking_left.png', 8], fps: 10, loop: true },
-            hurt: { left: ['assets/animation_mudMonster_red_damaged_left.png', 5], fps: 12, loop: false },
+            hurt: { left: ['assets/animation_mudMonster_red_damaged_left.png', 5], fps: 10, loop: false },
             attack: { left: ['assets/animation_mudMonster_red_attack_left.png', 7], fps: 14, loop: false },
             death: { left: ['assets/animation_mudMonster_red_killed_left.png', 6], fps: 8, loop: false }
           }


### PR DESCRIPTION
### Motivation
- Make the Mud Monster boss show its full "damaged" animation over a longer visible window so every frame is shown when it is hurt.

### Description
- When an enemy is damaged, set `hurtTimer` to `24` frames for the `mud-monster` boss and keep `12` frames for other enemies by introducing `const hurtDurationFrames = enemy.type === 'mud-monster' && enemy.isBoss ? 24 : 12;` and using it for `enemy.hurtTimer` in `damageEnemy` in `bayou-brawlers/index.html`.
- Reduce the damaged-track playback speed for the mud monster from `fps: 12` to `fps: 10` in both the `mud-monster` and `boss` sprite configs so the 5-frame damaged animation occupies the extended 24-frame window in-game.
- Changes are contained in `bayou-brawlers/index.html` (enemy sprite sheet config and damage handling).

### Testing
- Ran unit tests with `npm test -- --runInBand` and all test suites passed (3 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb520180c8329b4377ad527ac560a)