### PR TITLE
bayou-brawlers: double enemy spawns and halve XP rewards

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -886,6 +886,7 @@
     };
 
     const INITIAL_WAVE_ENEMY_MULTIPLIER = 0.75;
+    const ENEMY_COUNT_MULTIPLIER = 2;
     const ENEMY_SPEED_MULTIPLIER = 0.82;
     const REGULAR_WAVE_COUNT = 8;
     const TOTAL_WAVE_COUNT = 9;
@@ -932,7 +933,7 @@
     const SPECIAL_COST = MAX_MAGIC / 3;
     const SUPER_COST = SPECIAL_COST;
     const XP_TABLE = [0, 60, 140, 260, 420, 620, 860, 1160, 1540, 2050];
-    const XP_BY_TIER = { small: 14, medium: 24, elite: 45, boss: 100 };
+    const XP_BY_TIER = { small: 7, medium: 12, elite: 22.5, boss: 50 };
     const MAGIC_BY_TIER = { small: 5, medium: 8, elite: 12, boss: 15 };
     const SAVE_SLOT_KEY = `${GAME_ID}:slot:default:progress`;
 
@@ -1726,11 +1727,12 @@
           [{ type: 'choking-blossom', delay: 0 }, { type: 'choking-blossom', delay: 8 }, { type: 'daphodilus', delay: 210, opts: { burrowCooldown: 90 } }]
         ];
         const entries = script[waveIndex] || [];
+        const doubledEntries = Array.from({ length: ENEMY_COUNT_MULTIPLIER }, () => entries).flat();
         const waveLockX = getWaveLockX(waveIndex);
         state.lockX = waveLockX;
         state.enemies = [];
         state.spawnQueue = [];
-        entries.forEach(item => {
+        doubledEntries.forEach(item => {
           queueSpawn(item.type, item.delay, item.opts || {});
         });
         state.waveIndex = waveIndex;
@@ -1743,9 +1745,9 @@
       const waveLockX = getWaveLockX(waveIndex);
       state.enemies = [];
       const baseX = clamp(waveLockX + 180, waveLockX + 80, state.levelWidth - 160);
-      const spawnCount = waveIndex === 0
+      const spawnCount = (waveIndex === 0
         ? Math.max(2, Math.round(wave.count * INITIAL_WAVE_ENEMY_MULTIPLIER))
-        : wave.count;
+        : wave.count) * ENEMY_COUNT_MULTIPLIER;
       for (let i = 0; i < spawnCount; i += 1) {
         const typeId = wave.types[i % wave.types.length];
         const enemy = createEnemy(typeId, baseX + rand(-80, 80) + i * 40, rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y));


### PR DESCRIPTION
### Motivation
- Rebalance Bayou Brawlers so encounters contain twice as many enemies while each enemy yields half the previous experience, adjusting difficulty and progression pacing.

### Description
- Added a new `ENEMY_COUNT_MULTIPLIER = 2` constant and applied it to wave spawning logic.
- For the scripted swamp waves in `spawnWave`, duplicated the scripted `entries` into `doubledEntries` and queue-spawned those to double scripted spawns.
- For regular waves, multiplied the computed `spawnCount` by `ENEMY_COUNT_MULTIPLIER` so non-scripted waves spawn twice as many enemies.
- Halved XP rewards by updating `XP_BY_TIER` to `{ small: 7, medium: 12, elite: 22.5, boss: 50 }` so overall XP per enemy is reduced by ~50%.

### Testing
- The patch was applied successfully via the repo patching tool (`apply_patch`) and the target file `bayou-brawlers/index.html` was updated without error.
- Code locations were inspected with `rg` and the modified regions were reviewed with `sed` and `nl` to confirm `ENEMY_COUNT_MULTIPLIER`, the doubled swamp-script handling in `spawnWave`, the multiplied `spawnCount` for regular waves, and the updated `XP_BY_TIER` values.
- Verification steps completed and showed the spawn logic and XP table reflect the intended changes (all checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae416157608329bff6507aa83f9847)