### PR TITLE
Use controlSquare animation for Bayou Brawlers special attacks

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1430,6 +1430,7 @@
         },
         animationSignals: {
           attack: false,
+          special: false,
           hurt: false
         },
         charData
@@ -1454,6 +1455,9 @@
       } else if ((anim.state === 'hurt' && !anim.complete) || player.animationSignals.hurt) {
         nextState = 'hurt';
         player.animationSignals.hurt = false;
+      } else if ((anim.state === 'special' && !anim.complete) || player.animationSignals.special) {
+        nextState = 'special';
+        player.animationSignals.special = false;
       } else if (player.actionLock > 0) {
         nextState = 'special';
       } else if ((anim.state === 'attack' && !anim.complete) || player.animationSignals.attack) {
@@ -2130,7 +2134,7 @@
         player.facing = attackFacing;
         player.specialCooldown = castSuper ? 360 : 210;
         player.actionLock = 20;
-        player.animationSignals.attack = true;
+        player.animationSignals.special = true;
         addMagic(player, -(castSuper ? SUPER_COST : SPECIAL_COST));
         castCharacterAbility(player, castSuper);
       }


### PR DESCRIPTION
### Motivation
- Special attacks should use the character’s "control square" (controlSquare) animation track instead of reusing the normal `attack` track so visuals match move intent.
- The code previously reused `player.animationSignals.attack` for both attack and special actions, preventing the `special`/controlSquare track from being selected.

### Description
- Added a dedicated `animationSignals.special` flag on player objects to signal special animation playback.
- Updated `updatePlayerAnimation` to detect and prioritize the `special` state when `player.animationSignals.special` is set and to clear the flag after switching states.
- Changed special-input handling in the attack flow to set `player.animationSignals.special = true` (instead of reusing the `attack` signal) so `special` animation tracks are used when available.

### Testing
- Served the project locally with `python3 -m http.server 4173` and successfully loaded the modified `bayou-brawlers/index.html` in a headless browser.
- Ran a Playwright script to open `http://127.0.0.1:4173/bayou-brawlers/index.html` and captured a screenshot to validate the page and assets load with the updated animation logic, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af32cba908832984e723d21790c04d)