### PR TITLE
Improve Bayou Brawlers enemy wandering and anti-clustering behavior

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -929,6 +929,10 @@
     const STING_ATTACH_FRAMES = 150;
     const ROOT_SNARE_FRAMES = 90;
     const ENEMY_DEATH_HOLD_FRAMES = 240;
+    const ENEMY_SEPARATION_RADIUS = 82;
+    const ENEMY_SEPARATION_FORCE = 0.36;
+    const ENEMY_WANDER_STEP = 0.28;
+    const ENEMY_WANDER_PUSH = 0.22;
     const MAX_LEVEL = 10;
     const MAX_MAGIC = 100;
     const SPECIAL_COST = MAX_MAGIC / 3;
@@ -1567,12 +1571,36 @@
         dashFrames: 0,
         dashCooldown: rand(90, 160),
         pressureBoost: 1,
+        wanderAngle: rand(0, 360) * (Math.PI / 180),
+        wanderDrift: rand(8, 22) / 100,
+        wanderTimer: rand(18, 60),
         bossEncounterId: options.bossEncounterId || null,
         hurtTimer: 0,
         deathHoldFrames: 0,
         statuses: {}
       };
       return enemy;
+    }
+
+    function applyEnemyCrowdSteering(enemy) {
+      let pushX = 0;
+      let pushY = 0;
+      let neighbors = 0;
+      state.enemies.forEach(other => {
+        if (other === enemy || other.hp <= 0) return;
+        const ox = enemy.x - other.x;
+        const oy = enemy.y - other.y;
+        const dist = Math.hypot(ox, oy);
+        if (dist <= 0.01 || dist > ENEMY_SEPARATION_RADIUS) return;
+        const influence = (ENEMY_SEPARATION_RADIUS - dist) / ENEMY_SEPARATION_RADIUS;
+        pushX += (ox / dist) * influence;
+        pushY += (oy / dist) * influence;
+        neighbors += 1;
+      });
+      if (neighbors <= 0) return;
+      enemy.x += (pushX / neighbors) * ENEMY_SEPARATION_FORCE;
+      enemy.y += (pushY / neighbors) * ENEMY_SEPARATION_FORCE;
+      enemy.isMoving = true;
     }
 
     function getEnemyHitbox(enemy) {
@@ -2710,6 +2738,17 @@
         }
 
         if (enemy.attackAnimTimer > 0) enemy.attackAnimTimer -= 1;
+        if (enemy.aiState !== 'Underground' && enemy.attachTargetFrames <= 0 && enemy.holdTargetFrames <= 0) {
+          enemy.wanderTimer -= 1;
+          if (enemy.wanderTimer <= 0) {
+            enemy.wanderTimer = rand(20, 64);
+            enemy.wanderDrift = rand(8, 22) / 100;
+          }
+          enemy.wanderAngle += rand(-100, 100) / 1000;
+          enemy.x += Math.cos(enemy.wanderAngle) * enemy.wanderDrift * ENEMY_WANDER_PUSH;
+          enemy.y += Math.sin(enemy.wanderAngle) * enemy.wanderDrift * ENEMY_WANDER_STEP;
+          applyEnemyCrowdSteering(enemy);
+        }
         const verticalBounds = getEnemyVerticalBounds(enemy);
         enemy.y = clamp(enemy.y, verticalBounds.minY, verticalBounds.maxY);
         applyMovementMaskClamp(enemy, prevX, prevY);


### PR DESCRIPTION
### Motivation
- Enemies in Bayou Brawlers were clustering tightly, making encounters feel crowded and static, so they should wander more and repel nearby allies to create more natural spacing.

### Description
- Added global tuning constants `ENEMY_SEPARATION_RADIUS`, `ENEMY_SEPARATION_FORCE`, `ENEMY_WANDER_STEP`, and `ENEMY_WANDER_PUSH` to control separation and wander strength.
- Extended enemy initialization to include per-enemy wander state fields `wanderAngle`, `wanderDrift`, and `wanderTimer` so each enemy wanders independently.
- Implemented `applyEnemyCrowdSteering(enemy)` which computes a local separation vector from nearby living enemies and nudges the enemy away to reduce clustering.
- Integrated light wander drift and crowd-steering into the main `updateEnemies` loop (skipping underground/attached/hold states) so enemies drift and spread out during updates.

### Testing
- Extracted inline scripts and ran a syntax check with `node --check /tmp/bayou-inline.js`, which completed successfully.
- Launched a local HTTP server (`python3 -m http.server 4173`) and loaded the updated page to validate runtime behavior and asset loading, which succeeded.
- Captured a runtime screenshot via an automated Playwright script to verify the build visually, which produced an artifact (`artifacts/bayou-brawlers-enemy-wander.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b04531907c832993baaa1728ceaf40)