### PR TITLE
Improve Bayou Brawlers enemy spacing and separation behavior

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -906,6 +906,10 @@
     const CHOKING_BLOSSOM_SCALE_MULTIPLIER = SWAMP_SCALE_MULTIPLIER * 2;
     const PHYSICS_HITBOX_PADDING = 3;
     const ENEMY_FACING_DEADZONE_X = 6;
+    const ENEMY_SEPARATION_DISTANCE = 68;
+    const ENEMY_SEPARATION_FORCE = 0.7;
+    const MIN_WAVE_SPAWN_SEPARATION_X = 95;
+    const MIN_WAVE_SPAWN_SEPARATION_Y = 46;
     const BRAWL_LANE_MIN_Y = Math.floor(canvas.height * 0.5);
     const BRAWL_LANE_BOTTOM_PADDING = 12;
     const BRAWL_LANE_MAX_Y = canvas.height - BRAWL_LANE_BOTTOM_PADDING;
@@ -1751,15 +1755,84 @@
       const spawnCount = (waveIndex === 0
         ? Math.max(2, Math.round(wave.count * INITIAL_WAVE_ENEMY_MULTIPLIER))
         : wave.count) * ENEMY_COUNT_MULTIPLIER;
+      const spawnedPositions = [];
       for (let i = 0; i < spawnCount; i += 1) {
         const typeId = wave.types[i % wave.types.length];
-        const enemy = createEnemy(typeId, baseX + rand(-80, 80) + i * 40, rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y));
+        const spawnPos = getSeparatedSpawnPosition(spawnedPositions, {
+          xMin: waveLockX + 40,
+          xMax: Math.min(state.levelWidth - 120, waveLockX + 640),
+          yMin: getBrawlLaneMinY(),
+          yMax: BRAWL_LANE_MAX_Y,
+          fallbackX: baseX + i * 52,
+          fallbackY: rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y)
+        });
+        const enemy = createEnemy(typeId, spawnPos.x, spawnPos.y);
+        spawnedPositions.push(spawnPos);
         state.enemies.push(enemy);
       }
       state.waveIndex = waveIndex;
       state.waveActive = true;
       state.lockX = waveLockX;
       updateWaveHud();
+    }
+
+    function getSeparatedSpawnPosition(existingPositions, bounds) {
+      const xMin = Math.min(bounds.xMin, bounds.xMax);
+      const xMax = Math.max(bounds.xMin, bounds.xMax);
+      const yMin = Math.min(bounds.yMin, bounds.yMax);
+      const yMax = Math.max(bounds.yMin, bounds.yMax);
+      let best = {
+        x: clamp(bounds.fallbackX, xMin, xMax),
+        y: clamp(bounds.fallbackY, yMin, yMax),
+        score: -1
+      };
+
+      for (let attempt = 0; attempt < 16; attempt += 1) {
+        const candidate = {
+          x: rand(xMin, xMax),
+          y: rand(yMin, yMax)
+        };
+        if (existingPositions.length === 0) {
+          return candidate;
+        }
+        let minDistance = Infinity;
+        let passesSpacing = true;
+        existingPositions.forEach(pos => {
+          const dx = candidate.x - pos.x;
+          const dy = candidate.y - pos.y;
+          const distance = Math.hypot(dx, dy);
+          minDistance = Math.min(minDistance, distance);
+          if (Math.abs(dx) < MIN_WAVE_SPAWN_SEPARATION_X && Math.abs(dy) < MIN_WAVE_SPAWN_SEPARATION_Y) {
+            passesSpacing = false;
+          }
+        });
+        if (passesSpacing) return candidate;
+        if (minDistance > best.score) {
+          best = { x: candidate.x, y: candidate.y, score: minDistance };
+        }
+      }
+
+      return { x: best.x, y: best.y };
+    }
+
+    function applyEnemySeparation(enemy) {
+      if (!enemy || enemy.hp <= 0 || enemy.untargetable) return;
+      const verticalBounds = getEnemyVerticalBounds(enemy);
+      let pushX = 0;
+      let pushY = 0;
+      state.enemies.forEach(other => {
+        if (!other || other === enemy || other.hp <= 0 || other.untargetable) return;
+        const dx = enemy.x - other.x;
+        const dy = enemy.y - other.y;
+        const distance = Math.hypot(dx, dy);
+        if (distance <= 0 || distance >= ENEMY_SEPARATION_DISTANCE) return;
+        const influence = (1 - (distance / ENEMY_SEPARATION_DISTANCE)) * ENEMY_SEPARATION_FORCE;
+        pushX += (dx / distance) * influence;
+        pushY += (dy / distance) * influence;
+      });
+      if (pushX === 0 && pushY === 0) return;
+      enemy.x += pushX;
+      enemy.y = clamp(enemy.y + pushY, verticalBounds.minY, verticalBounds.maxY);
     }
 
     function spawnBoss(level) {
@@ -2710,6 +2783,7 @@
         }
 
         if (enemy.attackAnimTimer > 0) enemy.attackAnimTimer -= 1;
+        applyEnemySeparation(enemy);
         const verticalBounds = getEnemyVerticalBounds(enemy);
         enemy.y = clamp(enemy.y, verticalBounds.minY, verticalBounds.maxY);
         applyMovementMaskClamp(enemy, prevX, prevY);
@@ -2892,8 +2966,19 @@
         const ready = state.spawnQueue.filter(entry => entry.frames <= 0);
         state.spawnQueue = state.spawnQueue.filter(entry => entry.frames > 0);
         ready.forEach(entry => {
-          const spawnX = clamp(state.cameraX + canvas.width + 140 + rand(0, 60), state.cameraX + canvas.width + 120, state.levelWidth - 60);
-          const spawnY = clamp(rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y), getBrawlLaneMinY(), BRAWL_LANE_MAX_Y);
+          const spawnPos = getSeparatedSpawnPosition(
+            state.enemies.filter(enemy => enemy.hp > 0).map(enemy => ({ x: enemy.x, y: enemy.y })),
+            {
+              xMin: state.cameraX + canvas.width + 120,
+              xMax: state.levelWidth - 60,
+              yMin: getBrawlLaneMinY(),
+              yMax: BRAWL_LANE_MAX_Y,
+              fallbackX: state.cameraX + canvas.width + 140 + rand(0, 60),
+              fallbackY: rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y)
+            }
+          );
+          const spawnX = spawnPos.x;
+          const spawnY = spawnPos.y;
           const finalX = isSpawnOverlappingPlayer(spawnX, spawnY) ? (spawnX + 100) : spawnX;
           const enemy = createEnemy(entry.type, finalX, spawnY, false, Object.assign({ noDigUntil: 48 }, entry.opts || {}));
           state.enemies.push(enemy);


### PR DESCRIPTION
### Motivation
- Reduce enemy clustering so foes wander and engage the player more spread out, improving combat readability and pacing. 
- Make spawn placements for waves and queued reinforcements come from more distributed locations to avoid dense groups appearing at once.

### Description
- Added tuning constants for spacing and separation: `ENEMY_SEPARATION_DISTANCE`, `ENEMY_SEPARATION_FORCE`, `MIN_WAVE_SPAWN_SEPARATION_X`, and `MIN_WAVE_SPAWN_SEPARATION_Y`.
- Implemented `getSeparatedSpawnPosition(existingPositions, bounds)` to sample spawn positions that prefer to be distant from already-selected/active enemies and used it for regular wave creation in `spawnWave`.
- Updated queued/late spawns to use the same separated spawn helper so reinforcements also arrive from less clustered positions.
- Implemented `applyEnemySeparation(enemy)` and call it during per-frame enemy updates so nearby living enemies gently repel each other while respecting lane bounds.

### Testing
- Loaded the game in a local server via `python3 -m http.server 4173` and navigated to `http://127.0.0.1:4173/bayou-brawlers/` using an automated Playwright script, capturing a screenshot to validate spawn locations; the page loaded and the screenshot was produced successfully.
- Reviewed the modified file diff to confirm the new helper and separation calls are wired into `spawnWave`, queued spawns, and the enemies update loop; changes applied as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b062eba93083298465fdc6f597c30a)