### PR TITLE
Bayou Brawlers: render invulnerability notification on two lines

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -244,6 +244,7 @@
       color: #eef7ff;
       font-size: 12px;
       line-height: 1.45;
+      white-space: pre-line;
       box-shadow: 0 12px 24px rgba(0, 0, 0, 0.42), 0 0 16px rgba(255, 215, 0, 0.2);
       opacity: 0;
       transform: translateY(12px) scale(0.97);
@@ -1837,7 +1838,7 @@
       state.cheats.lockScoreToZero = true;
       state.score = 0;
       document.getElementById('score').textContent = '0';
-      showNotification('Invulnerability activated. Score set to zero.');
+      showNotification('Invulnerability activated.\nScore set to zero.');
     }
 
     function showNotification(message, holdMs = 2400) {


### PR DESCRIPTION
### Motivation
- Ensure the invulnerability cheat notification displays as two separate rows so the bubble reads `Invulnerability activated.` on the first line and `Score set to zero.` on the second line.

### Description
- Add `white-space: pre-line;` to `.notification-bubble` CSS and change the cheat message to `showNotification('Invulnerability activated.\nScore set to zero.');` so newline characters are respected.

### Testing
- Ran `npm test -- --runInBand` and all test suites passed (3 suites, 6 tests); an automated Playwright screenshot attempt was run but failed due to Chromium crashing with a `SIGSEGV` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b17019a2848329a127749202a1ade1)