### PR TITLE
Move Bayou Brawlers on-screen controls closer to play area

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -352,7 +352,7 @@
     }
     .controls {
       position: absolute;
-      bottom: calc(20px + env(safe-area-inset-bottom));
+      bottom: calc(56px + env(safe-area-inset-bottom));
       left: calc(16px + env(safe-area-inset-left));
       right: calc(16px + env(safe-area-inset-right));
       display: flex;
@@ -499,7 +499,11 @@
 
     @media (max-width: 600px) {
       .panel { width: calc(100vw - 24px); padding: 14px; }
-      .controls { flex-direction: row; align-items: center; }
+      .controls {
+        flex-direction: row;
+        align-items: center;
+        bottom: calc(44px + env(safe-area-inset-bottom));
+      }
       .direction-pad { width: 118px; height: 118px; }
       .direction-pad-knob { width: 48px; height: 48px; }
       .pad-btn { width: 38px; height: 38px; font-size: 10px; }
@@ -519,6 +523,7 @@
       .stage { padding-top: calc(138px + env(safe-area-inset-top)); }
       .panel h2 { font-size: 13px; }
       .panel p { font-size: 9px; }
+      .controls { bottom: calc(36px + env(safe-area-inset-bottom)); }
     }
   </style>
   <script>


### PR DESCRIPTION
### Motivation
- Improve mobile ergonomics by bringing the on-screen directional pad and action buttons closer to the canvas so controls are easier to reach while playing.

### Description
- Increased base `.controls` bottom offset from `calc(20px + env(safe-area-inset-bottom))` to `calc(56px + env(safe-area-inset-bottom))` in `bayou-brawlers/index.html` to raise the control cluster closer to the play area.
- Added responsive bottom offsets inside the `@media (max-width: 600px)` and `@media (max-width: 420px)` rules by setting `bottom: calc(44px + env(safe-area-inset-bottom))` and `bottom: calc(36px + env(safe-area-inset-bottom))` respectively to keep controls comfortably reachable on smaller screens.
- No JavaScript behavior changes; this is a CSS-only adjustment contained in `bayou-brawlers/index.html`.

### Testing
- Inspected the CSS diff for `bayou-brawlers/index.html` and confirmed the `.controls` bottom offsets were updated as intended (diff verification succeeded).
- Launched a local static HTTP server to serve the project for visual verification (server started successfully).
- Attempted to capture a visual screenshot using Playwright, but the headless Chromium process crashed in this environment (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19940f9188329ad8fe529dae3dec9)