### PR TITLE
Increase Bayou Brawlers stage 2 hired gun size

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -934,6 +934,7 @@
     const MAX_FRAME_DELTA_MS = 1000;
     const MAX_CATCH_UP_STEPS = 6;
     const ENTITY_DISPLAY_SCALE_BOOST = 1.2;
+    const STAGE_TWO_HIRED_GUN_SCALE_MULTIPLIER = 4;
     const PLAYER_SCALE_MULTIPLIER = 4;
     const PLAYER_DRAW_SIZE = (56 * PLAYER_SCALE_MULTIPLIER) * ENTITY_DISPLAY_SCALE_BOOST;
     const ENEMY_DRAW_SIZE = 48 * ENTITY_DISPLAY_SCALE_BOOST;
@@ -999,6 +1000,10 @@
       if (typeId === 'daphodilus') return asPlayerSizeRatio(1);
 
       if (typeId === 'mud-monster') return isBoss ? asPlayerSizeRatio(2.1) : asPlayerSizeRatio(1.6);
+
+      if (typeId === 'hiredGun' && state.levelIndex === 1) {
+        return STAGE_TWO_HIRED_GUN_SCALE_MULTIPLIER;
+      }
 
       return isBoss ? BOSS_RENDER_SCALE_MULTIPLIER : 1;
     }


### PR DESCRIPTION
### Motivation
- Make the hired gun minion visually larger in stage 2 (Mirewatch) so the unit reads as a more prominent threat by increasing its render scale by 300%.

### Description
- Add a new constant `STAGE_TWO_HIRED_GUN_SCALE_MULTIPLIER = 4` to control the stage-2 hired gun render scale. 
- Apply the multiplier in `getEnemyRenderScale` by returning the constant when `typeId === 'hiredGun' && state.levelIndex === 1` so the change affects only stage 2 hired guns. 
- The change was made in `bayou-brawlers/index.html` and only affects rendering scale, not enemy stats or hitboxes.

### Testing
- Verified the new constant and conditional exist using `rg` and `git diff` against `bayou-brawlers/index.html`, which succeeded. 
- Committed the change with `git commit`, which succeeded. 
- Launched a static server with `python3 -m http.server` (succeeded), and attempted automated screenshots via Playwright which failed due to environment issues (Chromium crashed with SIGSEGV and Firefox failed with `NS_ERROR_NET_RESET`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22dc7268483299b9617d05f00a2ff)