### PR TITLE
Show upgrade artwork in Bayou Brawlers level-up choice cards

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -353,6 +353,7 @@
     .levelup-panel { max-width: 640px; }
     .levelup-choices { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-top: 10px; }
     .levelup-choice { text-align: left; background: rgba(17,22,30,0.95); border: 1px solid rgba(255,214,92,0.35); border-radius: 10px; padding: 10px; color: #f8f8ef; cursor: pointer; }
+    .levelup-choice-image { width: 100%; aspect-ratio: 16 / 9; object-fit: cover; border-radius: 8px; margin-bottom: 8px; border: 1px solid rgba(255,255,255,0.08); background: rgba(0, 0, 0, 0.25); }
     .levelup-choice h4 { margin: 0 0 6px 0; font-size: 12px; color: #ffd65c; }
     .levelup-choice p { margin: 0; font-size: 10px; color: #bdd9d3; }
     .levelup-tag { display: inline-block; margin-bottom: 6px; font-size: 9px; letter-spacing: 0.08em; color: #f3d28a; text-transform: uppercase; }
@@ -2172,6 +2173,30 @@
       showNotification(`${upgrade.name} unlocked`);
     }
 
+    const UPGRADE_IMAGE_KEY_OVERRIDES = {
+      'billy-boxby': {
+        icebreaker: 'iceBreaker',
+        whiteout: 'whiteOut',
+        'ice-in-the-veins': 'iceInTheVanes'
+      },
+      'grimma-the-feared': {
+        veilwalker: 'veilWalker'
+      }
+    };
+
+    function toCamelCaseToken(slug) {
+      const parts = String(slug || '').split('-').filter(Boolean);
+      if (parts.length === 0) return '';
+      return parts[0] + parts.slice(1).map((part) => `${part[0].toUpperCase()}${part.slice(1)}`).join('');
+    }
+
+    function getUpgradeImagePath(characterId, upgradeId) {
+      const characterKey = toCamelCaseToken(characterId);
+      const override = UPGRADE_IMAGE_KEY_OVERRIDES[characterId]?.[upgradeId];
+      const upgradeKey = override || toCamelCaseToken(upgradeId);
+      return `assets/upgrade_${characterKey}_${upgradeKey}.png`;
+    }
+
     function showLevelUpOverlay(player, level) {
       const overlay = document.getElementById('levelUpOverlay');
       const title = document.getElementById('levelUpTitle');
@@ -2197,7 +2222,7 @@
         choiceList.forEach((upgrade) => {
           const button = document.createElement('button');
           button.className = 'levelup-choice';
-          button.innerHTML = `<span class="levelup-tag">${upgrade.tag}</span><h4>${upgrade.name}</h4><p>${upgrade.description}</p>`;
+          button.innerHTML = `<img class="levelup-choice-image" src="${getUpgradeImagePath(player.charData.id, upgrade.id)}" alt="${upgrade.name} upgrade artwork"><span class="levelup-tag">${upgrade.tag}</span><h4>${upgrade.name}</h4><p>${upgrade.description}</p>`;
           button.addEventListener('click', () => {
             applyChosenUpgrade(player, upgrade);
             overlay.classList.remove('show');


### PR DESCRIPTION
### Motivation
- Improve the level-up UI by displaying artwork for each upgrade so players can visually identify choices quickly.
- Map the existing `upgrade_(character)_(upgrade).png` asset naming convention to upgrade choices to avoid changing binary assets.

### Description
- Added a responsive image style `.levelup-choice-image` to the level-up card CSS in `bayou-brawlers/index.html` to display artwork at the top of each choice card.
- Implemented `toCamelCaseToken` and `getUpgradeImagePath` helpers plus an `UPGRADE_IMAGE_KEY_OVERRIDES` table to derive filenames like `assets/upgrade_oldManCroc_coldBlooded.png` from character and upgrade IDs without modifying PNG files.
- Updated `showLevelUpOverlay` to render an `<img>` using `getUpgradeImagePath(player.charData.id, upgrade.id)` inside each `.levelup-choice` button so images appear above the tag/name/description.

### Testing
- Verified asset layout and naming with a quick scan script to identify mismatches and added targeted overrides for the known cases that would not match naive tokenization (`iceBreaker`, `whiteOut`, `iceInTheVanes`, `veilWalker`).
- Ran a local server with `python -m http.server 4173` and executed a Playwright script to load `bayou-brawlers/index.html`, trigger the level-up overlay, and capture a screenshot of the UI; the overlay displayed upgrade images as expected (screenshot artifact produced).
- No automated unit tests were required; visual verification via the headless browser run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44c5375ec8329961c3f42861803b8)