### PR TITLE
Add upgrade image support for Bayou Brawlers level-up choices

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -352,7 +352,27 @@
     }
     .levelup-panel { max-width: 640px; }
     .levelup-choices { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-top: 10px; }
-    .levelup-choice { text-align: left; background: rgba(17,22,30,0.95); border: 1px solid rgba(255,214,92,0.35); border-radius: 10px; padding: 10px; color: #f8f8ef; cursor: pointer; }
+    .levelup-choice {
+      text-align: left;
+      background: rgba(17,22,30,0.95);
+      border: 1px solid rgba(255,214,92,0.35);
+      border-radius: 10px;
+      padding: 10px;
+      color: #f8f8ef;
+      cursor: pointer;
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+    }
+    .levelup-choice-icon {
+      width: 64px;
+      height: 64px;
+      flex: 0 0 64px;
+      border-radius: 8px;
+      object-fit: contain;
+      image-rendering: pixelated;
+    }
+    .levelup-choice-text { min-width: 0; }
     .levelup-choice h4 { margin: 0 0 6px 0; font-size: 12px; color: #ffd65c; }
     .levelup-choice p { margin: 0; font-size: 10px; color: #bdd9d3; }
     .levelup-tag { display: inline-block; margin-bottom: 6px; font-size: 9px; letter-spacing: 0.08em; color: #f3d28a; text-transform: uppercase; }
@@ -1174,6 +1194,32 @@
         { id: 'cold-blooded', name: 'Cold Blooded', tag: 'Utility', description: 'Take less damage while below half health.' }
       ]
     };
+
+    const UPGRADE_IMAGE_OVERRIDES = {
+      character: {
+        possumatli: 'possomatli'
+      },
+      upgrade: {
+        icebreaker: 'iceBreaker',
+        'white-out': 'whiteOut',
+        'ice-in-the-veins': 'iceInTheVanes',
+        veilwalker: 'veilWalker'
+      }
+    };
+
+    function toAssetCamelCase(value) {
+      if (!value) return '';
+      return String(value)
+        .split('-')
+        .map((part, index) => index === 0 ? part : `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+        .join('');
+    }
+
+    function getUpgradeImagePath(characterId, upgradeId) {
+      const characterName = UPGRADE_IMAGE_OVERRIDES.character[characterId] || toAssetCamelCase(characterId);
+      const upgradeName = UPGRADE_IMAGE_OVERRIDES.upgrade[upgradeId] || toAssetCamelCase(upgradeId);
+      return `assets/upgrade_${characterName}_${upgradeName}.png`;
+    }
 
     function debugLog(channel, ...args) {
       if (state.debug && state.debug[channel]) {
@@ -2197,7 +2243,14 @@
         choiceList.forEach((upgrade) => {
           const button = document.createElement('button');
           button.className = 'levelup-choice';
-          button.innerHTML = `<span class="levelup-tag">${upgrade.tag}</span><h4>${upgrade.name}</h4><p>${upgrade.description}</p>`;
+          const imagePath = getUpgradeImagePath(player.charData.id, upgrade.id);
+          button.innerHTML = `
+            <img class="levelup-choice-icon" src="${imagePath}" alt="${upgrade.name} icon" width="64" height="64" loading="lazy" decoding="async">
+            <div class="levelup-choice-text">
+              <span class="levelup-tag">${upgrade.tag}</span>
+              <h4>${upgrade.name}</h4>
+              <p>${upgrade.description}</p>
+            </div>`;
           button.addEventListener('click', () => {
             applyChosenUpgrade(player, upgrade);
             overlay.classList.remove('show');


### PR DESCRIPTION
### Motivation
- Show a visual icon for each level-up upgrade option by linking upgrades to their matching `upgrade_<character>_<upgrade>.png` assets and keep icons large and square inside the choice bubble.

### Description
- Updated the level-up option layout to render an icon plus text by adding CSS rules for `.levelup-choice`, `.levelup-choice-icon`, and `.levelup-choice-text` with `width/height: 64px`, `object-fit: contain`, and `image-rendering: pixelated` to preserve the full 64x64 image.
- Added deterministic asset helpers: `toAssetCamelCase`, `getUpgradeImagePath`, and an `UPGRADE_IMAGE_OVERRIDES` map to handle known filename mismatches when building `assets/upgrade_<character>_<upgrade>.png` paths.
- Injected the icon element into each upgrade button in `showLevelUpOverlay` so each choice loads the corresponding image at render time.
- Changed file: `bayou-brawlers/index.html`.

### Testing
- Served the site locally with `python -m http.server 4173` and confirmed the page loads successfully (server responded and assets were requested).
- Ran a Playwright script with Chromium which failed due to a browser crash in this environment (Playwright/Chromium error), reported as a runtime failure.
- Ran the same Playwright validation with Firefox which succeeded and produced screenshots of the level-up overlay with upgrade icons loading (asset requests for `upgrade_oldManCroc_*.png` returned 200).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b12c929c832983ac9258558b1f54)