### PR TITLE
Reduce Bayou Brawlers enemy damage by 25%

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1028,6 +1028,7 @@
     };
 
     const INITIAL_WAVE_ENEMY_MULTIPLIER = 0.75;
+    const ENEMY_DAMAGE_MULTIPLIER = 0.75;
     const ENEMY_COUNT_MULTIPLIER = 2;
     const ENEMY_SPEED_MULTIPLIER = 0.82;
     const REGULAR_WAVE_COUNT = 8;
@@ -1296,7 +1297,7 @@
     function getStagedStats(typeId, stage) {
       const base = enemyTypes[typeId];
       if (!base) return { hp: 10, speed: 1, damage: 1, range: 20, score: 10 };
-      return { hp: base.hp, speed: base.speed, damage: base.damage, range: base.range, score: base.score };
+      return { hp: base.hp, speed: base.speed, damage: base.damage * ENEMY_DAMAGE_MULTIPLIER, range: base.range, score: base.score };
     }
 
     function getEnemyRenderScale(typeId, stage, isBoss) {


### PR DESCRIPTION
### Motivation
- Reduce overall enemy damage in the Bayou Brawlers game by 25% for balance tuning.

### Description
- Added a global `ENEMY_DAMAGE_MULTIPLIER = 0.75` and applied it to the `damage` field returned by `getStagedStats` in `bayou-brawlers/index.html` so all enemy base damage is scaled down.

### Testing
- Verified the constant and usage with `rg -n "ENEMY_DAMAGE_MULTIPLIER|getStagedStats\(" bayou-brawlers/index.html`, inspected the file with `nl`, and committed the change with `git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c2efccbc8329b8be628949a79f4b)