### PR TITLE
Halve enemy damage in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1030,6 +1030,7 @@
     const INITIAL_WAVE_ENEMY_MULTIPLIER = 0.75;
     const ENEMY_COUNT_MULTIPLIER = 2;
     const ENEMY_SPEED_MULTIPLIER = 0.82;
+    const ENEMY_DAMAGE_MULTIPLIER = 0.5;
     const REGULAR_WAVE_COUNT = 8;
     const TOTAL_WAVE_COUNT = 9;
     const WAVE_TRIGGER_PCTS = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
@@ -1886,7 +1887,7 @@
         hp: stats.hp * (isBoss ? 1.15 : 1),
         maxHp: stats.hp * (isBoss ? 1.15 : 1),
         speed: stats.speed * ENEMY_SPEED_MULTIPLIER,
-        damage: stats.damage,
+        damage: stats.damage * ENEMY_DAMAGE_MULTIPLIER,
         range: stats.range,
         score: stats.score,
         sprite: base.sprite === 'boss' ? assets.boss : assets.enemies[base.sprite],


### PR DESCRIPTION
### Motivation
- Centralize and reduce all enemy-sourced damage by 50% to rebalance combat and make the change easy to tweak later.

### Description
- Add `ENEMY_DAMAGE_MULTIPLIER = 0.5` and apply it to enemy `damage` when creating enemies (`damage: stats.damage * ENEMY_DAMAGE_MULTIPLIER`).

### Testing
- Verified the change via `git diff -- bayou-brawlers/index.html` to confirm the new constant and modified assignment; the diff shows the multiplier applied and succeeded.
- Confirmed repository state with `git status -sb` and committed the update with message `bayou-brawlers: halve all enemy damage`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62b87bff48329b3ea7cfb70494b07)