### PR TITLE
Nerf Bayou Brawlers enemy damage by 25%

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1072,6 +1072,7 @@
     const STING_ATTACH_FRAMES = 150;
     const ROOT_SNARE_FRAMES = 90;
     const ENEMY_DEATH_HOLD_FRAMES = 240;
+    const ENEMY_DAMAGE_MULTIPLIER = 0.75;
     const MAX_LEVEL = Number.POSITIVE_INFINITY;
     const BASE_MAX_MAGIC = 100;
     const SPECIAL_COST = BASE_MAX_MAGIC / 3;
@@ -2461,7 +2462,7 @@
       const player = state.player;
       if (!player || player.hp <= 0) return;
       if (state.cheats.invincible) return;
-      let finalAmount = amount;
+      let finalAmount = amount * ENEMY_DAMAGE_MULTIPLIER;
       if (sourceEnemy?.statuses?.WEAKEN) finalAmount *= (1 - sourceEnemy.statuses.WEAKEN.magnitude);
       if (player.block || player.shieldTimer > 0) {
         finalAmount *= 0.45;


### PR DESCRIPTION
### Motivation
- Reduce incoming enemy damage across Bayou Brawlers so players take 25% less damage from enemy sources.

### Description
- Added a global `ENEMY_DAMAGE_MULTIPLIER = 0.75` constant to `bayou-brawlers/index.html` alongside other game constants.
- Updated `damagePlayer` in `bayou-brawlers/index.html` to scale incoming `amount` by `ENEMY_DAMAGE_MULTIPLIER` before applying weaken and block/shield modifiers.
- Change is limited to `bayou-brawlers/index.html` and is committed under SHA `fab73c5`.

### Testing
- Ran the patch application and repository checks via `apply_patch` and `git commit`, which both completed successfully. 
- Verified the modified file contents and surrounding context with `nl -ba bayou-brawlers/index.html` to ensure the constant and multiplication are present and correct. 
- No automated gameplay/unit tests are present for this title, so no game-run tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62eea9dcc832992fef230ddcc62a8)