### PR TITLE
Increase Bayou Brawlers enemy sizes for hiredGun, stingy, and sidewinder

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4594,7 +4594,7 @@
         },
         hiredGun: {
           profileId: 'enemy-hiredGun',
-          sizeMultiplier: 1,
+          sizeMultiplier: 4,
           states: {
             idle: { left: ['assets/animation_hiredGun_red_controlSquare_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_hiredGun_red_walking_left.png', 8], fps: 10, loop: true },
@@ -4605,7 +4605,7 @@
         },
         stingy: {
           profileId: 'enemy-stingy',
-          sizeMultiplier: 1,
+          sizeMultiplier: 4,
           states: {
             idle: { left: ['assets/animation_stingy_red_controlSquare_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_stingy_red_walking_left.png', 8], fps: 10, loop: true },
@@ -4616,7 +4616,7 @@
         },
         sidewinder: {
           profileId: 'enemy-sidewinder',
-          sizeMultiplier: 1,
+          sizeMultiplier: 4,
           states: {
             idle: { left: ['assets/animation_sidewinder_red_walking_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_sidewinder_red_walking_left.png', 8], fps: 10, loop: true },


### PR DESCRIPTION
### Motivation
- Make the stingy, hired gun, and sidewinder enemies visually larger by increasing their render/physics size so they stand out more in the Bayou Brawlers scene (requested 300% increase, i.e., render at 4× baseline).

### Description
- Set `sizeMultiplier` from `1` to `4` for the `hiredGun`, `stingy`, and `sidewinder` enemy entries in `bayou-brawlers/index.html`.
- No other enemy stats or gameplay properties (HP, speed, damage, range, score) were modified; only the render/physics multiplier was changed.

### Testing
- Applied the change and inspected the updated lines with `nl -ba bayou-brawlers/index.html | sed -n '4588,4632p'`, which shows the three `sizeMultiplier` updates as expected.
- Served the site with `python3 -m http.server 4173` and captured a verification screenshot using Playwright, which completed successfully.
- Basic file checks were performed and show only the three intended `sizeMultiplier` edits in `bayou-brawlers/index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b766734c54832987e455d6bd6a8b63)