### PR TITLE
Refresh Bayou Brawlers soundtrack list to new BB_soundtrack_XX naming

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -718,8 +718,11 @@
 
     const SOUNDTRACK_VOLUME = 0.45;
     const soundtrackFiles = [
-      'assets/BB_soundtrack001.mp3',
-      'assets/BB_soundtrack002.mp3'
+      'assets/BB_soundtrack_01.mp3',
+      'assets/BB_soundtrack_02.mp3',
+      'assets/BB_soundtrack_03.mp3',
+      'assets/BB_soundtrack_04.mp3',
+      'assets/BB_soundtrack_05.mp3'
     ];
     const soundtrackState = {
       muted: false,


### PR DESCRIPTION
### Motivation
- Standardize and refresh the Bayou Brawlers soundtrack list so the in-game soundtrack system recognizes newly added MP3 assets using the new `BB_soundtrack_01`, `BB_soundtrack_02`, ... naming convention.

### Description
- Replaced the old soundtrack entries in `bayou-brawlers/index.html` with an updated `soundtrackFiles` array containing `assets/BB_soundtrack_01.mp3` through `assets/BB_soundtrack_05.mp3`, and made this change in code only (no binary assets modified).

### Testing
- Ran automated checks to validate the update: confirmed the five `BB_soundtrack_0*.mp3` files exist in `bayou-brawlers/assets` (via `find`), grepped for the updated `soundtrackFiles` constant in `bayou-brawlers/index.html` (via `rg`), and printed the file region to verify the new entries; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b76a3250248329a1116bac4b71ee30)