### PR TITLE
bayou-brawlers: halve charm heart icon size

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4068,7 +4068,7 @@
       const topOpaqueY = walkFrame ? (drawTopY + ((topOpaquePixel / Math.max(1, walkFrame.height)) * drawSize)) : drawTopY;
       const y = topOpaqueY - Math.max(24, drawSize * 0.22);
       const pulse = 1 + (Math.sin(performance.now() * 0.01) * 0.08);
-      const heartSize = Math.max(30, drawSize * 0.34) * pulse;
+      const heartSize = Math.max(15, drawSize * 0.17) * pulse;
 
       ctx.save();
       ctx.translate(x, y);


### PR DESCRIPTION
### Motivation
- Make the heart indicator that appears above charmed enemies visually half the previous size so it no longer dominates small enemies.

### Description
- Updated `drawCharmHeart` in `bayou-brawlers/index.html` to reduce the heart size calculation from `Math.max(30, drawSize * 0.34) * pulse` to `Math.max(15, drawSize * 0.17) * pulse`, halving both the minimum clamp and the scale factor.

### Testing
- Served the project with a local HTTP server and used Playwright to load `/bayou-brawlers/index.html` and capture a screenshot to validate the visual change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba135cb43483299ee2dedc3a39d580)