### PR TITLE
Add bright green poison tint for Bayou Brawlers sprites

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3941,6 +3941,9 @@
     }
 
     function getEntityStatusTint(entity) {
+      const hasPoisonTint = !!(entity?.statuses?.POISON?.duration > 0);
+      if (hasPoisonTint) return 'rgba(70, 255, 95, 0.72)';
+
       const hasFreezeTint = !!(entity?.statuses?.FREEZE?.duration > 0);
       if (hasFreezeTint) return 'rgba(120, 205, 255, 0.52)';
 


### PR DESCRIPTION
### Motivation
- Visually indicate the `POISON` condition on players and enemies by applying a bright green tint to their sprite frames while ensuring only non-transparent (pixelated) sprite pixels are tinted.

### Description
- Added a `POISON` detection in `getEntityStatusTint` that returns `rgba(70, 255, 95, 0.72)` and reuses the existing `drawAnimationFrame` masked rendering pipeline (the `statusTintCanvas` + `globalCompositeOperation = 'source-atop'` flow) so tinting only affects sprite pixels (file: `bayou-brawlers/index.html`).

### Testing
- Ran `npm test -- --runInBand` which passed all automated suites (3 passed, 6 tests) with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb31d8392883299a4b4d788d0a6003)