### PR TITLE
Add floating "Dodged" combat text when enemy hits are evaded

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2624,6 +2624,12 @@
       const player = state.player;
       if (!player || player.hp <= 0) return;
       if (state.cheats.invincible) return;
+      const dodgeChance = getPlayerDodgeChance(player);
+      const dodged = player.dashTimer > 0 || (dodgeChance > 0 && Math.random() < dodgeChance);
+      if (dodged) {
+        spawnDodgedText(player);
+        return;
+      }
       let finalAmount = amount * ENEMY_DAMAGE_MULTIPLIER;
       if (sourceEnemy?.statuses?.WEAKEN) finalAmount *= (1 - sourceEnemy.statuses.WEAKEN.magnitude);
       if (player.block || player.shieldTimer > 0) {
@@ -2639,6 +2645,31 @@
       if (player.hp <= 0) {
         endGame(false);
       }
+    }
+
+    function getPlayerDodgeChance(player) {
+      if (!player) return 0;
+      let chance = 0;
+      if (hasUpgrade(player, 'dancers-step')) chance += 0.12;
+      return clamp(chance, 0, 0.9);
+    }
+
+    function spawnDodgedText(entity) {
+      if (!entity) return;
+      const topOpaqueWorldY = getEntityWalkTopOpaqueWorldY(entity, PLAYER_DRAW_SIZE);
+      state.effects.push({
+        type: 'floating-text',
+        text: 'Dodged',
+        x: entity.x + rand(-6, 6),
+        y: topOpaqueWorldY - 14,
+        vx: rand(-0.12, 0.12),
+        vy: -0.95,
+        drift: rand(-0.03, 0.03),
+        timer: 34,
+        maxTimer: 34,
+        color: 'rgba(230, 255, 195, 0.98)',
+        outline: 'rgba(50, 65, 38, 0.95)'
+      });
     }
 
     function spawnHealPlusCluster(entity, healedAmount = 0) {
@@ -3644,6 +3675,12 @@
           effect.vy = (effect.vy || 0) - 0.03;
           effect.vx = ((effect.vx || 0) * 0.97) + (effect.drift || 0);
         }
+        if (effect.type === 'floating-text') {
+          effect.x += (effect.vx || 0);
+          effect.y += (effect.vy || 0);
+          effect.vy = ((effect.vy || 0) * 0.98) - 0.02;
+          effect.vx = ((effect.vx || 0) * 0.96) + (effect.drift || 0);
+        }
         if (['shock', 'root', 'beam', 'root-poison'].includes(effect.type) && (effect.timer % (effect.type === 'beam' ? 8 : 18) === 0)) {
           state.enemies.forEach(enemy => {
             const distance = Math.hypot(enemy.x - effect.x, enemy.y - effect.y);
@@ -4400,6 +4437,23 @@
           ctx.fillRect(x - half, y - (thickness / 2), size, thickness);
           ctx.strokeRect(x - (thickness / 2), y - half, thickness, size);
           ctx.strokeRect(x - half, y - (thickness / 2), size, thickness);
+          ctx.restore();
+        }
+        if (effect.type === 'floating-text') {
+          const maxTimer = effect.maxTimer || 34;
+          const alpha = clamp(effect.timer / maxTimer, 0, 1);
+          const x = effect.x - state.cameraX;
+          const y = effect.y - state.cameraY;
+          ctx.save();
+          ctx.globalAlpha = alpha;
+          ctx.font = 'bold 14px "Press Start 2P", monospace';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.lineWidth = 2.2;
+          ctx.strokeStyle = effect.outline || 'rgba(20, 20, 20, 0.95)';
+          ctx.fillStyle = effect.color || 'rgba(255, 255, 255, 0.95)';
+          ctx.strokeText(effect.text || '', x, y);
+          ctx.fillText(effect.text || '', x, y);
           ctx.restore();
         }
       });


### PR DESCRIPTION
### Motivation
- Provide clear visual feedback when an incoming enemy attack is successfully evaded so players immediately notice the dodge event.

### Description
- Added an early dodge check in `damagePlayer` so incoming hits are treated as evaded when `player.dashTimer > 0` or when a random roll succeeds against `getPlayerDodgeChance`, which is currently driven by the `dancers-step` upgrade.
- Implemented `getPlayerDodgeChance` and `spawnDodgedText` that emit a `floating-text` effect positioned above the player with initial velocity, drift, color and outline.
- Extended `updateEffects` to simulate motion for `floating-text` effects and added rendering logic in the draw loop to stroke/fill the floating text and fade it out over its `timer`.
- Changes are localized to `bayou-brawlers/index.html` and add a reusable `floating-text` effect type for other text popups.

### Testing
- Ran `git diff --check` to validate whitespace and diff issues and it succeeded.
- Ran a repository status check (`git status --short`) to confirm the change is isolated to the intended file and there are no outstanding errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd9e2100c83298f547163d3318e79)