### PR TITLE
Daphodilus resumes normal attacks after pop-up

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3545,7 +3545,7 @@
             }
             enemy.cooldown = rand(40, 80);
             if (enemy.type === 'daphodilus' && enemy.aiState === 'PopAttack') {
-              setEnemyState(enemy, 'Recover');
+              setEnemyState(enemy, 'Approach');
               enemy.burrowCooldown = 300;
             }
           }


### PR DESCRIPTION
### Motivation
- Delving Daphodilus was pausing after its pop-up attack; the intent is for it to continue attacking like other enemies once it resurfaces instead of idling.

### Description
- Replace `setEnemyState(enemy, 'Recover')` with `setEnemyState(enemy, 'Approach')` for the `daphodilus` case after `PopAttack` in `bayou-brawlers/index.html`, while keeping `enemy.burrowCooldown` intact.

### Testing
- Ran `npm test -- --runInBand`, and all tests passed (`3` test suites, `6` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc38da37688329ade264e3a50b2ec2)