### PR TITLE
daphodilus: remove post-teleport pause, add short chase before burrow/teleport

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1984,6 +1984,7 @@
         hurtTimer: 0,
         deathHoldFrames: 0,
         mudTrailDropCooldown: options.mudTrailDropCooldown || rand(4, 7),
+        teleportChaseFrames: 0,
         statuses: {}
       };
       return enemy;
@@ -3369,21 +3370,13 @@
               enemy.windup = 8;
               enemy.attackAnimTimer = 14;
             }
-          } else if (enemy.aiState === 'Recover') {
-            enemy.aiTimer += 1;
-            if (enemy.aiTimer > 48) {
-              setEnemyState(enemy, 'Approach');
-            }
           } else {
-            if (distance > 190) {
-              enemy.x += Math.sign(dx) * moveSpeed * 0.8;
-              enemy.y += Math.sign(dy) * moveSpeed * 0.4;
-              enemy.isMoving = true;
-            }
             const verticalGap = Math.abs(player.y - enemy.y);
-            if (distance > 150 && distance < 350 && verticalGap < 110 && enemy.burrowCooldown <= 0 && enemy.noDigUntil <= 0 && canGoUnderground()) {
+            const canBurrowNow = enemy.burrowCooldown <= 0 && enemy.noDigUntil <= 0 && canGoUnderground();
+            const startBurrowAttack = () => {
               setEnemyState(enemy, 'DigStart');
               enemy.aiTimer = 0;
+              enemy.teleportChaseFrames = 0;
               const preferBehindX = player.x - (player.facing >= 0 ? 70 : -70);
               const fallbackX = player.x + (player.facing >= 0 ? 70 : -70);
               enemy.targetX = clamp(preferBehindX, state.cameraX + 30, state.cameraX + canvas.width - 30);
@@ -3392,6 +3385,30 @@
               }
               const verticalBounds = getEnemyVerticalBounds(enemy);
               enemy.targetY = clamp(player.y + rand(-18, 18), verticalBounds.minY, verticalBounds.maxY);
+            };
+
+            if (distance > 190) {
+              enemy.x += Math.sign(dx) * moveSpeed * 0.8;
+              enemy.y += Math.sign(dy) * moveSpeed * 0.4;
+              enemy.isMoving = true;
+            }
+
+            const farDistanceForTeleport = 350;
+            const chaseBeforeTeleportFrames = 24;
+            if (distance > farDistanceForTeleport) {
+              enemy.teleportChaseFrames += 1;
+              enemy.x += Math.sign(dx) * moveSpeed * 0.45;
+              enemy.y += Math.sign(dy) * moveSpeed * 0.25;
+              enemy.isMoving = true;
+              if (enemy.teleportChaseFrames >= chaseBeforeTeleportFrames && verticalGap < 130 && canBurrowNow) {
+                startBurrowAttack();
+              }
+            } else {
+              enemy.teleportChaseFrames = 0;
+            }
+
+            if (distance > 150 && distance < 350 && verticalGap < 110 && canBurrowNow) {
+              startBurrowAttack();
             } else if (distance <= enemy.range && enemy.cooldown <= 0) {
               enemy.windup = 10;
               enemy.attackAnimTimer = 14;
@@ -3545,7 +3562,7 @@
             }
             enemy.cooldown = rand(40, 80);
             if (enemy.type === 'daphodilus' && enemy.aiState === 'PopAttack') {
-              setEnemyState(enemy, 'Recover');
+              setEnemyState(enemy, 'Approach');
               enemy.burrowCooldown = 300;
             }
           }

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3387,9 +3387,11 @@
               enemy.targetY = clamp(player.y + rand(-18, 18), verticalBounds.minY, verticalBounds.maxY);
             };
 
-            if (distance > 190) {
-              enemy.x += Math.sign(dx) * moveSpeed * 0.8;
-              enemy.y += Math.sign(dy) * moveSpeed * 0.4;
+            if (distance > enemy.range) {
+              const chaseScaleX = distance > 190 ? 0.8 : 0.95;
+              const chaseScaleY = distance > 190 ? 0.4 : 0.55;
+              enemy.x += Math.sign(dx) * moveSpeed * chaseScaleX;
+              enemy.y += Math.sign(dy) * moveSpeed * chaseScaleY;
               enemy.isMoving = true;
             }
 
@@ -3397,9 +3399,6 @@
             const chaseBeforeTeleportFrames = 24;
             if (distance > farDistanceForTeleport) {
               enemy.teleportChaseFrames += 1;
-              enemy.x += Math.sign(dx) * moveSpeed * 0.45;
-              enemy.y += Math.sign(dy) * moveSpeed * 0.25;
-              enemy.isMoving = true;
               if (enemy.teleportChaseFrames >= chaseBeforeTeleportFrames && verticalGap < 130 && canBurrowNow) {
                 startBurrowAttack();
               }


### PR DESCRIPTION
### Motivation
- Daphodilus would freeze in a `Recover` state after surfacing and attacking, making it behave differently from other melee enemies. 
- The goal is to have it resume normal chasing/attacking immediately after popping up so combat is more consistent and engaging. 
- When the player moves far away, daphodilus should briefly chase before deciding to dig/teleport so it doesn't immediately vanish from long range.

### Description
- Add a per-enemy `teleportChaseFrames` counter to the enemy object to track a short chase window before far-distance burrow teleports. 
- Replace the post-`PopAttack` transition to `Recover` with an immediate transition to `Approach` so the enemy resumes normal behavior after its pop attack. 
- Introduce a far-distance chase branch: when the player is beyond `farDistanceForTeleport` the daphodilus will increment `teleportChaseFrames` and chase slowly for `chaseBeforeTeleportFrames` frames, then trigger the burrow/teleport (`DigStart`) if other burrow conditions hold. 
- Reset `teleportChaseFrames` whenever a burrow is queued or the player comes back within range to prevent unintended teleports.

### Testing
- No automated tests were available or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc6001f1548329895f91eb7057b24b)