### PR TITLE
Fix enemy overlap melee hits and delving daphodilus chase behavior

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3393,7 +3393,7 @@
               }
               const verticalBounds = getEnemyVerticalBounds(enemy);
               enemy.targetY = clamp(player.y + rand(-18, 18), verticalBounds.minY, verticalBounds.maxY);
-            } else if (distance <= enemy.range && enemy.cooldown <= 0) {
+            } else if ((distance <= enemy.range || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0) {
               enemy.windup = 10;
               enemy.attackAnimTimer = 14;
             }
@@ -3506,7 +3506,7 @@
             enemy.x += Math.sign(dx) * moveSpeed * 0.6;
             enemy.y += Math.sign(dy) * moveSpeed * 0.4;
             enemy.isMoving = true;
-          } else if (distance > enemy.range) {
+          } else if (distance > enemy.range && !rectsOverlap(enemyBody, playerBody)) {
             enemy.x += Math.sign(dx) * moveSpeed;
             enemy.y += Math.sign(dy) * moveSpeed * 0.6;
             enemy.isMoving = true;

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3375,9 +3375,10 @@
               setEnemyState(enemy, 'Approach');
             }
           } else {
-            if (distance > 190) {
-              enemy.x += Math.sign(dx) * moveSpeed * 0.8;
-              enemy.y += Math.sign(dy) * moveSpeed * 0.4;
+            if (distance > enemy.range) {
+              const chaseSpeedScale = distance > 190 ? 0.8 : 0.95;
+              enemy.x += Math.sign(dx) * moveSpeed * chaseSpeedScale;
+              enemy.y += Math.sign(dy) * moveSpeed * 0.45;
               enemy.isMoving = true;
             }
             const verticalGap = Math.abs(player.y - enemy.y);
@@ -3540,12 +3541,18 @@
             } else {
               const attackReachMultiplier = enemy.isBoss ? 2 : 1;
               const forwardReach = ((enemy.range + 10) * attackReachMultiplier);
-              const meleeZone = { x: enemy.facing >= 0 ? enemyBody.x : enemyBody.x - forwardReach, y: enemyBody.y, width: enemyBody.width + forwardReach, height: enemyBody.height };
-              if (rectsOverlap(meleeZone, playerBody)) damagePlayer(enemy.damage);
+              const overlapReach = 12;
+              const meleeZone = {
+                x: (enemy.facing >= 0 ? enemyBody.x : enemyBody.x - forwardReach) - overlapReach,
+                y: enemyBody.y,
+                width: enemyBody.width + forwardReach + (overlapReach * 2),
+                height: enemyBody.height
+              };
+              if (rectsOverlap(meleeZone, playerBody) || rectsOverlap(enemyBody, playerBody)) damagePlayer(enemy.damage, enemy);
             }
             enemy.cooldown = rand(40, 80);
             if (enemy.type === 'daphodilus' && enemy.aiState === 'PopAttack') {
-              setEnemyState(enemy, 'Recover');
+              setEnemyState(enemy, 'Approach');
               enemy.burrowCooldown = 300;
             }
           }

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3393,7 +3393,7 @@
               }
               const verticalBounds = getEnemyVerticalBounds(enemy);
               enemy.targetY = clamp(player.y + rand(-18, 18), verticalBounds.minY, verticalBounds.maxY);
-            } else if ((distance <= enemy.range || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0) {
+            } else if ((distance <= enemy.range || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0 && enemy.windup <= 0) {
               enemy.windup = 10;
               enemy.attackAnimTimer = 14;
             }


### PR DESCRIPTION
### Motivation
- Ensure enemies can damage the player when their bodies overlap the player even if forward-facing reach misses, preventing missed hits while overlapped.
- Make the delving `daphodilus` remain aggressive: continue to pursue and attack while out of range and avoid pausing after its pop attack.

### Description
- Changed the daphodilus approach logic so it chases whenever `distance > enemy.range`, using a `chaseSpeedScale` to keep it moving toward the player at mid/long ranges (`distance > 190` uses a slightly lower scale).
- Expanded melee resolution by adding an `overlapReach` (12px) and checking a widened `meleeZone` plus `rectsOverlap(enemyBody, playerBody)` so contact while overlapped still triggers `damagePlayer`, and passed the attacking `enemy` into `damagePlayer` for correct attribution.
- Removed the post-`PopAttack` pause by transitioning daphodilus from `PopAttack` directly back to `Approach` (instead of `Recover`) and preserving its `burrowCooldown` handling.

### Testing
- Applied the patch and committed changes to `bayou-brawlers/index.html` and verified the diff with `git diff` showing the intended edits (succeeded).
- Verified working tree status with `git status --short` (clean) and committed the change (commit succeeded).
- Performed manual code inspection of the modified enemy update loop in `bayou-brawlers/index.html`; no automated gameplay test harness was available so no runtime automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc8a995df083298bba3c8c933355c5)