### PR TITLE
Double Stage 1 Mud Monster mud-trail width

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2094,7 +2094,7 @@
     }
 
     function spawnMudTrailPatch(x, y) {
-      const width = rand(42, 62);
+      const width = rand(84, 124);
       const height = rand(28, 40);
       const nearExistingPatch = state.hazards.some(h => h.kind === 'mud-trail'
         && Math.abs(h.x - x) < ((h.w + width) * 0.2)


### PR DESCRIPTION
### Motivation
- Make the Stage 1 Mud Monster boss hazard more impactful by increasing the generated mud-trail patch width so trails cover a larger area.

### Description
- Update in `bayou-brawlers/index.html`: change the width roll in `spawnMudTrailPatch` from `rand(42, 62)` to `rand(84, 124)` so spawned `mud-trail` hazards are roughly twice as wide while leaving height unchanged.

### Testing
- Verified the change by inspecting the modified lines with `nl -ba bayou-brawlers/index.html | sed -n '2090,2120p'` and confirmed the new `rand(84, 124)` width range; no unit/CI tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd81136cc883299824a786e9ddff6b)