### PR TITLE
Make stage‑1 Mud Monster faster and add orbiting mud‑trail trap AI

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3501,12 +3501,16 @@
               enemy.isMoving = true;
             }
           }
-        } else if (enemy.type === 'mud-monster' && enemy.isBoss && enemy.stage === 1 && state.levelIndex === 0) {
+        } else if (enemy.type === 'mud-monster' && enemy.isBoss && enemy.stage < 3 && state.levelIndex === 0) {
           if (!enemy.orbitDirection) enemy.orbitDirection = Math.random() < 0.5 ? -1 : 1;
-          const orbitRadiusX = 118;
-          const orbitRadiusY = 62;
-          const orbitStep = 0.052;
-          const chaseSpeed = moveSpeed * 1.4;
+          const isSecondStageClone = enemy.stage === 2;
+          const orbitRadiusX = isSecondStageClone ? 176 : 150;
+          const orbitRadiusY = isSecondStageClone ? 104 : 90;
+          const orbitStep = isSecondStageClone ? 0.042 : 0.05;
+          const chaseSpeed = moveSpeed * 1.45;
+          if (enemy.orbitPrepFrames === undefined) {
+            enemy.orbitPrepFrames = isSecondStageClone ? 170 : 130;
+          }
           const moveToTarget = (tx, ty, speed) => {
             const toTargetX = tx - enemy.x;
             const toTargetY = ty - enemy.y;
@@ -3517,28 +3521,45 @@
             return toTargetDistance;
           };
 
-          if (enemy.orbitAngle === undefined || !Number.isFinite(enemy.orbitAngle)) {
-            enemy.orbitAngle = Math.atan2(enemy.y - player.y, enemy.x - player.x);
+          if (enemy.orbitPrepFrames > 0) {
+            if (enemy.orbitAngle === undefined || !Number.isFinite(enemy.orbitAngle)) {
+              enemy.orbitAngle = Math.atan2(enemy.y - player.y, enemy.x - player.x);
+            }
+            enemy.orbitAngle += orbitStep * enemy.orbitDirection;
+
+            const desiredX = player.x + Math.cos(enemy.orbitAngle) * orbitRadiusX;
+            const desiredY = player.y + Math.sin(enemy.orbitAngle) * orbitRadiusY;
+            const orbitEntryDistance = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+            const isOutsideOrbit = orbitEntryDistance > orbitRadiusX + 26;
+
+            moveToTarget(desiredX, desiredY, isOutsideOrbit ? chaseSpeed : chaseSpeed * 0.9);
+
+            enemy.mudTrailDropCooldown -= 1;
+            if (enemy.mudTrailDropCooldown <= 0) {
+              const trapX = player.x + Math.cos(enemy.orbitAngle) * orbitRadiusX;
+              const trapY = player.y + Math.sin(enemy.orbitAngle) * orbitRadiusY;
+              spawnMudTrailPatch(trapX, trapY);
+              enemy.mudTrailDropCooldown = rand(2, 4);
+            }
+            enemy.orbitPrepFrames -= 1;
+          } else if (distance > enemy.range * 0.92 && !rectsOverlap(enemyBody, playerBody)) {
+            enemy.x += Math.sign(dx) * chaseSpeed;
+            enemy.y += Math.sign(dy) * chaseSpeed * 0.68;
+            enemy.isMoving = true;
           }
-          enemy.orbitAngle += orbitStep * enemy.orbitDirection;
 
-          const desiredX = player.x + Math.cos(enemy.orbitAngle) * orbitRadiusX;
-          const desiredY = player.y + Math.sin(enemy.orbitAngle) * orbitRadiusY;
-          const orbitEntryDistance = Math.hypot(enemy.x - player.x, enemy.y - player.y);
-          const isOutsideOrbit = orbitEntryDistance > orbitRadiusX + 24;
-
-          moveToTarget(desiredX, desiredY, isOutsideOrbit ? chaseSpeed : chaseSpeed * 0.9);
-
-          enemy.mudTrailDropCooldown -= 1;
-          if (enemy.mudTrailDropCooldown <= 0) {
-            const trapX = player.x + Math.cos(enemy.orbitAngle) * orbitRadiusX;
-            const trapY = player.y + Math.sin(enemy.orbitAngle) * orbitRadiusY;
-            spawnMudTrailPatch(trapX, trapY);
-            enemy.mudTrailDropCooldown = rand(2, 4);
-          }
-
-          if ((distance <= enemy.range * 1.15 || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0 && enemy.windup <= 0) {
+          if (enemy.orbitPrepFrames <= 0 && (distance <= enemy.range * 1.15 || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0 && enemy.windup <= 0) {
             enemy.windup = 10;
+            enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
+          }
+        } else if (enemy.type === 'mud-monster' && enemy.isBoss && enemy.stage === 3 && state.levelIndex === 0) {
+          const chaseSpeed = moveSpeed * 1.12;
+          if (distance > enemy.range * 0.92 && !rectsOverlap(enemyBody, playerBody)) {
+            enemy.x += Math.sign(dx) * chaseSpeed;
+            enemy.y += Math.sign(dy) * chaseSpeed * 0.7;
+            enemy.isMoving = true;
+          } else if (enemy.windup <= 0 && enemy.cooldown <= 0) {
+            enemy.windup = 11;
             enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
           }
         } else {
@@ -3605,7 +3626,7 @@
         enemy.y = clamp(enemy.y, verticalBounds.minY, verticalBounds.maxY);
         applyMovementMaskClamp(enemy, prevX, prevY);
 
-        if (enemy.isBoss && enemy.type === 'mud-monster' && state.levelIndex === 0 && enemy.hp > 0 && enemy.stage !== 1) {
+        if (enemy.isBoss && enemy.type === 'mud-monster' && state.levelIndex === 0 && enemy.hp > 0 && enemy.stage === 3) {
           enemy.mudTrailDropCooldown -= 1;
           if (enemy.isMoving && enemy.mudTrailDropCooldown <= 0) {
             spawnMudTrailPatch(enemy.x, enemy.y - 2);

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1326,7 +1326,7 @@
         const stageStatScale = {
           3: { hp: 1, speed: 1, damage: 1, score: 1 },
           2: { hp: 0.62, speed: 1.08, damage: 0.72, score: 0.58 },
-          1: { hp: 0.36, speed: 1.14, damage: 0.5, score: 0.34 }
+          1: { hp: 0.36, speed: 1.34, damage: 0.5, score: 0.34 }
         };
         const scale = stageStatScale[stage] || stageStatScale[1];
         return {
@@ -3501,6 +3501,46 @@
               enemy.isMoving = true;
             }
           }
+        } else if (enemy.type === 'mud-monster' && enemy.isBoss && enemy.stage === 1 && state.levelIndex === 0) {
+          if (!enemy.orbitDirection) enemy.orbitDirection = Math.random() < 0.5 ? -1 : 1;
+          const orbitRadiusX = 118;
+          const orbitRadiusY = 62;
+          const orbitStep = 0.052;
+          const chaseSpeed = moveSpeed * 1.4;
+          const moveToTarget = (tx, ty, speed) => {
+            const toTargetX = tx - enemy.x;
+            const toTargetY = ty - enemy.y;
+            const toTargetDistance = Math.hypot(toTargetX, toTargetY) || 1;
+            enemy.x += (toTargetX / toTargetDistance) * speed;
+            enemy.y += (toTargetY / toTargetDistance) * speed;
+            enemy.isMoving = true;
+            return toTargetDistance;
+          };
+
+          if (enemy.orbitAngle === undefined || !Number.isFinite(enemy.orbitAngle)) {
+            enemy.orbitAngle = Math.atan2(enemy.y - player.y, enemy.x - player.x);
+          }
+          enemy.orbitAngle += orbitStep * enemy.orbitDirection;
+
+          const desiredX = player.x + Math.cos(enemy.orbitAngle) * orbitRadiusX;
+          const desiredY = player.y + Math.sin(enemy.orbitAngle) * orbitRadiusY;
+          const orbitEntryDistance = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+          const isOutsideOrbit = orbitEntryDistance > orbitRadiusX + 24;
+
+          moveToTarget(desiredX, desiredY, isOutsideOrbit ? chaseSpeed : chaseSpeed * 0.9);
+
+          enemy.mudTrailDropCooldown -= 1;
+          if (enemy.mudTrailDropCooldown <= 0) {
+            const trapX = player.x + Math.cos(enemy.orbitAngle) * orbitRadiusX;
+            const trapY = player.y + Math.sin(enemy.orbitAngle) * orbitRadiusY;
+            spawnMudTrailPatch(trapX, trapY);
+            enemy.mudTrailDropCooldown = rand(2, 4);
+          }
+
+          if ((distance <= enemy.range * 1.15 || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0 && enemy.windup <= 0) {
+            enemy.windup = 10;
+            enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
+          }
         } else {
           if (enemy.ranged && distance > enemy.range * 0.7) {
             enemy.x += Math.sign(dx) * moveSpeed * 0.6;
@@ -3565,7 +3605,7 @@
         enemy.y = clamp(enemy.y, verticalBounds.minY, verticalBounds.maxY);
         applyMovementMaskClamp(enemy, prevX, prevY);
 
-        if (enemy.isBoss && enemy.type === 'mud-monster' && state.levelIndex === 0 && enemy.hp > 0) {
+        if (enemy.isBoss && enemy.type === 'mud-monster' && state.levelIndex === 0 && enemy.hp > 0 && enemy.stage !== 1) {
           enemy.mudTrailDropCooldown -= 1;
           if (enemy.isMoving && enemy.mudTrailDropCooldown <= 0) {
             spawnMudTrailPatch(enemy.x, enemy.y - 2);


### PR DESCRIPTION
### Motivation
- Make the stage 1 split of the Mud Monster move noticeably faster and behave more tactically. 
- Have the boss attempt to circle the player and leave mud patches to create trapping rings rather than only chasing directly.

### Description
- Increased the stage‑1 speed multiplier for `mud-monster` in `getStagedStats` from `1.14` to `1.34` so the split phase moves faster.  
- Added a stage‑1 specific AI branch in the enemy update loop that orbits the player using an `orbitAngle`/`orbitDirection` and target orbit radii, and moves the boss toward orbital target points.  
- While orbiting the player the boss periodically spawns mud trail patches along the orbit using `spawnMudTrailPatch` to form ring‑like traps and uses a melee windup when in range.  
- Prevented duplicate trail spawning by restricting the legacy boss trail logic to non‑stage‑1 phases so only the new orbit branch drops the close orbit patches.

### Testing
- Ran unit tests with `npm test -- --runInBand` and all test suites passed.  
- Test run summary: 3 test suites passed, 6 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bde02e9a948329b33d8a6f4e5c40fc)