### PR TITLE
Tune Bayou Brawlers mud monster split phases

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1324,9 +1324,9 @@
       if (!base) return { hp: 10, speed: 1, damage: 1, range: 20, score: 10 };
       if (typeId === 'mud-monster') {
         const stageStatScale = {
-          3: { hp: 1, speed: 1, damage: 1, score: 1 },
-          2: { hp: 0.62, speed: 1.08, damage: 0.72, score: 0.58 },
-          1: { hp: 0.36, speed: 1.34, damage: 0.5, score: 0.34 }
+          3: { hp: 2, speed: 1, damage: 1, score: 1 },
+          2: { hp: 1.24, speed: 1.26, damage: 0.72, score: 0.58 },
+          1: { hp: 0.72, speed: 1.62, damage: 0.5, score: 0.34 }
         };
         const scale = stageStatScale[stage] || stageStatScale[1];
         return {
@@ -3506,11 +3506,9 @@
           const isSecondStageClone = enemy.stage === 2;
           const orbitRadiusX = isSecondStageClone ? 176 : 150;
           const orbitRadiusY = isSecondStageClone ? 104 : 90;
-          const orbitStep = isSecondStageClone ? 0.042 : 0.05;
-          const chaseSpeed = moveSpeed * 1.45;
-          if (enemy.orbitPrepFrames === undefined) {
-            enemy.orbitPrepFrames = isSecondStageClone ? 170 : 130;
-          }
+          const orbitStep = isSecondStageClone ? 0.082 : 0.096;
+          const chaseSpeed = moveSpeed * 1.72;
+          const orbitLoopsBeforeAssault = 10;
           const moveToTarget = (tx, ty, speed) => {
             const toTargetX = tx - enemy.x;
             const toTargetY = ty - enemy.y;
@@ -3521,11 +3519,22 @@
             return toTargetDistance;
           };
 
-          if (enemy.orbitPrepFrames > 0) {
+          if (enemy.orbitAngleProgress === undefined) enemy.orbitAngleProgress = 0;
+          if (enemy.orbitLoopsCompleted === undefined) enemy.orbitLoopsCompleted = 0;
+
+          const shouldOrbit = enemy.orbitLoopsCompleted < orbitLoopsBeforeAssault;
+
+          if (shouldOrbit) {
             if (enemy.orbitAngle === undefined || !Number.isFinite(enemy.orbitAngle)) {
               enemy.orbitAngle = Math.atan2(enemy.y - player.y, enemy.x - player.x);
             }
-            enemy.orbitAngle += orbitStep * enemy.orbitDirection;
+            const orbitDelta = orbitStep * enemy.orbitDirection;
+            enemy.orbitAngle += orbitDelta;
+            enemy.orbitAngleProgress += Math.abs(orbitDelta);
+            if (enemy.orbitAngleProgress >= Math.PI * 2) {
+              enemy.orbitLoopsCompleted += 1;
+              enemy.orbitAngleProgress -= Math.PI * 2;
+            }
 
             const desiredX = player.x + Math.cos(enemy.orbitAngle) * orbitRadiusX;
             const desiredY = player.y + Math.sin(enemy.orbitAngle) * orbitRadiusY;
@@ -3541,14 +3550,13 @@
               spawnMudTrailPatch(trapX, trapY);
               enemy.mudTrailDropCooldown = rand(2, 4);
             }
-            enemy.orbitPrepFrames -= 1;
           } else if (distance > enemy.range * 0.92 && !rectsOverlap(enemyBody, playerBody)) {
             enemy.x += Math.sign(dx) * chaseSpeed;
             enemy.y += Math.sign(dy) * chaseSpeed * 0.68;
             enemy.isMoving = true;
           }
 
-          if (enemy.orbitPrepFrames <= 0 && (distance <= enemy.range * 1.15 || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0 && enemy.windup <= 0) {
+          if (!shouldOrbit && (distance <= enemy.range * 1.15 || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0 && enemy.windup <= 0) {
             enemy.windup = 10;
             enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
           }


### PR DESCRIPTION
### Motivation
- Make the Mud Monster split iterations more threatening and dynamic by increasing their health, speeding up the smaller forms, and having them attempt to encircle the player multiple times before switching to direct attacks.

### Description
- Doubled HP scale for mud monster stages and increased movement speed multipliers for stage 2 and stage 1 inside `getStagedStats` in `bayou-brawlers/index.html`.
- Replaced the timed `orbitPrepFrames` approach with loop-tracking state (`orbitAngleProgress`, `orbitLoopsCompleted`) and a `orbitLoopsBeforeAssault = 10` threshold for split-form AI when `stage < 3`.
- Increased `orbitStep` and `chaseSpeed` tuning values for split forms and changed the attack trigger so split forms only commit to an assault after completing the configured number of orbit loops.
- Kept existing mud-trail spawn behavior while orbiting by continuing to decrement and reset `mudTrailDropCooldown` during the new orbit loop logic.

### Testing
- Ran `git diff --check`, which completed successfully.
- No automated unit or gameplay test suite was executed for this HTML/JS gameplay tuning change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdf7685e708329b67a49ae1374f8d4)