### PR TITLE
Halve Billy Boxby damage and make slow/freeze procs chance-based

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2903,7 +2903,7 @@
       if (characterId === 'billy-boxby') {
         const coneLength = heavy ? 420 : 336;
         const coneSpread = heavy ? 0.66 : 0.57;
-        const baseDmg = (heavy ? tuning.heavy : tuning.light) * player.power * (heavy ? getHeavyDamageMultiplier(player) : getBasicDamageMultiplier(player));
+        const baseDmg = (heavy ? tuning.heavy : tuning.light) * player.power * (heavy ? getHeavyDamageMultiplier(player) : getBasicDamageMultiplier(player)) * 0.5;
         const coneOriginX = player.x + player.facing * 16;
         const coneOriginY = player.y - 44;
         let hitCount = 0;
@@ -3048,11 +3048,18 @@
       if (!canPlayerAffectEnemy(enemy)) return;
       const id = player.charData.id;
       if (id === 'billy-boxby') {
+        const isIncorporeal = enemy.type.includes('ghost');
+        const slowChance = heavy
+          ? (isIncorporeal ? 1 : 0.75)
+          : (isIncorporeal ? 0.8 : 0.4);
+        const freezeChance = heavy
+          ? (isIncorporeal ? 0.6 : 0.25)
+          : 0;
         const slow = heavy ? 0.4 : 0.2;
-        const freezeDur = enemy.type.includes('ghost') ? (heavy ? 120 : 72) : 0;
+        const freezeDur = heavy ? 120 : 0;
         const bonusDur = hasLevel(player, 10) ? 1.5 : 1;
-        applyStatus(enemy, 'SLOW', Math.floor((heavy ? 180 : 150) * bonusDur), slow);
-        if (freezeDur > 0) applyStatus(enemy, 'FREEZE', freezeDur, 1);
+        if (Math.random() < slowChance) applyStatus(enemy, 'SLOW', Math.floor((heavy ? 180 : 150) * bonusDur), slow);
+        if (freezeDur > 0 && Math.random() < freezeChance) applyStatus(enemy, 'FREEZE', freezeDur, 1);
       }
       if (id === 'green-fairy' && heavy && Math.random() < 0.2) applyStatus(enemy, 'CONFUSE', 90, 1);
       if (id === 'grimma-the-feared' && heavy && getEnemyTier(enemy) === 'small') enemy.x += (player.x - enemy.x) * 0.2;


### PR DESCRIPTION
### Motivation
- Rebalance Billy Boxby by reducing raw damage output and making his crowd-control effects probabilistic to better differentiate behavior against incorporeal (ghost) and non-incorporeal enemies.
- Preserve existing slow magnitudes and durations while introducing proc chances so status effects are less deterministic but still meaningful.

### Description
- Halved Billy Boxby cone attack damage by applying a `* 0.5` multiplier to the `baseDmg` calculation in `doAttack` for `billy-boxby`.
- Reworked `applyCharacterOnHitStatus` for `billy-boxby` to detect incorporeal enemies via `enemy.type.includes('ghost')` and compute `slowChance` and `freezeChance` based on `heavy` and ghost status.
- Status application now uses `Math.random()` against the computed chances before calling `applyStatus`, while keeping the existing slow magnitude and duration (with `hasLevel(player, 10)` bonus duration) and heavy freeze duration.

### Testing
- Ran `npm test -- --runInBand` and all automated tests passed.
- Test results: 3 test suites passed, 6 tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea4b80d1c8329af996d5676f41b31)