### PR TITLE
Redesign Bayou Brawlers character picker into swipe carousel

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -263,96 +263,111 @@
       transition: opacity 1700ms ease, transform 1700ms ease;
     }
     .character-grid {
+      margin-top: 14px;
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-      gap: 12px;
-      margin-top: 12px;
+      grid-template-columns: minmax(40px, 52px) minmax(0, 1fr) minmax(40px, 52px);
+      gap: 10px;
+      align-items: stretch;
     }
-    .card {
-      border: 2px solid rgba(255,215,0,0.4);
-      border-radius: 12px;
-      padding: 10px 8px;
-      background: rgba(10,12,16,0.8);
-      cursor: pointer;
-      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    .character-strip {
+      display: grid;
+      grid-template-rows: repeat(4, 1fr);
+      gap: 8px;
+      height: 100%;
+    }
+    .strip-thumb {
+      border: 2px solid rgba(255,215,0,0.22);
+      border-radius: 10px;
+      background: rgba(10,12,16,0.82);
       display: grid;
       place-items: center;
-      text-align: center;
-      min-height: 132px;
+      padding: 4px;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+      min-height: 0;
+    }
+    .strip-thumb img {
+      width: 100%;
+      max-width: 32px;
+      aspect-ratio: 1 / 1;
+      image-rendering: pixelated;
+      border-radius: 6px;
+      border: 1px solid rgba(255,255,255,0.2);
+      background: #0b0f12;
+      object-fit: cover;
+    }
+    .strip-thumb.active {
+      border-color: var(--emerald);
+      box-shadow: 0 0 14px rgba(45,212,191,0.75);
+      transform: scale(1.03);
+    }
+    .character-carousel {
+      border: 2px solid rgba(255,215,0,0.56);
+      border-radius: 14px;
+      background: rgba(7,10,14,0.95);
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,0.05), 0 0 20px rgba(255,215,0,0.15);
+      padding: 14px;
+      min-height: clamp(220px, 44vw, 320px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
       user-select: none;
       -webkit-user-select: none;
-      touch-action: none;
-      position: relative;
+      touch-action: pan-y;
     }
-    .card.selected {
-      border-color: var(--gold);
-      box-shadow: 0 0 16px rgba(255,215,0,0.4);
-      transform: translateY(-2px);
-    }
-    .card img {
-      width: clamp(46px, 8vw, 60px);
-      height: clamp(46px, 8vw, 60px);
-      image-rendering: pixelated;
-      margin-bottom: 6px;
-      border: 1px solid rgba(255,255,255,0.2);
-      border-radius: 6px;
-      background: #0b0f12;
-    }
-    .card h3 {
-      margin: 4px 0 6px;
-      font-size: clamp(9px, 1.8vw, 11px);
-      color: #fff;
-    }
-    .card .hold-tip {
-      font-size: 7px;
-      color: #9fd6cf;
-      line-height: 1.4;
-      text-transform: uppercase;
-      letter-spacing: 0.3px;
-    }
-    .hold-progress {
+    .character-display {
       width: 100%;
-      height: 5px;
-      border-radius: 99px;
-      margin-top: 6px;
-      background: rgba(255,255,255,0.12);
-      overflow: hidden;
-      opacity: 0;
-      transition: opacity 0.15s ease;
-    }
-    .card.holding .hold-progress { opacity: 1; }
-    .hold-progress-fill {
-      width: 0%;
       height: 100%;
-      background: linear-gradient(90deg, #5F9EA0, #FFD700);
+      display: grid;
+      grid-template-columns: minmax(120px, 42%) minmax(0, 1fr);
+      gap: 14px;
+      align-items: center;
     }
-    .character-detail {
-      text-align: left;
-      margin-top: 14px;
-      border: 2px solid rgba(255,215,0,0.45);
+    .character-display-portrait {
+      width: 100%;
+      height: 100%;
+      min-height: 172px;
+      border-radius: 12px;
+      border: 2px solid rgba(255,215,0,0.38);
+      background: radial-gradient(circle at 50% 26%, rgba(95,158,160,0.32), rgba(6,8,11,0.92));
+      display: grid;
+      place-items: center;
+      padding: 10px;
+    }
+    .character-display-portrait img {
+      width: 100%;
+      max-width: 200px;
+      aspect-ratio: 1 / 1;
+      object-fit: contain;
+      image-rendering: pixelated;
       border-radius: 10px;
-      background: rgba(6,8,11,0.9);
-      padding: 12px;
-      display: none;
+      border: 1px solid rgba(255,255,255,0.18);
+      background: rgba(0,0,0,0.3);
     }
-    .character-detail.show { display: block; }
-    .character-detail h3 {
-      margin: 0 0 8px;
+    .character-display-info {
+      text-align: left;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .character-display-info h3 {
+      margin: 0;
       color: var(--gold);
-      font-size: 12px;
+      font-size: clamp(12px, 2.2vw, 16px);
+      line-height: 1.3;
     }
-    .character-detail .stat,
-    .character-detail .move {
+    .character-display-info p {
+      margin: 0;
       font-size: 9px;
       line-height: 1.5;
-      margin: 0;
     }
-    .character-detail .stat { color: #9fd6cf; }
-    .character-detail .move { color: #f3d28a; }
-    .character-detail-actions {
+    .character-display-info .stat { color: #9fd6cf; }
+    .character-display-info .move { color: #f3d28a; }
+    .swipe-hint {
       margin-top: 8px;
-      display: flex;
-      justify-content: flex-end;
+      font-size: 8px;
+      color: #86c5bb;
+      text-align: center;
+      letter-spacing: 0.5px;
     }
     .levelup-panel { max-width: 640px; }
     .levelup-choices { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; margin-top: 10px; }
@@ -535,9 +550,14 @@
       .pad-btn { width: 38px; height: 38px; font-size: 10px; }
       .action-pad { gap: 5px; }
       .action-pad .pad-btn { width: 44px; height: 44px; font-size: 8px; }
-      .character-grid { grid-template-columns: repeat(auto-fit, minmax(92px, 1fr)); gap: 8px; }
+      .character-grid { grid-template-columns: minmax(32px, 46px) minmax(0, 1fr) minmax(32px, 46px); gap: 7px; }
+      .character-carousel { min-height: clamp(200px, 60vw, 280px); padding: 10px; }
+      .character-display { grid-template-columns: minmax(88px, 38%) minmax(0, 1fr); gap: 10px; }
+      .character-display-portrait { min-height: 148px; padding: 6px; }
+      .character-display-info h3 { font-size: 11px; }
+      .character-display-info p { font-size: 8px; }
+      .swipe-hint { font-size: 7px; }
       .levelup-choices { grid-template-columns: 1fr; }
-      .card { min-height: 116px; }
       .instructions { font-size: 8px; }
     }
 
@@ -627,9 +647,8 @@
     <div class="overlay" id="startOverlay">
       <div class="panel start-panel">
         <h2>Pick Your Brawler</h2>
-        <p>Choose a fighter with distinct stats and unique abilities. Every character has a fast strike, a power hit, and a signature special. Press and hold any thumbnail for a full stat card.</p>
+        <p>Choose a fighter with distinct stats and unique abilities. Every character has a fast strike, a power hit, and a signature special. Swipe left or right on the profile card to browse each brawler.</p>
         <div class="character-grid" id="characterGrid"></div>
-        <div class="character-detail" id="characterDetail" aria-live="polite"></div>
         <button class="btn" id="startBtn" disabled>Start the Journey</button>
         <div class="instructions">
           <strong>Desktop:</strong> Move (WASD/Arrows), Fast (J), Power (K), Special (L), Jump (Space), Block (Shift).<br>
@@ -4759,105 +4778,112 @@
 
     function initCharacterSelection() {
       const grid = document.getElementById('characterGrid');
-      const detailPanel = document.getElementById('characterDetail');
-      const HOLD_TO_OPEN_MS = 1200;
-      let selected = null;
+      const startBtn = document.getElementById('startBtn');
+      let selectedIndex = 0;
+      let selected = characters[selectedIndex];
+      let swipeStartX = null;
+      let swipeStartY = null;
+      const SWIPE_THRESHOLD = 42;
 
-      const renderDetail = (character) => {
-        detailPanel.classList.add('show');
-        detailPanel.innerHTML = `
-          <h3>${character.name}</h3>
-          <p class="stat">Speed ${character.stats.speed.toFixed(1)} | Power ${character.stats.power.toFixed(2)} | Range ${character.stats.range} | Durability ${character.stats.durability}</p>
-          <p class="move"><strong>Fast:</strong> ${character.moves.fast}</p>
-          <p class="move"><strong>Power:</strong> ${character.moves.power}</p>
-          <p class="move"><strong>Special:</strong> ${character.moves.special}</p>
-          <div class="character-detail-actions">
-            <button class="btn" type="button" id="closeDetailBtn">Close Details</button>
+      const leftCharacters = characters.slice(0, 4);
+      const rightCharacters = characters.slice(4, 8);
+
+      grid.innerHTML = `
+        <div class="character-strip" id="characterStripLeft"></div>
+        <div>
+          <div class="character-carousel" id="characterCarousel" role="button" tabindex="0" aria-live="polite" aria-label="Character profile browser. Swipe left or right to change character.">
+            <div class="character-display" id="characterDisplay"></div>
           </div>
-        `;
-        const closeButton = document.getElementById('closeDetailBtn');
-        closeButton.addEventListener('click', () => {
-          detailPanel.classList.remove('show');
-          detailPanel.innerHTML = '';
+          <div class="swipe-hint">SWIPE OR USE ARROW KEYS TO BROWSE</div>
+        </div>
+        <div class="character-strip" id="characterStripRight"></div>
+      `;
+
+      const leftStrip = document.getElementById('characterStripLeft');
+      const rightStrip = document.getElementById('characterStripRight');
+      const display = document.getElementById('characterDisplay');
+      const carousel = document.getElementById('characterCarousel');
+
+      const createStripThumb = (character) => {
+        const thumb = document.createElement('div');
+        thumb.className = 'strip-thumb';
+        thumb.dataset.characterId = character.id;
+        thumb.innerHTML = `<img src="${character.portrait}" alt="${character.name}">`;
+        thumb.setAttribute('title', character.name);
+        thumb.addEventListener('click', () => {
+          selectedIndex = characters.findIndex(entry => entry.id === character.id);
+          renderSelection();
+        });
+        return thumb;
+      };
+
+      leftCharacters.forEach(character => leftStrip.appendChild(createStripThumb(character)));
+      rightCharacters.forEach(character => rightStrip.appendChild(createStripThumb(character)));
+
+      const updateStripHighlights = () => {
+        grid.querySelectorAll('.strip-thumb').forEach((thumb) => {
+          thumb.classList.toggle('active', thumb.dataset.characterId === selected.id);
         });
       };
 
-      characters.forEach(character => {
-        const card = document.createElement('div');
-        card.className = 'card';
-        card.setAttribute('role', 'button');
-        card.setAttribute('tabindex', '0');
-        card.setAttribute('aria-label', `${character.name}. Press to select. Press and hold for details.`);
-        card.innerHTML = `
-          <img src="${character.portrait}" alt="${character.name}">
-          <h3>${character.name}</h3>
-          <div class="hold-tip">Tap to Select • Hold for Details</div>
-          <div class="hold-progress" aria-hidden="true"><div class="hold-progress-fill"></div></div>
+      const renderSelection = () => {
+        selected = characters[selectedIndex];
+        display.innerHTML = `
+          <div class="character-display-portrait">
+            <img src="${selected.portrait}" alt="${selected.name}">
+          </div>
+          <div class="character-display-info">
+            <h3>${selected.name}</h3>
+            <p class="stat">Speed ${selected.stats.speed.toFixed(1)} | Power ${selected.stats.power.toFixed(2)} | Range ${selected.stats.range} | Durability ${selected.stats.durability}</p>
+            <p class="move"><strong>Fast:</strong> ${selected.moves.fast}</p>
+            <p class="move"><strong>Power:</strong> ${selected.moves.power}</p>
+            <p class="move"><strong>Special:</strong> ${selected.moves.special}</p>
+          </div>
         `;
-        const progressFill = card.querySelector('.hold-progress-fill');
-        let holdTimer = null;
-        let progressTimer = null;
-        let holdTriggered = false;
+        updateStripHighlights();
+        startBtn.disabled = false;
+      };
 
-        const clearHold = () => {
-          if (holdTimer) {
-            clearTimeout(holdTimer);
-            holdTimer = null;
-          }
-          if (progressTimer) {
-            clearInterval(progressTimer);
-            progressTimer = null;
-          }
-          card.classList.remove('holding');
-          progressFill.style.width = '0%';
-        };
+      const stepSelection = (direction) => {
+        const count = characters.length;
+        selectedIndex = (selectedIndex + direction + count) % count;
+        renderSelection();
+      };
 
-        const beginHold = () => {
-          holdTriggered = false;
-          clearHold();
-          card.classList.add('holding');
-          const start = performance.now();
-          progressTimer = setInterval(() => {
-            const elapsed = performance.now() - start;
-            const progress = Math.min(100, (elapsed / HOLD_TO_OPEN_MS) * 100);
-            progressFill.style.width = `${progress}%`;
-          }, 16);
-
-          holdTimer = setTimeout(() => {
-            holdTriggered = true;
-            clearHold();
-            renderDetail(character);
-          }, HOLD_TO_OPEN_MS);
-        };
-
-        card.addEventListener('pointerdown', beginHold);
-        card.addEventListener('pointerup', clearHold);
-        card.addEventListener('pointerleave', clearHold);
-        card.addEventListener('pointercancel', clearHold);
-        card.addEventListener('click', () => {
-          if (holdTriggered) {
-            holdTriggered = false;
-            return;
-          }
-          document.querySelectorAll('.card').forEach(el => el.classList.remove('selected'));
-          card.classList.add('selected');
-          selected = character;
-          document.getElementById('startBtn').disabled = false;
-        });
-        card.addEventListener('keydown', (event) => {
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            card.click();
-          }
-          if (event.key.toLowerCase() === 'i') {
-            event.preventDefault();
-            renderDetail(character);
-          }
-        });
-        grid.appendChild(card);
+      carousel.addEventListener('pointerdown', (event) => {
+        swipeStartX = event.clientX;
+        swipeStartY = event.clientY;
       });
 
-      document.getElementById('startBtn').addEventListener('click', () => {
+      carousel.addEventListener('pointerup', (event) => {
+        if (swipeStartX === null || swipeStartY === null) return;
+        const deltaX = event.clientX - swipeStartX;
+        const deltaY = event.clientY - swipeStartY;
+        if (Math.abs(deltaX) > SWIPE_THRESHOLD && Math.abs(deltaX) > Math.abs(deltaY)) {
+          stepSelection(deltaX < 0 ? 1 : -1);
+        }
+        swipeStartX = null;
+        swipeStartY = null;
+      });
+
+      carousel.addEventListener('pointercancel', () => {
+        swipeStartX = null;
+        swipeStartY = null;
+      });
+
+      carousel.addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          stepSelection(1);
+        } else if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          stepSelection(-1);
+        }
+      });
+
+      renderSelection();
+
+      startBtn.addEventListener('click', () => {
         if (!selected) return;
         state.player = createPlayer(selected);
         state.player.level = 1;


### PR DESCRIPTION
### Motivation
- Replace the grid-of-thumbnails picker with a wider rectangular profile/info display that shows a large portrait at left and stats/info at right to improve readability and mobile friendliness.
- Surface quick navigation by adding small stacked thumbnails outside the main box so players can see and pick characters quickly.
- Provide intuitive touch navigation by enabling swipe left/right (and arrow key) browsing of character profiles instead of hold-to-open detail cards.

### Description
- Reworked CSS for the start panel: replaced the old `.card` grid with `.character-grid`, `.character-strip`, `.strip-thumb`, `.character-carousel`, `.character-display`, `.character-display-portrait`, `.character-display-info`, and `.swipe-hint` to implement the wide rectangular main display and vertical thumbnail columns.
- Replaced the `initCharacterSelection` implementation with a new function that builds left/right thumbnail strips (4 per side), renders the large profile/info panel, updates highlight state for the active tiny portrait, and enables swipe gestures and arrow-key navigation to cycle characters (`pointerdown`/`pointerup` handlers, `stepSelection`, `renderSelection`, `updateStripHighlights`).
- Removed the old hold-to-open detail card workflow and associated DOM `characterDetail` element and updated the start-panel helper text to instruct users to swipe or use arrow keys.
- Adjusted responsive rules in media queries to ensure the new carousel layout scales down for smaller screens.

### Testing
- Ran the automated unit test `npm test -- --runInBand __tests__/shuffle.test.js` and it passed. 
- No additional automated UI/browser tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec8960e188329921bc4655c7de768)