### PR TITLE
Tighten Bayou Brawlers character select layout for small screens

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -166,10 +166,25 @@
       width: calc(100vw - 40px);
     }
     .panel.start-panel {
-      max-height: min(84dvh, 820px);
-      overflow: auto;
-      overscroll-behavior: contain;
-      padding-bottom: calc(18px + env(safe-area-inset-bottom));
+      height: min(92dvh, 820px);
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      overflow: hidden;
+      padding: 14px 16px calc(12px + env(safe-area-inset-bottom));
+    }
+    .start-panel h2,
+    .start-panel p,
+    .start-panel .instructions {
+      margin: 0;
+    }
+    .start-panel h2 {
+      font-size: clamp(12px, 2.2vh, 16px);
+      line-height: 1.2;
+    }
+    .start-panel > p {
+      font-size: clamp(8px, 1.55vh, 11px);
+      line-height: 1.35;
     }
     .panel h2 {
       margin: 0 0 10px;
@@ -263,15 +278,15 @@
       transition: opacity 1700ms ease, transform 1700ms ease;
     }
     .character-grid {
-      margin-top: 12px;
+      margin-top: 0;
       width: min(100%, 680px);
       margin-inline: auto;
     }
     .thumbnail-row {
       display: grid;
       grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 10px;
-      margin: 8px 4px;
+      gap: clamp(4px, 0.8vh, 10px);
+      margin: clamp(2px, 0.6vh, 8px) 4px;
     }
     .thumb-card {
       border: 2px solid rgba(159,214,207,0.45);
@@ -287,8 +302,8 @@
       touch-action: manipulation;
     }
     .thumb-card img {
-      width: clamp(34px, 6vw, 46px);
-      height: clamp(34px, 6vw, 46px);
+      width: clamp(28px, 4.8vh, 44px);
+      height: clamp(28px, 4.8vh, 44px);
       image-rendering: pixelated;
       border-radius: 6px;
       border: 1px solid rgba(255,255,255,0.2);
@@ -304,16 +319,17 @@
       border: 2px solid rgba(255,215,0,0.45);
       border-radius: 12px;
       background: rgba(6,8,11,0.94);
-      padding: 12px;
+      padding: clamp(8px, 1.4vh, 12px);
       display: grid;
-      grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
-      gap: 14px;
+      grid-template-columns: minmax(130px, 28vh) minmax(0, 1fr);
+      gap: clamp(8px, 1.1vh, 14px);
       align-items: center;
       touch-action: pan-y;
+      min-height: 0;
     }
     .character-hero-img {
       width: 100%;
-      max-width: 240px;
+      max-width: min(28vh, 220px);
       aspect-ratio: 1 / 1;
       object-fit: contain;
       image-rendering: pixelated;
@@ -327,20 +343,20 @@
     .character-detail.show { display: grid; }
     .character-detail-main { min-width: 0; }
     .character-detail h3 {
-      margin: 0 0 8px;
+      margin: 0 0 clamp(3px, 0.6vh, 8px);
       color: var(--gold);
-      font-size: 14px;
+      font-size: clamp(11px, 1.95vh, 14px);
     }
     .character-detail .stat,
     .character-detail .move {
-      font-size: 10px;
-      line-height: 1.5;
+      font-size: clamp(8px, 1.35vh, 10px);
+      line-height: 1.3;
       margin: 0;
     }
     .character-detail .stat { color: #9fd6cf; }
     .character-detail .move { color: #f3d28a; }
     .character-detail-actions {
-      margin-top: 8px;
+      margin-top: clamp(4px, 0.9vh, 8px);
       display: flex;
       justify-content: flex-start;
     }
@@ -503,11 +519,15 @@
       font-size: clamp(8px, 1.5vw, 10px);
     }
     .instructions {
-      font-size: 9px;
+      font-size: clamp(7px, 1.2vh, 9px);
       color: #9fd6cf;
-      line-height: 1.6;
-      margin-top: 10px;
+      line-height: 1.35;
+      margin-top: 0;
       text-align: left;
+    }
+    #startBtn {
+      align-self: center;
+      margin-top: 0;
     }
 
     @media (max-width: 720px) {
@@ -519,6 +539,10 @@
 
     @media (max-width: 600px) {
       .panel { width: calc(100vw - 24px); padding: 14px; }
+      .panel.start-panel {
+        height: min(94dvh, 780px);
+        padding: 12px;
+      }
       .controls { flex-direction: row; align-items: center; gap: 8px; bottom: calc(24px + env(safe-area-inset-bottom)); }
       .direction-pad { width: 104px; height: 104px; }
       .direction-pad-knob { width: 40px; height: 40px; }
@@ -538,6 +562,10 @@
     }
 
     @media (max-width: 420px) {
+      .panel.start-panel {
+        gap: 6px;
+        height: min(96dvh, 760px);
+      }
       .title h1 { font-size: 11px; }
       .btn { padding: 7px 9px; font-size: 9px; }
       .hud { top: calc(92px + env(safe-area-inset-top)); padding: 4px 7px; gap: 5px; }
@@ -551,6 +579,31 @@
       }
       .panel h2 { font-size: 13px; }
       .panel p { font-size: 9px; }
+      .start-panel > p {
+        display: none;
+      }
+      .character-detail {
+        padding: 8px;
+      }
+      .character-detail .move:last-of-type {
+        display: none;
+      }
+    }
+
+    @media (max-height: 760px) {
+      .panel.start-panel {
+        height: min(96dvh, 720px);
+        gap: 6px;
+      }
+      .start-panel > p {
+        display: none;
+      }
+      .instructions {
+        font-size: 7px;
+      }
+      .character-detail .move:last-of-type {
+        display: none;
+      }
     }
   </style>
   <script>


### PR DESCRIPTION
### Motivation

- Ensure the initial character-selection screen fits within a typical desktop, tablet, or mobile viewport without requiring internal scrolling by users.

### Description

- Convert `.panel.start-panel` from a scrollable panel to a fixed, viewport-aware flex column (`height: min(...dvh, ...)`, `overflow: hidden`) and normalize panel padding and margins.
- Use viewport-aware `clamp()` sizing for thumbnails, portrait, detail panel spacing, and typography to scale elements across device sizes.
- Add responsive rules for narrow and short viewports (`@media (max-width: 420px)` and `@media (max-height: 760px)`) that hide low-priority copy and the final move line to prevent overflow.
- Center the `#startBtn`, reduce instruction footprint, and tweak gaps/padding so all primary controls remain visible without scrolling on constrained screens.

### Testing

- `git diff --check` was run and returned no issues (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed0a3c3e483298f7faaaeea269d9d)