### PR TITLE
Refine Sweetykins boss AI to run-run-brawl-retreat cycle

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2231,6 +2231,29 @@
       return scopedTracks[facingName];
     }
 
+    function ensureSweetykinsCycle(enemy) {
+      if (enemy.type !== 'sweetykins') return null;
+      if (!enemy.sweetykinsCycle) {
+        const initialDirection = enemy.x > state.player.x ? -1 : 1;
+        enemy.sweetykinsCycle = {
+          phase: 'charge',
+          runsCompleted: 0,
+          chargeDirection: initialDirection,
+          turnTimer: 0,
+          attackFramesLeft: 0,
+          runHitCooldown: 0
+        };
+      }
+      return enemy.sweetykinsCycle;
+    }
+
+    function getSweetykinsOffscreenX(direction) {
+      const margin = 120;
+      return direction >= 0
+        ? state.cameraX - margin
+        : state.cameraX + canvas.width + margin;
+    }
+
     function updateEnemyAnimation(enemy, dt) {
       if (!enemy.animation) return;
       const anim = enemy.animation;
@@ -3586,30 +3609,92 @@
             enemy.isMoving = true;
           }
         } else if (enemy.type === 'sweetykins') {
-          enemy.dashCooldown = Math.max(0, enemy.dashCooldown - 1);
-          if (enemy.dashFrames > 0) {
-            enemy.dashFrames -= 1;
-            enemy.x += enemy.facing * moveSpeed * 2.9;
-            enemy.y += Math.sign(dy) * moveSpeed * 0.25;
-            enemy.isMoving = true;
-            if (rectsOverlap({ x: enemyBody.x - 18, y: enemyBody.y - 8, width: enemyBody.width + 36, height: enemyBody.height + 16 }, playerBody)) {
-              damagePlayer(Math.round(enemy.damage * 1.2), enemy);
+          const cycle = ensureSweetykinsCycle(enemy);
+          if (cycle) cycle.runHitCooldown = Math.max(0, cycle.runHitCooldown - 1);
+
+          if (cycle.phase === 'charge') {
+            enemy.windup = 0;
+            enemy.attackAnimTimer = 0;
+            if (cycle.turnTimer > 0) {
+              cycle.turnTimer -= 1;
+            } else {
+              const runDirection = cycle.chargeDirection >= 0 ? 1 : -1;
+              enemy.facing = runDirection;
+              enemy.x += runDirection * moveSpeed * 3.8;
+              enemy.y += clamp(dy * 0.18, -moveSpeed * 0.45, moveSpeed * 0.45);
+              enemy.isMoving = true;
+
+              const runZone = {
+                x: enemyBody.x - 24,
+                y: enemyBody.y - 8,
+                width: enemyBody.width + 48,
+                height: enemyBody.height + 16
+              };
+              if (cycle.runHitCooldown <= 0 && (rectsOverlap(runZone, playerBody) || Math.hypot(player.x - enemy.x, player.y - enemy.y) < 74)) {
+                damagePlayer(Math.round(enemy.damage * 1.2), enemy);
+                cycle.runHitCooldown = 16;
+              }
             }
-            if (enemy.dashFrames <= 0) {
-              enemy.cooldown = rand(40, 70);
-              enemy.dashCooldown = rand(60, 110);
+
+            const runExitedScreen = enemy.x < state.cameraX - 100 || enemy.x > state.cameraX + canvas.width + 100;
+            if (runExitedScreen) {
+              cycle.runsCompleted += 1;
+              if (cycle.runsCompleted < 2) {
+                cycle.chargeDirection *= -1;
+                enemy.x = getSweetykinsOffscreenX(cycle.chargeDirection);
+                cycle.turnTimer = 8;
+              } else {
+                cycle.phase = 'approach';
+                enemy.x = getSweetykinsOffscreenX(cycle.chargeDirection);
+                enemy.facing = player.x >= enemy.x ? 1 : -1;
+              }
             }
-          } else if (enemy.dashCooldown <= 0 && distance < 380) {
-            enemy.facing = dx >= 0 ? 1 : -1;
-            enemy.dashFrames = rand(24, 34);
-            enemy.windup = 8;
-            enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 20);
-          } else {
-            const closeDistance = 100;
-            if (distance > closeDistance) {
-              enemy.x += Math.sign(dx) * moveSpeed * 0.9;
+          } else if (cycle.phase === 'approach') {
+            enemy.windup = 0;
+            enemy.attackAnimTimer = 0;
+            const approachDx = player.x - enemy.x;
+            const approachDy = player.y - enemy.y;
+            const approachDistance = Math.hypot(approachDx, approachDy);
+            if (Math.abs(approachDx) > ENEMY_FACING_DEADZONE_X) enemy.facing = approachDx >= 0 ? 1 : -1;
+            if (approachDistance > enemy.range * 0.95) {
+              enemy.x += Math.sign(approachDx) * moveSpeed * 0.9;
+              enemy.y += Math.sign(approachDy) * moveSpeed * 0.45;
+              enemy.isMoving = true;
+            } else {
+              cycle.phase = 'brawl';
+              cycle.attackFramesLeft = 60 * 5;
+              enemy.cooldown = 0;
+            }
+          } else if (cycle.phase === 'brawl') {
+            cycle.attackFramesLeft = Math.max(0, cycle.attackFramesLeft - 1);
+            if (distance > enemy.range * 0.92 && !rectsOverlap(enemyBody, playerBody)) {
+              enemy.x += Math.sign(dx) * moveSpeed * 0.95;
               enemy.y += Math.sign(dy) * moveSpeed * 0.45;
               enemy.isMoving = true;
+            } else if (enemy.cooldown <= 0 && enemy.windup <= 0) {
+              enemy.windup = 10;
+              enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
+            }
+
+            if (cycle.attackFramesLeft <= 0) {
+              cycle.phase = 'retreat';
+              cycle.chargeDirection = enemy.x < state.cameraX + (canvas.width * 0.5) ? -1 : 1;
+            }
+          } else if (cycle.phase === 'retreat') {
+            enemy.windup = 0;
+            enemy.attackAnimTimer = 0;
+            const retreatDirection = cycle.chargeDirection >= 0 ? 1 : -1;
+            enemy.facing = retreatDirection;
+            enemy.x += retreatDirection * moveSpeed * 3.2;
+            enemy.y += clamp((player.y - enemy.y) * 0.08, -moveSpeed * 0.2, moveSpeed * 0.2);
+            enemy.isMoving = true;
+            const retreatedOffscreen = enemy.x < state.cameraX - 110 || enemy.x > state.cameraX + canvas.width + 110;
+            if (retreatedOffscreen) {
+              cycle.phase = 'charge';
+              cycle.runsCompleted = 0;
+              cycle.chargeDirection *= -1;
+              enemy.x = getSweetykinsOffscreenX(cycle.chargeDirection);
+              cycle.turnTimer = 8;
             }
           }
         } else if (enemy.type === 'mud-monster' && enemy.isBoss && enemy.stage < 3 && state.levelIndex === 0) {
@@ -3765,7 +3850,11 @@
         if (enemy.attackAnimTimer > 0) enemy.attackAnimTimer -= 1;
         const verticalBounds = getEnemyVerticalBounds(enemy);
         enemy.y = clamp(enemy.y, verticalBounds.minY, verticalBounds.maxY);
-        applyMovementMaskClamp(enemy, prevX, prevY);
+        const sweetykinsCycle = enemy.type === 'sweetykins' ? ensureSweetykinsCycle(enemy) : null;
+        const isSweetykinsOffscreenPhase = sweetykinsCycle && ['charge', 'approach', 'retreat'].includes(sweetykinsCycle.phase);
+        if (!isSweetykinsOffscreenPhase) {
+          applyMovementMaskClamp(enemy, prevX, prevY);
+        }
 
         if (enemy.isBoss && enemy.type === 'mud-monster' && state.levelIndex === 0 && enemy.hp > 0 && enemy.stage === 3) {
           enemy.mudTrailDropCooldown -= 1;

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2235,6 +2235,7 @@
       if (enemy.type !== 'sweetykins') return null;
       if (!enemy.sweetykinsCycle) {
         const initialDirection = enemy.x > state.player.x ? -1 : 1;
+        enemy.x = getSweetykinsOffscreenX(initialDirection);
         enemy.sweetykinsCycle = {
           phase: 'charge',
           runsCompleted: 0,
@@ -2252,6 +2253,13 @@
       return direction >= 0
         ? state.cameraX - margin
         : state.cameraX + canvas.width + margin;
+    }
+
+    function getSweetykinsExitOffscreenX(direction) {
+      const margin = 120;
+      return direction >= 0
+        ? state.cameraX + canvas.width + margin
+        : state.cameraX - margin;
     }
 
     function updateEnemyAnimation(enemy, dt) {
@@ -3645,7 +3653,7 @@
                 cycle.turnTimer = 8;
               } else {
                 cycle.phase = 'approach';
-                enemy.x = getSweetykinsOffscreenX(cycle.chargeDirection);
+                enemy.x = getSweetykinsExitOffscreenX(cycle.chargeDirection);
                 enemy.facing = player.x >= enemy.x ? 1 : -1;
               }
             }
@@ -3657,8 +3665,8 @@
             const approachDistance = Math.hypot(approachDx, approachDy);
             if (Math.abs(approachDx) > ENEMY_FACING_DEADZONE_X) enemy.facing = approachDx >= 0 ? 1 : -1;
             if (approachDistance > enemy.range * 0.95) {
-              enemy.x += Math.sign(approachDx) * moveSpeed * 0.9;
-              enemy.y += Math.sign(approachDy) * moveSpeed * 0.45;
+              enemy.x += Math.sign(approachDx) * moveSpeed * 1.25;
+              enemy.y += Math.sign(approachDy) * moveSpeed * 0.62;
               enemy.isMoving = true;
             } else {
               cycle.phase = 'brawl';


### PR DESCRIPTION
### Motivation
- Implement Sweetykins stage-2 boss behavior so it performs two continuous high-speed runs across the screen (damaging the player on contact), then walks in to attack for 5 seconds, retreats quickly, and repeats the cycle.

### Description
- Modified `bayou-brawlers/index.html` to add a Sweetykins state machine via `ensureSweetykinsCycle` and offscreen helpers with `getSweetykinsOffscreenX`.
- Replaced the previous dash logic in `updateEnemies` for `enemy.type === 'sweetykins'` with a phased AI (`charge -> approach -> brawl -> retreat`) that performs two opposite-direction full-screen charge runs dealing proximity damage without using charge windup animations.
- Added a 5-second `brawl` phase where Sweetykins approaches at normal walking pace and uses existing melee attack flow, then initiates a fast `retreat` offscreen and resets the cycle.
- Prevented movement-mask clamping during offscreen travel phases so Sweetykins can enter/exit the screen cleanly, and added small timers/`runHitCooldown`/`turnTimer` to stabilize run collisions and transitions.

### Testing
- Ran the test suite with `npm test -- --runInBand`, which completed successfully.
- Jest results: `Test Suites: 3 passed, 3 total`, `Tests: 6 passed, 6 total`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf29444e2083298256988c6daaf1a6)