### PR TITLE
Adjust Bayou Brawlers heal-plus cluster size, spacing, and float speed

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2775,14 +2775,14 @@
       for (let i = 0; i < symbolCount; i += 1) {
         state.effects.push({
           type: 'heal-plus',
-          x: entity.x + rand(-18, 18),
-          y: topOpaqueWorldY - rand(8, 24),
-          vx: rand(-0.35, 0.35),
-          vy: rand(-1.5, -0.95),
+          x: entity.x + rand(-28, 28),
+          y: topOpaqueWorldY - rand(10, 34),
+          vx: rand(-0.28, 0.28),
+          vy: rand(-0.95, -0.55),
           drift: rand(-0.05, 0.05),
-          size: rand(14, 20),
-          timer: rand(28, 42),
-          maxTimer: 42
+          size: rand(20, 28),
+          timer: rand(36, 52),
+          maxTimer: 52
         });
       }
     }
@@ -3881,7 +3881,7 @@
         if (effect.type === 'heal-plus') {
           effect.x += (effect.vx || 0);
           effect.y += (effect.vy || 0);
-          effect.vy = (effect.vy || 0) - 0.03;
+          effect.vy = (effect.vy || 0) - 0.012;
           effect.vx = ((effect.vx || 0) * 0.97) + (effect.drift || 0);
         }
         if (effect.type === 'floating-text') {
@@ -4628,7 +4628,7 @@
           ctx.fillRect(effect.x - state.cameraX - 2, effect.y - state.cameraY - 2, 3, 3);
         }
         if (effect.type === 'heal-plus') {
-          const maxTimer = effect.maxTimer || 42;
+          const maxTimer = effect.maxTimer || 52;
           const alpha = clamp(effect.timer / maxTimer, 0, 1);
           const x = effect.x - state.cameraX;
           const y = effect.y - state.cameraY;


### PR DESCRIPTION
### Motivation
- Make healing feedback easier to see by increasing the visual size of the red plus symbols. 
- Reduce visual clutter by spreading the plus symbols farther apart in their spawn cluster. 
- Create a gentler float-up animation by slowing upward acceleration and slightly extending the effect lifetime.

### Description
- Increased spawn horizontal and vertical offsets from `rand(-18, 18)` / `rand(8, 24)` to `rand(-28, 28)` / `rand(10, 34)` to widen spacing. 
- Reduced lateral velocity range from `rand(-0.35, 0.35)` to `rand(-0.28, 0.28)` and reduced upward initial speed from `rand(-1.5, -0.95)` to `rand(-0.95, -0.55)` to lessen rapid clustering and spread items more. 
- Increased symbol `size` range from `rand(14, 20)` to `rand(20, 28)` and increased `timer` range from `rand(28, 42)` to `rand(36, 52)` while setting `maxTimer` to `52` to make symbols larger and last longer. 
- Slowed heal-plus upward acceleration in `updateEffects` by changing the per-frame vy update from `-0.03` to `-0.012` and updated the render fallback `maxTimer` from `42` to `52` so fade-out matches the longer lifetime.

### Testing
- Ran the project test suite with `npm test -- --runInBand`, and all automated tests passed (3 suites, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf5c68653483299af9be05e08e2a2e)