### PR TITLE
Make heal-plus symbols larger, separated, and orbiting in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2784,12 +2784,12 @@
           y: centerY + Math.sin(angle) * (baseRadius * 0.52),
           centerX,
           centerY,
-          vx: rand(-0.16, 0.16),
-          vy: rand(-0.62, -0.42),
-          drift: rand(-0.012, 0.012),
+          vx: rand(-0.13, 0.13),
+          vy: rand(-0.52, -0.34),
+          drift: rand(-0.01, 0.01),
           size,
-          timer: rand(40, 56),
-          maxTimer: 56,
+          timer: rand(48, 66),
+          maxTimer: 66,
           orbitAngle: angle + rand(-0.06, 0.06),
           orbitSpeed: rand(0.06, 0.1) * (i % 2 === 0 ? 1 : -1),
           orbitRadiusX: baseRadius,
@@ -3895,8 +3895,8 @@
         if (effect.type === 'heal-plus') {
           effect.centerX = (effect.centerX ?? effect.x) + (effect.vx || 0);
           effect.centerY = (effect.centerY ?? effect.y) + (effect.vy || 0);
-          effect.vy = ((effect.vy || 0) * 0.985) - 0.006;
-          effect.vx = ((effect.vx || 0) * 0.985) + (effect.drift || 0);
+          effect.vy = ((effect.vy || 0) * 0.988) - 0.004;
+          effect.vx = ((effect.vx || 0) * 0.988) + (effect.drift || 0);
           effect.orbitAngle = (effect.orbitAngle || 0) + (effect.orbitSpeed || 0);
           effect.pulsePhase = (effect.pulsePhase || 0) + (effect.pulseSpeed || 0);
           const pulse = 1 + (Math.sin(effect.pulsePhase || 0) * (effect.pulseAmount || 0) / Math.max(1, effect.orbitRadiusX || 1));

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2773,16 +2773,30 @@
       const topOpaqueWorldY = getEntityWalkTopOpaqueWorldY(entity, PLAYER_DRAW_SIZE);
       const symbolCount = 9;
       for (let i = 0; i < symbolCount; i += 1) {
+        const angle = (Math.PI * 2 * i) / symbolCount;
+        const baseRadius = (i % 2 === 0) ? rand(54, 62) : rand(70, 78);
+        const size = rand(28, 40);
+        const centerX = entity.x + rand(-8, 8);
+        const centerY = topOpaqueWorldY - rand(18, 34);
         state.effects.push({
           type: 'heal-plus',
-          x: entity.x + rand(-18, 18),
-          y: topOpaqueWorldY - rand(8, 24),
-          vx: rand(-0.35, 0.35),
-          vy: rand(-1.5, -0.95),
-          drift: rand(-0.05, 0.05),
-          size: rand(14, 20),
-          timer: rand(28, 42),
-          maxTimer: 42
+          x: centerX + Math.cos(angle) * baseRadius,
+          y: centerY + Math.sin(angle) * (baseRadius * 0.52),
+          centerX,
+          centerY,
+          vx: rand(-0.16, 0.16),
+          vy: rand(-0.62, -0.42),
+          drift: rand(-0.012, 0.012),
+          size,
+          timer: rand(40, 56),
+          maxTimer: 56,
+          orbitAngle: angle + rand(-0.06, 0.06),
+          orbitSpeed: rand(0.06, 0.1) * (i % 2 === 0 ? 1 : -1),
+          orbitRadiusX: baseRadius,
+          orbitRadiusY: baseRadius * rand(0.48, 0.6),
+          pulsePhase: rand(0, Math.PI * 2),
+          pulseSpeed: rand(0.12, 0.18),
+          pulseAmount: rand(4, 10)
         });
       }
     }
@@ -3879,10 +3893,17 @@
           effect.vx *= 0.96;
         }
         if (effect.type === 'heal-plus') {
-          effect.x += (effect.vx || 0);
-          effect.y += (effect.vy || 0);
-          effect.vy = (effect.vy || 0) - 0.03;
-          effect.vx = ((effect.vx || 0) * 0.97) + (effect.drift || 0);
+          effect.centerX = (effect.centerX ?? effect.x) + (effect.vx || 0);
+          effect.centerY = (effect.centerY ?? effect.y) + (effect.vy || 0);
+          effect.vy = ((effect.vy || 0) * 0.985) - 0.006;
+          effect.vx = ((effect.vx || 0) * 0.985) + (effect.drift || 0);
+          effect.orbitAngle = (effect.orbitAngle || 0) + (effect.orbitSpeed || 0);
+          effect.pulsePhase = (effect.pulsePhase || 0) + (effect.pulseSpeed || 0);
+          const pulse = 1 + (Math.sin(effect.pulsePhase || 0) * (effect.pulseAmount || 0) / Math.max(1, effect.orbitRadiusX || 1));
+          const orbitRadiusX = (effect.orbitRadiusX || 0) * pulse;
+          const orbitRadiusY = (effect.orbitRadiusY || 0) * pulse;
+          effect.x = effect.centerX + Math.cos(effect.orbitAngle || 0) * orbitRadiusX;
+          effect.y = effect.centerY + Math.sin(effect.orbitAngle || 0) * orbitRadiusY;
         }
         if (effect.type === 'floating-text') {
           effect.x += (effect.vx || 0);


### PR DESCRIPTION
### Motivation
- Improve the visibility of healing feedback by increasing the size and lifetime of the red plus symbols.
- Prevent overlap so individual heal-plus symbols are visually distinct when many spawn at once.
- Add a lively, readable motion (bounce/orbit/pulse) while slowing their upward float to make heals feel more tangible.

### Description
- Updated `spawnHealPlusCluster` in `bayou-brawlers/index.html` to spawn symbols in a layered radial layout using computed `angle`, `baseRadius`, and `centerX/centerY`, and increased symbol `size` range to `28–40` with longer `timer`/`maxTimer` values.
- Added orbit and pulse properties (`orbitAngle`, `orbitSpeed`, `orbitRadiusX`, `orbitRadiusY`, `pulsePhase`, `pulseSpeed`, `pulseAmount`) and reduced linear velocity ranges (`vx`, `vy`, `drift`) so symbols float up more slowly and are separated in the cluster.
- Updated the `updateEffects` handling for `heal-plus` to advance `centerX/centerY`, decay `vx/vy` more gently, advance `orbitAngle` and `pulsePhase`, compute a pulsing multiplier, and recompute `x,y` from orbit math to produce the bounce-around/orbiting motion.

### Testing
- Ran `npm test -- --runInBand` which executed the full test suite and completed successfully.
- Test results: `3` test suites passed and `6` tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf760ba3d08329a76124e37174275d)