### PR TITLE
Dust Collector: spawn power '+' clusters when charmed enemies hit others

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2476,6 +2476,16 @@
       return gained;
     }
 
+    const DUST_COLLECTOR_POWER_GAIN = 3;
+
+    function triggerDustCollectorPowerGain(sourceEnemy) {
+      const player = state.player;
+      if (!player || player.charData.id !== 'green-fairy' || !hasUpgrade(player, 'dust-collector')) return 0;
+      const gainedPower = addPower(player, DUST_COLLECTOR_POWER_GAIN);
+      if (gainedPower > 0) spawnPowerPlusCluster(sourceEnemy || player, gainedPower);
+      return gainedPower;
+    }
+
     function setSuperReadyGlow(active) {
       document.querySelectorAll('[data-input="special"]').forEach((button) => {
         button.classList.toggle('super-ready', active);
@@ -2777,7 +2787,10 @@
 
     function spawnPlusCluster(entity, amount = 0, type = 'heal-plus') {
       if (!entity || amount <= 0) return;
-      const topOpaqueWorldY = getEntityWalkTopOpaqueWorldY(entity, PLAYER_DRAW_SIZE);
+      const entityDrawSize = entity.charData
+        ? PLAYER_DRAW_SIZE
+        : (entity.isBoss ? BOSS_DRAW_SIZE : ENEMY_DRAW_SIZE);
+      const topOpaqueWorldY = getEntityWalkTopOpaqueWorldY(entity, entityDrawSize);
       const symbolCount = 9;
       for (let i = 0; i < symbolCount; i += 1) {
         const angle = (Math.PI * 2 * i) / symbolCount;
@@ -3495,6 +3508,7 @@
                 const charmDamage = Math.max(2, enemy.damage * (enemy.ranged ? 0.85 : 0.95));
                 const charmStun = enemy.ranged ? 8 : 14;
                 damageEnemy(charmTarget, charmDamage, charmStun);
+                triggerDustCollectorPowerGain(enemy);
                 enemy.cooldown = rand(24, 40);
               }
             } else {


### PR DESCRIPTION
### Motivation
- Add the visual and gameplay feedback for the Dust Collector upgrade so the Green Fairy gains power when charmed enemies damage other enemies and the player sees the power gain as floating blue "+" clusters above the charmed attacker. 
- Ensure the plus-cluster visuals position correctly for non-player entities (enemies and bosses) so the effect appears over the attacker rather than the player.

### Description
- Added `DUST_COLLECTOR_POWER_GAIN` constant and a gated helper `triggerDustCollectorPowerGain(sourceEnemy)` that only grants power when the active player is `green-fairy` and has the `dust-collector` upgrade, and spawns power-plus clusters on success. 
- Hooked `triggerDustCollectorPowerGain(enemy)` into the charmed-enemy attack resolution so it triggers exactly when a charmed enemy deals damage to another enemy. 
- Adjusted `spawnPlusCluster` to compute `entityDrawSize` from the entity type (player vs enemy vs boss) and pass that into `getEntityWalkTopOpaqueWorldY`, fixing vertical placement for clusters spawned above enemies. 
- All changes are contained in `bayou-brawlers/index.html` and only affect charm-related power gain visuals/logic.

### Testing
- Ran unit tests with `npm test -- --runInBand` and all test suites passed (3 passed, 3 total). 
- Verified the patch applied without breaking the existing test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03134e7c88329b7fa152ea03fcab9)