### PR TITLE
Long Glamour: grant Green Fairy invulnerability while enemies are charmed

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4445,6 +4445,11 @@
     function isPlayerInvulnerable(player) {
       if (!player) return false;
       if (state.cheats.invincible) return true;
+      if (
+        player.charData?.id === 'green-fairy'
+        && hasUpgrade(player, 'long-glamour')
+        && state.enemies.some(enemy => enemy.hp > 0 && isCharmed(enemy))
+      ) return true;
       return player.dashTimer > 0;
     }
 


### PR DESCRIPTION
### Motivation
- Make the Long Glamour upgrade provide the invulnerability visual/state to the Green Fairy for the full duration of any active charm so the effect is visible and enforced consistently.

### Description
- Update `isPlayerInvulnerable(player)` in `bayou-brawlers/index.html` to return `true` when `player.charData?.id === 'green-fairy'`, `hasUpgrade(player, 'long-glamour')`, and `state.enemies.some(enemy => enemy.hp > 0 && isCharmed(enemy))`, thereby reusing the existing invulnerability rendering/path.

### Testing
- Applied the patch and verified the change with `git diff -- bayou-brawlers/index.html`, `git status --short`, and committed the update successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17ad5a12c8329a4fd9d7868ef7c94)