### PR TITLE
Green Fairy: 25% basic slow, 50% heavy stun, double AoE radius

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3294,7 +3294,8 @@
 
       if (aoeAttackers.has(characterId)) {
         const weakAoeDamage = dmg * 0.65;
-        const weakAoeRadius = heavy ? 90 : 72;
+        const aoeRadiusMultiplier = characterId === 'green-fairy' ? 2 : 1;
+        const weakAoeRadius = (heavy ? 90 : 72) * aoeRadiusMultiplier;
         let hitCount = 0;
         state.enemies.forEach(enemy => {
           if (enemy.hp <= 0 || !canPlayerAffectEnemy(enemy)) return;
@@ -3380,7 +3381,10 @@
         if (Math.random() < slowChance) applyStatus(enemy, 'SLOW', Math.floor((heavy ? 180 : 150) * bonusDur), slow);
         if (freezeDur > 0 && Math.random() < freezeChance) applyStatus(enemy, 'FREEZE', freezeDur, 1);
       }
-      if (id === 'green-fairy' && heavy && Math.random() < 0.2) applyStatus(enemy, 'CONFUSE', 90, 1);
+      if (id === 'green-fairy') {
+        if (!heavy && Math.random() < 0.25) applyStatus(enemy, 'SLOW', 150, 0.2);
+        if (heavy && Math.random() < 0.5) enemy.stun = Math.max(enemy.stun || 0, 72 + STUN_DURATION_BONUS_FRAMES);
+      }
       if (id === 'grimma-the-feared' && heavy && getEnemyTier(enemy) === 'small') enemy.x += (player.x - enemy.x) * 0.2;
       if (id === 'scarlett-glumpkin') applyStatus(enemy, 'POISON', heavy ? 360 : 240, heavy ? 2 : 1);
       if (id === 'rustbucket' && heavy && hasLevel(player, 4)) enemy.x += player.facing * 14;


### PR DESCRIPTION
### Motivation
- Tune Green Fairy so her basic attack can reliably slow targets and her heavy attack can reliably stun, and increase the felt area of her AoE attacks to match design intent.
- Make these changes local to Green Fairy without affecting other AoE characters.

### Description
- Doubled Green Fairy's AoE radius by applying an `aoeRadiusMultiplier` for `characterId === 'green-fairy'`, so basic AoE goes from `72 -> 144` and heavy AoE from `90 -> 180` inside `bayou-brawlers/index.html` (AoE logic near `doAttack`).
- Added a 25% chance for non-heavy (basic) Green Fairy hits to apply `SLOW` for `150` frames at magnitude `0.2` in `applyCharacterOnHitStatus`.
- Changed Green Fairy heavy-hit behavior to apply a stun with a 50% chance by setting `enemy.stun` to `72 + STUN_DURATION_BONUS_FRAMES` when the heavy proc succeeds, replacing the previous confuse-heavy behavior.
- All edits are contained in `bayou-brawlers/index.html` (AOE multiplier in the AOE handling block and status procs in `applyCharacterOnHitStatus`).

### Testing
- No automated tests were run for this change; modifications were validated by static code inspection and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17ffd83e083299b4a64217c45de96)