### PR TITLE
Grimma: Gate and make Dancer’s Step stackable (+10% per rank, 50% cap)

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1266,7 +1266,7 @@
         { id: 'soul-drain', name: 'Soul Drain', tag: 'Super', description: 'Super heals Grimma based on damage dealt.' },
         { id: 'demon-slayer', name: 'Demon Slayer', tag: 'Utility', description: 'Bonus damage against demons and ghosts.' },
         { id: 'sadists-grace', name: 'Sadist’s Grace', tag: 'Utility', description: 'Chance of a small heal on enemy kill.' },
-        { id: 'dancers-step', name: 'Dancer’s Step', tag: 'Utility', description: 'Small chance to dodge enemy attacks.' },
+        { id: 'dancers-step', name: 'Dancer’s Step', tag: 'Utility', description: 'Gain +10% dodge chance (stacks, up to 50% total dodge chance).', requiresLevel: 5, repeatable: true },
         { id: 'veilwalker', name: 'Veilwalker', tag: 'Utility', description: 'Brief damage reduction after using special.' },
         { id: 'whip-mastery', name: 'Whip Mastery', tag: 'Utility', description: 'Enemies are worth more experience points.' }
       ],
@@ -1932,6 +1932,7 @@
         stunResistanceMultiplier: 1,
         knockbackResistanceMultiplier: 1,
         selectedUpgrades: new Set(),
+        upgradeRanks: {},
         renderScale: charData.renderScale || 1,
         physicsProfileId: charData.physicsProfileId,
         attackFacing: 1,
@@ -2221,6 +2222,11 @@
 
     function hasUpgrade(player, upgradeId) {
       return !!(player && player.selectedUpgrades && player.selectedUpgrades.has(upgradeId));
+    }
+
+    function getUpgradeRank(player, upgradeId) {
+      if (!player || !player.upgradeRanks) return 0;
+      return player.upgradeRanks[upgradeId] || 0;
     }
 
     function getEnvironmentalHazardSlowMultiplier(player) {
@@ -2656,8 +2662,9 @@
     function getEligibleUpgradeChoices(player) {
       const pool = CHARACTER_UPGRADES[player.charData.id] || [];
       return pool.filter((entry) => {
-        if (player.selectedUpgrades.has(entry.id)) return false;
+        if (!entry.repeatable && player.selectedUpgrades.has(entry.id)) return false;
         if (entry.requiresLevel && player.level < entry.requiresLevel) return false;
+        if (entry.id === 'dancers-step' && getPlayerDodgeChance(player) >= 0.5) return false;
         return true;
       });
     }
@@ -2676,6 +2683,7 @@
     function applyChosenUpgrade(player, upgrade) {
       if (!player || !upgrade) return;
       player.selectedUpgrades.add(upgrade.id);
+      player.upgradeRanks[upgrade.id] = getUpgradeRank(player, upgrade.id) + 1;
       showNotification(`${upgrade.name} unlocked`);
     }
 
@@ -2936,9 +2944,9 @@
     function getPlayerDodgeChance(player) {
       if (!player) return 0;
       let chance = 0;
-      if (hasUpgrade(player, 'dancers-step')) chance += 0.12;
+      chance += getUpgradeRank(player, 'dancers-step') * 0.1;
       if (player.charData.id === 'grimma-the-feared' && hasLevel5SignaturePassive(player)) chance += 0.2;
-      return clamp(chance, 0, 0.9);
+      return clamp(chance, 0, 0.5);
     }
 
     function spawnDodgedText(entity) {


### PR DESCRIPTION
### Motivation
- Make Grimma the Feared’s defensive upgrade behavior match design: `Dancer’s Step` should only be offered once Grimma has dodge ability (level 5) and should stack in controlled increments up to a hard cap.
- Prevent the upgrade from being offered endlessly after dodge reaches the intended maximum.

### Description
- Updated the `CHARACTER_UPGRADES` entry for `dancers-step` to clarify the effect, add `requiresLevel: 5`, and mark it `repeatable: true` so it can be picked multiple times with an explicit description of +10% per pick and a 50% cap.
- Added per-player `upgradeRanks` storage and a helper `getUpgradeRank(player, upgradeId)` to track repeatable upgrade counts.
- Changed upgrade eligibility in `getEligibleUpgradeChoices` to allow repeatable upgrades and to explicitly exclude `dancers-step` when `getPlayerDodgeChance(player) >= 0.5` so the choice is no longer offered at the cap.
- Updated `applyChosenUpgrade` to increment `player.upgradeRanks[upgrade.id]` when an upgrade is selected, and rewrote `getPlayerDodgeChance(player)` to compute dodge as `getUpgradeRank(player, 'dancers-step') * 0.1` plus Grimma’s level-5 passive and clamp the result to `0.5`.

### Testing
- Ran `git diff -- bayou-brawlers/index.html` to inspect changes and confirmed the intended edits succeeded (passed).
- Checked repository state with `git status --short` and `git log -1 --oneline` to confirm a clean commit was created (passed).
- Applied and verified patch updates to `bayou-brawlers/index.html` using scripted `apply_patch` operations and line inspections (`nl`) to confirm inserted helpers and logic (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c18b4a6edc8329b51e60772c13c2eb)