### PR TITLE
Add oval beam-impact shockwave visual for Shunky Rooster

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3183,6 +3183,22 @@
       state.effects.push({ x, y, radius, timer: 30, damage, knockback, stun, type: 'shock' });
     }
 
+    function spawnBeamImpactShockwave(x, y, owner = null) {
+      const ownerBody = owner ? getPlayerHitbox(owner) : null;
+      const baseWidth = ownerBody ? ownerBody.width : (PLAYER_DRAW_SIZE * 0.7);
+      state.effects.push({
+        type: 'beam-impact-shockwave',
+        x,
+        y,
+        radiusX: baseWidth * 0.48,
+        radiusY: baseWidth * 0.3,
+        maxRadiusX: baseWidth * 1.12,
+        maxRadiusY: baseWidth * 0.74,
+        timer: 28,
+        maxTimer: 28
+      });
+    }
+
     function spawnShatterShockBurst(x, y) {
       const shardCount = 28;
       const icePalette = ['#ecf9ff', '#dff3ff', '#d1edff', '#c3e4ff', '#b4dbff', '#a4d0ff', '#9bc8ff'];
@@ -4383,6 +4399,7 @@
             if (!rectsOverlap(beamRect, enemyBody)) return;
             damageEnemy(enemy, effect.damage, effect.stun || 0);
             enemy.x += effect.facing * 6;
+            spawnBeamImpactShockwave(enemyBody.x + enemyBody.width * 0.5, enemyBody.y + enemyBody.height * 0.45, effect.owner || null);
             if (effect.owner) applyCharacterOnHitStatus(effect.owner, enemy, false);
             hitCount += 1;
           });
@@ -5167,6 +5184,28 @@
           ctx.beginPath();
           ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY - 10, effect.radius * (effect.timer / 30), 0, Math.PI * 2);
           ctx.stroke();
+        }
+        if (effect.type === 'beam-impact-shockwave') {
+          const maxTimer = Math.max(1, effect.maxTimer || 28);
+          const lifePct = clamp(effect.timer / maxTimer, 0, 1);
+          const expandPct = 1 - lifePct;
+          const radiusX = (effect.radiusX || 16) + ((effect.maxRadiusX || 52) - (effect.radiusX || 16)) * expandPct;
+          const radiusY = (effect.radiusY || 10) + ((effect.maxRadiusY || 30) - (effect.radiusY || 10)) * expandPct;
+          const screenX = effect.x - state.cameraX;
+          const screenY = effect.y - state.cameraY;
+          ctx.save();
+          ctx.globalCompositeOperation = 'lighter';
+          ctx.strokeStyle = `rgba(255, 240, 168, ${0.1 + lifePct * 0.65})`;
+          ctx.lineWidth = 1.2 + lifePct * 1.8;
+          ctx.beginPath();
+          ctx.ellipse(screenX, screenY, radiusX, radiusY, 0, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.strokeStyle = `rgba(255, 253, 214, ${0.05 + lifePct * 0.45})`;
+          ctx.lineWidth = Math.max(0.8, 0.8 + lifePct);
+          ctx.beginPath();
+          ctx.ellipse(screenX, screenY, radiusX * 0.72, radiusY * 0.72, 0, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.restore();
         }
         if (effect.type === 'root' || effect.type === 'root-poison' || effect.type === 'frost-patch' || effect.type === 'beam') {
           ctx.strokeStyle = effect.type === 'frost-patch' ? 'rgba(120,190,255,0.8)' : (effect.type === 'beam' ? 'rgba(255,245,170,0.8)' : 'rgba(122, 255, 156, 0.7)');


### PR DESCRIPTION
### Motivation
- Add a visual effect for the Shunky Rooster beam so a large oval shockwave is shown on beam impact that spreads out slowly before disappearing. 
- Make the impact ring roughly the width of the player and visually distinct from existing circular `shock` effects. 

### Description
- Introduced a new helper `spawnBeamImpactShockwave(x, y, owner = null)` which pushes a `beam-impact-shockwave` effect into `state.effects` and sizes the initial and max oval radii from the owner's hitbox (falling back to `PLAYER_DRAW_SIZE`).
- Hooked the Shunky Rooster beam hit logic to call `spawnBeamImpactShockwave(...)` whenever an enemy is damaged by the `shunky-laser` beam so the effect appears at the contact point.
- Implemented rendering for `beam-impact-shockwave` in the main effects draw loop using `ctx.ellipse`, layered strokes, `globalCompositeOperation = 'lighter'`, alpha fade and slow expansion driven by `timer`/`maxTimer`.
- The change is visual-only and does not change beam damage, stun, or other gameplay mechanics.

### Testing
- Ran the project test suite with `npm test -- --runInBand` and all automated tests passed (`3` test suites, `6` tests total).
- No automated visual snapshot tests were added; rendering was exercised in code paths covered by existing logic but visual verification should be done in-browser during playtesting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c288443ccc8329bccc6f02229c43be)