### PR TITLE
Add Overheated Core flame/smoke beam overlay in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2861,6 +2861,7 @@
       if (enemy.hp <= 0) {
         const player = state.player;
         const isFrozenOnDefeat = (enemy.statuses?.FREEZE?.duration || 0) > 0;
+        const hadBurnOnDefeat = (enemy.statuses?.BURN?.duration || 0) > 0;
         const shouldTriggerShatterShock = !!(player && hasUpgrade(player, 'shatter-shock') && isFrozenOnDefeat);
         const shouldTriggerSparkleBloom = !!(
           player &&
@@ -2873,6 +2874,7 @@
         enemy.windup = 0;
         enemy.attackAnimTimer = 0;
         enemy.deathHoldFrames = shouldTriggerShatterShock ? 0 : ENEMY_DEATH_HOLD_FRAMES;
+        enemy.burnCorpseFrames = hadBurnOnDefeat ? enemy.deathHoldFrames : 0;
         if (shouldTriggerShatterShock) spawnShatterShockBurst(enemy.x, enemy.y);
         if (shouldTriggerSparkleBloom) triggerSparkleBloom(enemy);
         handleEnemyDeath(enemy);
@@ -3727,6 +3729,7 @@
         if (enemy.hp <= 0) {
           enemy.isMoving = false;
           if (enemy.deathHoldFrames > 0) enemy.deathHoldFrames -= 1;
+          enemy.burnCorpseFrames = Math.max(0, (enemy.burnCorpseFrames || 0) - 1);
           updateEnemyAnimation(enemy, dt);
           return;
         }
@@ -5061,6 +5064,72 @@
       ctx.restore();
     }
 
+    function drawBurningAura(entity, size, corpseBurnRatio = 0) {
+      if (!entity) return;
+      const burnDuration = entity.statuses?.BURN?.duration || 0;
+      const isBurning = burnDuration > 0;
+      const hasCorpseBurn = !isBurning && corpseBurnRatio > 0;
+      if (!isBurning && !hasCorpseBurn) return;
+
+      const depthScale = getDepthScaleForY(entity.y);
+      const drawSize = size * (entity.renderScale || 1) * depthScale;
+      const centerX = entity.x - state.cameraX;
+      const baseY = entity.y - state.cameraY - entity.z - (drawSize * (hasCorpseBurn ? 0.38 : 0.66));
+      const burnIntensity = clamp(
+        isBurning
+          ? (0.58 + (Math.min(220, burnDuration) / 220) * 0.42)
+          : (0.35 + (corpseBurnRatio * 0.65)),
+        0,
+        1
+      );
+      const flameCount = Math.max(2, Math.floor((drawSize / 28) * (0.85 + burnIntensity * 0.45)));
+      const smokeCount = Math.max(2, Math.floor((drawSize / 36) * (0.9 + burnIntensity * 0.4)));
+      const animTime = (performance.now() * 0.015) + ((entity.uid || 0) * 1.17);
+
+      ctx.save();
+      ctx.globalCompositeOperation = 'lighter';
+      ctx.globalAlpha = 0.72 + (burnIntensity * 0.2);
+      for (let i = 0; i < flameCount; i += 1) {
+        const t = flameCount === 1 ? 0.5 : (i / (flameCount - 1));
+        const offsetX = ((t - 0.5) * drawSize * 0.62) + (Math.sin(animTime + (i * 0.82)) * 2.5);
+        const flameX = centerX + offsetX;
+        const flameHeight = (12 + (Math.sin((animTime * 1.7) + (i * 1.05)) + 1) * 5.2) * (0.8 + burnIntensity * 0.5);
+        const flameWidth = (4.2 + (Math.cos((animTime * 1.3) + i) + 1) * 1.7) * (0.88 + burnIntensity * 0.24);
+        const flameY = baseY + (Math.sin(animTime * 1.1 + i) * 1.8);
+        const grad = ctx.createLinearGradient(flameX, flameY, flameX, flameY - flameHeight);
+        grad.addColorStop(0, 'rgba(255, 104, 34, 0.85)');
+        grad.addColorStop(0.45, 'rgba(255, 172, 62, 0.82)');
+        grad.addColorStop(1, 'rgba(255, 238, 162, 0.22)');
+        ctx.fillStyle = grad;
+        ctx.beginPath();
+        ctx.moveTo(flameX - flameWidth, flameY);
+        ctx.quadraticCurveTo(flameX - (flameWidth * 0.2), flameY - (flameHeight * 0.74), flameX, flameY - flameHeight);
+        ctx.quadraticCurveTo(flameX + (flameWidth * 0.18), flameY - (flameHeight * 0.72), flameX + flameWidth, flameY);
+        ctx.closePath();
+        ctx.fill();
+      }
+      ctx.restore();
+
+      ctx.save();
+      ctx.globalAlpha = 0.5 + (burnIntensity * 0.25);
+      for (let i = 0; i < smokeCount; i += 1) {
+        const t = smokeCount === 1 ? 0.5 : (i / (smokeCount - 1));
+        const drift = ((performance.now() * 0.02) + (entity.uid || 0) + (i * 2.4));
+        const puffX = centerX + ((t - 0.5) * drawSize * 0.5) + (Math.sin(drift) * 6);
+        const puffY = baseY - 8 - (t * drawSize * 0.44) - (((performance.now() * 0.09) + (i * 11)) % Math.max(16, drawSize * 0.35));
+        const radius = (4.5 + (1 - t) * 5.8) * (0.92 + burnIntensity * 0.4);
+        const smoke = ctx.createRadialGradient(puffX, puffY, 0, puffX, puffY, radius);
+        smoke.addColorStop(0, 'rgba(148, 152, 160, 0.3)');
+        smoke.addColorStop(0.6, 'rgba(102, 106, 114, 0.18)');
+        smoke.addColorStop(1, 'rgba(78, 82, 88, 0)');
+        ctx.fillStyle = smoke;
+        ctx.beginPath();
+        ctx.arc(puffX, puffY, radius, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.restore();
+    }
+
     function draw() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       if (state.shake > 0) {
@@ -5102,6 +5171,8 @@
       renderQueue.sort((a, b) => a.sortY - b.sortY);
       renderQueue.forEach(({ entity, size }) => {
         drawEntity(entity, size);
+        const corpseBurnRatio = (entity.burnCorpseFrames || 0) / Math.max(1, ENEMY_DEATH_HOLD_FRAMES);
+        drawBurningAura(entity, size, corpseBurnRatio);
         if ((entity.statuses?.CHARM?.duration || 0) > 0) {
           drawCharmHeart(entity, size);
         }

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -5330,6 +5330,8 @@
           const y = effect.y - state.cameraY;
           const direction = effect.facing || 1;
           const endX = x + (effect.length * direction);
+          const hasOverheatedCore = effect.owner && hasUpgrade(effect.owner, 'overheated-core');
+          const beamProgress = 1 - clamp(effect.timer / maxTimer, 0, 1);
           ctx.save();
           ctx.globalAlpha = alpha;
           const outer = ctx.createLinearGradient(x, y, endX, y);
@@ -5350,6 +5352,50 @@
           ctx.moveTo(x, y);
           ctx.lineTo(endX, y);
           ctx.stroke();
+
+          if (hasOverheatedCore) {
+            const pulseTime = (Date.now() * 0.014) + (beamProgress * 9);
+            const beamLen = Math.max(18, Math.abs(effect.length));
+            const flameCount = Math.max(3, Math.floor(beamLen / 34));
+            const smokeCount = Math.max(2, Math.floor(beamLen / 52));
+
+            for (let i = 0; i < flameCount; i += 1) {
+              const t = flameCount === 1 ? 0.5 : (i / (flameCount - 1));
+              const flameX = x + (effect.length * direction * t);
+              const flicker = Math.sin((pulseTime * 1.9) + (i * 0.95));
+              const flameHeight = (6 + (Math.abs(flicker) * 6)) * (0.92 + (alpha * 0.4));
+              const flameWidth = (3.5 + (Math.abs(Math.cos(pulseTime + i)) * 3.5)) * (0.92 + (alpha * 0.25));
+              const lift = Math.sin((pulseTime * 1.35) + (i * 1.2)) * 2.2;
+              const baseY = y - (effect.width * 0.22) - 3 + lift;
+
+              const flameGrad = ctx.createLinearGradient(flameX, baseY, flameX, baseY - flameHeight);
+              flameGrad.addColorStop(0, 'rgba(255, 120, 36, 0.88)');
+              flameGrad.addColorStop(0.45, 'rgba(255, 180, 72, 0.84)');
+              flameGrad.addColorStop(1, 'rgba(255, 234, 176, 0.24)');
+              ctx.fillStyle = flameGrad;
+              ctx.beginPath();
+              ctx.moveTo(flameX - flameWidth, baseY);
+              ctx.quadraticCurveTo(flameX - (flameWidth * 0.18), baseY - (flameHeight * 0.72), flameX, baseY - flameHeight);
+              ctx.quadraticCurveTo(flameX + (flameWidth * 0.2), baseY - (flameHeight * 0.68), flameX + flameWidth, baseY);
+              ctx.closePath();
+              ctx.fill();
+            }
+
+            for (let i = 0; i < smokeCount; i += 1) {
+              const t = smokeCount === 1 ? 0.5 : (i / (smokeCount - 1));
+              const smokeX = x + (effect.length * direction * t) - (direction * ((beamProgress * 28) + (i * 8)));
+              const smokeY = y - (effect.width * 0.65) - 8 - (beamProgress * 26) - (Math.sin((pulseTime * 0.68) + (i * 0.85)) * 3);
+              const smokeRadius = 6 + ((1 - t) * 6) + (beamProgress * 4);
+              const smokeGrad = ctx.createRadialGradient(smokeX, smokeY, 0, smokeX, smokeY, smokeRadius);
+              smokeGrad.addColorStop(0, `rgba(145, 148, 154, ${0.28 * alpha})`);
+              smokeGrad.addColorStop(0.65, `rgba(96, 100, 106, ${0.18 * alpha})`);
+              smokeGrad.addColorStop(1, 'rgba(70, 74, 80, 0)');
+              ctx.fillStyle = smokeGrad;
+              ctx.beginPath();
+              ctx.arc(smokeX, smokeY, smokeRadius, 0, Math.PI * 2);
+              ctx.fill();
+            }
+          }
           ctx.restore();
         }
         if (effect.type === 'shunky-beam-shockwave') {


### PR DESCRIPTION
### Motivation
- Add a visual-only overheated effect to Shunky Rooster's special so the `overheated-core` upgrade shows animated flames and a smoke trail layered on top of the existing beam visuals.

### Description
- Added a conditional visual branch in the `shunky-laser` render path that checks `hasUpgrade(effect.owner, 'overheated-core')` and computes `beamProgress` and `pulseTime` to drive animation. (`bayou-brawlers/index.html`)
- Rendered multiple pulsing flame tongues along the beam using bezier/quadratic shapes and warm linear gradients so the original beam drawing is preserved beneath. (`shunky-laser` draw block)
- Rendered drifting smoke puffs along the beam direction using radial gradients with alpha scaled by the beam's life to produce a trailing smoke effect.
- Kept all existing beam stroke drawing and damage/status logic untouched so gameplay behavior is unchanged.

### Testing
- Ran `git diff --check` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b8605d2c8329b40f02f8e7e8b6b3)