### PR TITLE
Fix Shunky Rooster scorched-ground fire hit detection

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4450,10 +4450,10 @@
             state.enemies.forEach(enemy => {
               if (enemy.hp <= 0 || !canPlayerAffectEnemy(enemy)) return;
               const enemyBody = getEnemyHitbox(enemy);
-              const enemyGroundRadius = Math.max(8, Math.min(enemyBody.width, enemyBody.height) * 0.35);
-              const burnRange = effect.radius + enemyGroundRadius;
-              const distanceToEnemyGround = Math.hypot(enemy.x - effect.x, enemy.y - effect.y);
-              if (distanceToEnemyGround > burnRange) return;
+              const nearestX = clamp(effect.x, enemyBody.x, enemyBody.x + enemyBody.width);
+              const nearestY = clamp(effect.y, enemyBody.y, enemyBody.y + enemyBody.height);
+              const distanceToEnemyBody = Math.hypot(effect.x - nearestX, effect.y - nearestY);
+              if (distanceToEnemyBody > effect.radius) return;
               damageEnemy(enemy, effect.damage || 4, 0);
               applyStatus(enemy, 'BURN', 45, 1, { effectSource: 'scorched-ground' });
             });


### PR DESCRIPTION
### Motivation
- Shunky Rooster’s scorched-ground flames were not damaging enemies because the code used a distance check from the flame to the enemy origin instead of testing overlap with the enemy hitbox, so enemies standing in the fire patch were missed.

### Description
- Update `scorched-ground-fire` logic to perform a closest-point circle-vs-rectangle collision using `getEnemyHitbox(enemy)` and `clamp()` to find the nearest point on the enemy body and compare that distance to `effect.radius`, while leaving the existing `damageEnemy` and `applyStatus(..., 'BURN', ...)` behavior intact; change made in `bayou-brawlers/index.html`.

### Testing
- Ran `npm test -- --runInBand` and all automated tests passed (`Test Suites: 3 passed, 3 total`; `Tests: 6 passed, 6 total`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c352e7f4f48329874cdfd6c1e53104)