### PR TITLE
Make Shunky Rooster scorched-ground flames damage enemies on hitbox contact

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2221,6 +2221,14 @@
         && a.y + a.height > b.y;
     }
 
+    function circleIntersectsRect(circleX, circleY, circleRadius, rect) {
+      const clampedX = clamp(circleX, rect.x, rect.x + rect.width);
+      const clampedY = clamp(circleY, rect.y, rect.y + rect.height);
+      const dx = circleX - clampedX;
+      const dy = circleY - clampedY;
+      return (dx * dx) + (dy * dy) <= circleRadius * circleRadius;
+    }
+
     function hasUpgrade(player, upgradeId) {
       return !!(player && player.selectedUpgrades && player.selectedUpgrades.has(upgradeId));
     }
@@ -2273,6 +2281,7 @@
 
     function spawnScorchedGroundFires(player) {
       const fireCount = 14;
+      const shunkyBaseBasicAttackDamage = getCharacterTuning({ charData: { id: 'shunky-rooster' }, range: 52 }).light;
       for (let i = 0; i < fireCount; i += 1) {
         const angle = Math.random() * Math.PI * 2;
         const distance = rand(90, 340);
@@ -2290,8 +2299,8 @@
           radius,
           timer: lifetime,
           maxTimer: lifetime,
-          damage: 5,
-          tickRate: 10,
+          damage: shunkyBaseBasicAttackDamage,
+          touchingEnemies: new Set(),
           phase: Math.random() * Math.PI * 2
         });
       }
@@ -4446,18 +4455,23 @@
         }
         if (effect.type === 'scorched-ground-fire') {
           effect.phase = (effect.phase || 0) + 0.2;
-          if (effect.timer % (effect.tickRate || 15) === 0) {
-            state.enemies.forEach(enemy => {
-              if (enemy.hp <= 0 || !canPlayerAffectEnemy(enemy)) return;
-              const enemyBody = getEnemyHitbox(enemy);
-              const enemyGroundRadius = Math.max(8, Math.min(enemyBody.width, enemyBody.height) * 0.35);
-              const burnRange = effect.radius + enemyGroundRadius;
-              const distanceToEnemyGround = Math.hypot(enemy.x - effect.x, enemy.y - effect.y);
-              if (distanceToEnemyGround > burnRange) return;
-              damageEnemy(enemy, effect.damage || 4, 0);
-              applyStatus(enemy, 'BURN', 45, 1, { effectSource: 'scorched-ground' });
-            });
-          }
+          if (!effect.touchingEnemies) effect.touchingEnemies = new Set();
+          state.enemies.forEach(enemy => {
+            if (enemy.hp <= 0 || !canPlayerAffectEnemy(enemy)) {
+              effect.touchingEnemies.delete(enemy);
+              return;
+            }
+            const enemyBody = getEnemyHitbox(enemy);
+            const enemyOverlapsFlame = circleIntersectsRect(effect.x, effect.y, effect.radius, enemyBody);
+            if (!enemyOverlapsFlame) {
+              effect.touchingEnemies.delete(enemy);
+              return;
+            }
+            if (effect.touchingEnemies.has(enemy)) return;
+            effect.touchingEnemies.add(enemy);
+            damageEnemy(enemy, effect.damage || 13, 0);
+            applyStatus(enemy, 'BURN', 45, 1, { effectSource: 'scorched-ground' });
+          });
         }
       });
       state.effects = state.effects.filter(effect => effect.timer > 0);


### PR DESCRIPTION
### Motivation
- Flames spawned by Shunky Rooster's Scorched Ground super were visually present but did not reliably damage enemies because overlap checks used center-distance logic and repeated-frame hits were not handled.
- Align flame contact damage with Shunky Rooster's baseline basic attack so contact damage matches the requested starting-hit value.

### Description
- Added `circleIntersectsRect(circleX, circleY, circleRadius, rect)` helper to test circle (flame) vs enemy hitbox intersection and used it for flame contact detection. 
- Changed `spawnScorchedGroundFires` so each `scorched-ground-fire` effect stores `damage` derived from Shunky Rooster's starting basic attack (`getCharacterTuning(...).light`) and initializes a `touchingEnemies` set. 
- Updated the `scorched-ground-fire` update logic to apply damage and `BURN` only when an enemy's hitbox first enters the flame area (using `touchingEnemies` to avoid repeat damage while continuously overlapping). 
- Removed the old periodic center-distance tick behavior and replaced it with hitbox-based entry detection so flames reliably deal damage on contact.

### Testing
- Ran unit tests with `npm test -- --runInBand`, all test suites passed (3/3).
- No browser/playtest was performed in this environment; change is limited to game logic and automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c360c3474083299d0f26fcf320c031)