### PR TITLE
Adjust Shunky Rooster laser origin to chest height

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3423,12 +3423,13 @@
 
       if (characterId === 'shunky-rooster') {
         const beamDuration = 60;
+        const beamOriginYOffset = 62;
         player.attackCooldown = Math.max(player.attackCooldown, 180);
         player.powerCooldown = Math.max(player.powerCooldown, 180);
         state.effects.push({
           type: 'shunky-laser',
           x: player.x + player.facing * 12,
-          y: player.y - 44,
+          y: player.y - beamOriginYOffset,
           facing: player.facing,
           heavy,
           width: heavy ? 64 : 48,


### PR DESCRIPTION
### Motivation
- Make Shunky Rooster’s laser visually originate from the circle on his chest (mid‑sprite) instead of the lower body so beams line up with the artwork.

### Description
- Replace the hardcoded vertical offset with a `beamOriginYOffset` constant and use it for the `shunky-laser` effect `y` position (`y: player.y - beamOriginYOffset`, value set to `62`).

### Testing
- Verified the change was applied and the diff shows the new `beamOriginYOffset` insertion via `git -C /workspace/ai-game-of-the-day diff -- bayou-brawlers/index.html` and inspected the file with `nl -ba /workspace/ai-game-of-the-day/bayou-brawlers/index.html | sed -n '3418,3442p'`, both succeeded; `git commit` also succeeded; no automated visual/browser tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c37c58d7a88329869a4e0ad2692b09)