### PR TITLE
Fix Shunky Rooster beam origin to chest position

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3214,6 +3214,16 @@
       state.projectiles.push(projectile);
     }
 
+    function getShunkyLaserOrigin(player) {
+      const depthScale = getDepthScaleForY(player.y);
+      const drawSize = PLAYER_DRAW_SIZE * (player.renderScale || 1) * depthScale;
+      const topOpaqueWorldY = getEntityWalkTopOpaqueWorldY(player, PLAYER_DRAW_SIZE);
+      return {
+        x: player.x + (player.facing * drawSize * 0.12),
+        y: topOpaqueWorldY + (drawSize * 0.3)
+      };
+    }
+
     function spawnShockwave(x, y, radius, damage, knockback, stun) {
       state.effects.push({ x, y, radius, timer: 30, damage, knockback, stun, type: 'shock' });
     }
@@ -3423,12 +3433,13 @@
 
       if (characterId === 'shunky-rooster') {
         const beamDuration = 60;
+        const beamOrigin = getShunkyLaserOrigin(player);
         player.attackCooldown = Math.max(player.attackCooldown, 180);
         player.powerCooldown = Math.max(player.powerCooldown, 180);
         state.effects.push({
           type: 'shunky-laser',
-          x: player.x + player.facing * 12,
-          y: player.y - 44,
+          x: beamOrigin.x,
+          y: beamOrigin.y,
           facing: player.facing,
           heavy,
           width: heavy ? 64 : 48,

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3220,7 +3220,7 @@
       const topOpaqueWorldY = getEntityWalkTopOpaqueWorldY(player, PLAYER_DRAW_SIZE);
       return {
         x: player.x + (player.facing * drawSize * 0.12),
-        y: topOpaqueWorldY + (drawSize * 0.3)
+        y: topOpaqueWorldY + (drawSize * 0.4)
       };
     }
 


### PR DESCRIPTION
### Motivation
- Shunky Rooster's laser effect was spawning from a low fixed offset on the sprite, but the beam should originate from the chest circle near the top of the character artwork so the visuals match the intent.

### Description
- Added `getShunkyLaserOrigin(player)` to compute a chest-level origin using depth-scaled `PLAYER_DRAW_SIZE` and `getEntityWalkTopOpaqueWorldY`, and updated the `shunky-laser` effect spawn to use `beamOrigin.x` / `beamOrigin.y` instead of the previous fixed offsets in `bayou-brawlers/index.html`.

### Testing
- Ran `git diff --check` which produced no issues and committed the change to `bayou-brawlers/index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c37dcd0e54832980af71535d9addd9)