### PR TITLE
Increase Shunky Rooster laser beam hitbox slightly

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4433,7 +4433,7 @@
           const left = Math.min(effect.x, endX);
           const right = Math.max(effect.x, endX);
           const hitboxCenterY = effect.y + 24;
-          const halfWidth = Math.max(effect.width * 1.25, 72);
+          const halfWidth = Math.max(effect.width * 1.3, 72);
           const beamRect = {
             x: left,
             y: hitboxCenterY - halfWidth,


### PR DESCRIPTION
### Motivation
- Make the Shunky Rooster laser beam collision slightly more forgiving so beam contacts register a bit easier and improve player feel.

### Description
- Change the hitbox half-width multiplier from `1.25` to `1.3` in `bayou-brawlers/index.html` for the `shunky-laser` collision rectangle while keeping the minimum half-width at `72`.

### Testing
- No automated tests were run for this small constant tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3cf1e809c8329a3a2d0855eaac98c)