### PR TITLE
Emergency Venting: Steam VFX and knockback hotboxes for Shunky Rooster

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2971,6 +2971,7 @@
         player.stun = Math.max(player.stun, (sourceEnemy.isBoss ? 42 : 24) + STUN_DURATION_BONUS_FRAMES);
       }
       player.hp = clamp(player.hp - finalAmount, 0, player.maxHp);
+      maybeTriggerEmergencyVenting(player);
       const sourceAngle = sourceEnemy ? Math.atan2(player.y - sourceEnemy.y, player.x - sourceEnemy.x) : null;
       spawnImpactBurst(player.x, player.y - 36, {
         strength: clamp(0.7 + (finalAmount / 9), 0.75, 2.45),
@@ -2982,6 +2983,51 @@
       if (player.hp <= 0) {
         endGame(false);
       }
+    }
+
+    function maybeTriggerEmergencyVenting(player) {
+      if (!player || player.charData.id !== 'shunky-rooster' || !hasUpgrade(player, 'emergency-venting')) return;
+      if (player.hp <= 0) return;
+      const healthThreshold = player.maxHp * 0.5;
+      if (player.hp > healthThreshold) return;
+      player.emergencyVentingCooldown = Math.max(0, (player.emergencyVentingCooldown || 0) - 1);
+      if (player.emergencyVentingCooldown > 0) return;
+
+      const sideOffsets = [-52, -36, -20, 20, 36, 52];
+      const ventHotboxes = sideOffsets.map(offsetX => ({
+        x: player.x + offsetX - 18,
+        y: player.y - 88 + rand(-8, 12),
+        width: 36,
+        height: 92
+      }));
+
+      const steamParticles = [];
+      sideOffsets.forEach(offsetX => {
+        const side = Math.sign(offsetX) || 1;
+        const burstCount = 4;
+        for (let i = 0; i < burstCount; i += 1) {
+          steamParticles.push({
+            x: player.x + offsetX + rand(-5, 5),
+            y: player.y - 72 + rand(-15, 14),
+            vx: side * rand(0.8, 2.3) + rand(-0.5, 0.5),
+            vy: rand(-1.15, -0.25),
+            growth: rand(0.45, 0.9),
+            radius: rand(10, 20),
+            alpha: rand(0.18, 0.38)
+          });
+        }
+      });
+
+      state.effects.push({
+        type: 'emergency-venting',
+        owner: player,
+        timer: 12,
+        maxTimer: 12,
+        hotboxes: ventHotboxes,
+        steamParticles,
+        pushForce: 72
+      });
+      player.emergencyVentingCooldown = 170;
     }
 
     function getPlayerDodgeChance(player) {
@@ -3778,6 +3824,7 @@
       player.specialCooldown = Math.max(0, player.specialCooldown - 1);
       player.jumpCooldown = Math.max(0, player.jumpCooldown - 1);
       player.shieldTimer = Math.max(0, player.shieldTimer - 1);
+      player.emergencyVentingCooldown = Math.max(0, (player.emergencyVentingCooldown || 0) - 1);
       player.actionLock = Math.max(0, player.actionLock - 1);
       player.passiveCooldown = Math.max(0, player.passiveCooldown - 1);
       if (player.comboTimer > 0) player.comboTimer -= 1;
@@ -4435,6 +4482,47 @@
           effect.vy = (effect.vy || 0) * 0.92 + (effect.driftY || 0);
           effect.size += effect.growth || 0;
           effect.alpha = Math.max(0, (effect.alpha || 0) * 0.98);
+        }
+        if (effect.type === 'emergency-venting') {
+          const owner = effect.owner;
+          if (!owner || owner.hp <= 0) {
+            effect.timer = 0;
+          } else {
+            const sideOffsets = [-52, -36, -20, 20, 36, 52];
+            const baseY = owner.y - 88;
+            effect.hotboxes = sideOffsets.map((offsetX, idx) => {
+              const priorHotbox = effect.hotboxes?.[idx];
+              return {
+                x: owner.x + offsetX - 18,
+                y: (priorHotbox?.y ?? baseY) + rand(-0.8, 0.8),
+                width: 36,
+                height: 92
+              };
+            });
+            (effect.steamParticles || []).forEach(particle => {
+              particle.x += particle.vx;
+              particle.y += particle.vy;
+              particle.vx *= 0.9;
+              particle.vy *= 0.92;
+              particle.radius += particle.growth;
+              particle.alpha *= 0.92;
+            });
+            if (effect.timer % 2 === 0) {
+              state.enemies.forEach(enemy => {
+                if (enemy.hp <= 0 || !canPlayerAffectEnemy(enemy)) return;
+                const enemyBody = getEnemyHitbox(enemy);
+                const overlappingHotbox = effect.hotboxes.find(hotbox => rectsOverlap(hotbox, enemyBody));
+                if (!overlappingHotbox) return;
+                const hotboxCenterX = overlappingHotbox.x + (overlappingHotbox.width * 0.5);
+                const pushDir = Math.sign(enemy.x - hotboxCenterX) || (enemy.x >= owner.x ? 1 : -1);
+                const centerY = enemyBody.y + (enemyBody.height * 0.5);
+                const verticalDir = Math.sign(centerY - (owner.y - 44));
+                enemy.x += pushDir * (effect.pushForce || 72);
+                enemy.y += verticalDir * 6;
+                enemy.stun = Math.max(enemy.stun, 20 + STUN_DURATION_BONUS_FRAMES);
+              });
+            }
+          }
         }
         if (effect.type === 'heal-plus' || effect.type === 'power-plus') {
           effect.centerX = (effect.centerX ?? effect.x) + (effect.vx || 0);
@@ -5546,6 +5634,27 @@
           ctx.beginPath();
           ctx.arc(drawX, drawY, radius, 0, Math.PI * 2);
           ctx.fill();
+        }
+        if (effect.type === 'emergency-venting') {
+          const lifePct = clamp(effect.timer / Math.max(1, effect.maxTimer || 12), 0, 1);
+          ctx.save();
+          ctx.globalCompositeOperation = 'lighter';
+          (effect.steamParticles || []).forEach(particle => {
+            if ((particle.alpha || 0) <= 0.01) return;
+            const x = particle.x - state.cameraX;
+            const y = particle.y - state.cameraY;
+            const particleAlpha = clamp((particle.alpha || 0) * lifePct, 0, 0.42);
+            const radius = particle.radius || 8;
+            const steamGradient = ctx.createRadialGradient(x, y, radius * 0.22, x, y, radius);
+            steamGradient.addColorStop(0, `rgba(255, 255, 255, ${particleAlpha})`);
+            steamGradient.addColorStop(0.7, `rgba(255, 255, 255, ${particleAlpha * 0.45})`);
+            steamGradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
+            ctx.fillStyle = steamGradient;
+            ctx.beginPath();
+            ctx.arc(x, y, radius, 0, Math.PI * 2);
+            ctx.fill();
+          });
+          ctx.restore();
         }
         if (effect.type === 'flash-cone') {
           const maxTimer = effect.maxTimer || 12;

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2952,7 +2952,10 @@
     function damagePlayer(amount, sourceEnemy = null) {
       const player = state.player;
       if (!player || player.hp <= 0) return;
-      if (isPlayerInvulnerable(player)) return;
+      if (isPlayerInvulnerable(player)) {
+        maybeTriggerEmergencyVenting(player);
+        return;
+      }
       const dodgeChance = getPlayerDodgeChance(player);
       const dodged = player.dashTimer > 0 || (dodgeChance > 0 && Math.random() < dodgeChance);
       if (dodged) {
@@ -2993,12 +2996,12 @@
       player.emergencyVentingCooldown = Math.max(0, (player.emergencyVentingCooldown || 0) - 1);
       if (player.emergencyVentingCooldown > 0) return;
 
-      const sideOffsets = [-52, -36, -20, 20, 36, 52];
+      const sideOffsets = [-70, -52, -34, 34, 52, 70];
       const ventHotboxes = sideOffsets.map(offsetX => ({
-        x: player.x + offsetX - 18,
-        y: player.y - 88 + rand(-8, 12),
-        width: 36,
-        height: 92
+        x: player.x + offsetX - 24,
+        y: player.y - 104 + rand(-10, 14),
+        width: 48,
+        height: 116
       }));
 
       const steamParticles = [];
@@ -3008,12 +3011,12 @@
         for (let i = 0; i < burstCount; i += 1) {
           steamParticles.push({
             x: player.x + offsetX + rand(-5, 5),
-            y: player.y - 72 + rand(-15, 14),
-            vx: side * rand(0.8, 2.3) + rand(-0.5, 0.5),
-            vy: rand(-1.15, -0.25),
-            growth: rand(0.45, 0.9),
-            radius: rand(10, 20),
-            alpha: rand(0.18, 0.38)
+            y: player.y - 82 + rand(-20, 16),
+            vx: side * rand(1.1, 2.8) + rand(-0.6, 0.6),
+            vy: rand(-1.4, -0.35),
+            growth: rand(0.65, 1.15),
+            radius: rand(16, 30),
+            alpha: rand(0.2, 0.42)
           });
         }
       });
@@ -3021,8 +3024,8 @@
       state.effects.push({
         type: 'emergency-venting',
         owner: player,
-        timer: 12,
-        maxTimer: 12,
+        timer: 24,
+        maxTimer: 24,
         hotboxes: ventHotboxes,
         steamParticles,
         pushForce: 72
@@ -4488,15 +4491,15 @@
           if (!owner || owner.hp <= 0) {
             effect.timer = 0;
           } else {
-            const sideOffsets = [-52, -36, -20, 20, 36, 52];
-            const baseY = owner.y - 88;
+            const sideOffsets = [-70, -52, -34, 34, 52, 70];
+            const baseY = owner.y - 104;
             effect.hotboxes = sideOffsets.map((offsetX, idx) => {
               const priorHotbox = effect.hotboxes?.[idx];
               return {
-                x: owner.x + offsetX - 18,
+                x: owner.x + offsetX - 24,
                 y: (priorHotbox?.y ?? baseY) + rand(-0.8, 0.8),
-                width: 36,
-                height: 92
+                width: 48,
+                height: 116
               };
             });
             (effect.steamParticles || []).forEach(particle => {


### PR DESCRIPTION
### Motivation
- Add a visible steam venting effect and corresponding gameplay hitboxes for the `Emergency Venting` utility so Shunky Rooster can push nearby enemies when on low health. 
- Ensure the effect is gated by upgrade ownership and a cooldown and only triggers when player health is below 50%. 

### Description
- Added `maybeTriggerEmergencyVenting(player)` and call from `damagePlayer(...)` to trigger the vent when `player.charData.id === 'shunky-rooster'` and `hasUpgrade(player, 'emergency-venting')` and HP is below `player.maxHp * 0.5`. 
- Spawned an `emergency-venting` effect payload (steam particle list, `hotboxes`, `timer`, `pushForce`) in `state.effects` to represent multiple vents on both left/right sides of the sprite (`bayou-brawlers/index.html`). 
- Hooked `player.emergencyVentingCooldown` into the player update loop so the vent cannot retrigger every frame. 
- Implemented update logic in `updateEffects` for `effect.type === 'emergency-venting'` to advance steam particles, update hotboxes, detect overlaps with enemy hitboxes, apply a large push to overlapping enemies and a short stun, and expire when finished. 
- Added rendering for `emergency-venting` steam particles (transparent white radial gradients) so the burst reads as quick white/steam venting on both sides. 

### Testing
- Ran the project test suite with `npm test -- --runInBand`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3dea3d2f48329909fcc03403b4589)