### PR TITLE
Double Shunky Rooster emergency venting VFX size, radius, and knockback

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2996,12 +2996,12 @@
       player.emergencyVentingCooldown = Math.max(0, (player.emergencyVentingCooldown || 0) - 1);
       if (player.emergencyVentingCooldown > 0) return;
 
-      const sideOffsets = [-70, -52, -34, 34, 52, 70];
+      const sideOffsets = [-140, -104, -68, 68, 104, 140];
       const ventHotboxes = sideOffsets.map(offsetX => ({
-        x: player.x + offsetX - 24,
+        x: player.x + offsetX - 48,
         y: player.y - 104 + rand(-10, 14),
-        width: 48,
-        height: 116
+        width: 96,
+        height: 232
       }));
 
       const steamParticles = [];
@@ -3014,8 +3014,8 @@
             y: player.y - 82 + rand(-20, 16),
             vx: side * rand(1.1, 2.8) + rand(-0.6, 0.6),
             vy: rand(-1.4, -0.35),
-            growth: rand(0.65, 1.15),
-            radius: rand(16, 30),
+            growth: rand(1.3, 2.3),
+            radius: rand(32, 60),
             alpha: rand(0.2, 0.42)
           });
         }
@@ -3028,7 +3028,7 @@
         maxTimer: 24,
         hotboxes: ventHotboxes,
         steamParticles,
-        pushForce: 72
+        pushForce: 144
       });
       player.emergencyVentingCooldown = 170;
     }
@@ -4491,15 +4491,15 @@
           if (!owner || owner.hp <= 0) {
             effect.timer = 0;
           } else {
-            const sideOffsets = [-70, -52, -34, 34, 52, 70];
+            const sideOffsets = [-140, -104, -68, 68, 104, 140];
             const baseY = owner.y - 104;
             effect.hotboxes = sideOffsets.map((offsetX, idx) => {
               const priorHotbox = effect.hotboxes?.[idx];
               return {
-                x: owner.x + offsetX - 24,
+                x: owner.x + offsetX - 48,
                 y: (priorHotbox?.y ?? baseY) + rand(-0.8, 0.8),
-                width: 48,
-                height: 116
+                width: 96,
+                height: 232
               };
             });
             (effect.steamParticles || []).forEach(particle => {
@@ -4520,7 +4520,7 @@
                 const pushDir = Math.sign(enemy.x - hotboxCenterX) || (enemy.x >= owner.x ? 1 : -1);
                 const centerY = enemyBody.y + (enemyBody.height * 0.5);
                 const verticalDir = Math.sign(centerY - (owner.y - 44));
-                enemy.x += pushDir * (effect.pushForce || 72);
+                enemy.x += pushDir * (effect.pushForce || 144);
                 enemy.y += verticalDir * 6;
                 enemy.stun = Math.max(enemy.stun, 20 + STUN_DURATION_BONUS_FRAMES);
               });


### PR DESCRIPTION
### Motivation
- Increase the visual impact and effective area of Shunky Rooster's Emergency Venting so the steam VFX reads larger and pushes enemies farther. 

### Description
- Doubled the lateral spread by scaling `sideOffsets` from `[-70, -52, -34, 34, 52, 70]` to `[-140, -104, -68, 68, 104, 140]` in both spawn and per-frame update logic in `bayou-brawlers/index.html`.
- Doubled vent hotbox footprint by changing hotbox `x` offset and doubling `width`/`height` from `48x116` to `96x232` where hotboxes are created and refreshed.
- Doubled steam particle visual size by increasing `growth` and `radius` ranges from `rand(0.65, 1.15)`/`rand(16, 30)` to `rand(1.3, 2.3)`/`rand(32, 60)`.
- Doubled horizontal knockback by increasing `pushForce` from `72` to `144` and updating the fallback push value used during effect updates.

### Testing
- Ran `git diff --check` and it passed without issues.
- Ran `git status --short` to confirm the modified file is tracked and changes are staged/committed, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3fe4eee8483298fd3124a9f1c1bb3)