### PR TITLE
Tune Shunky emergency venting trigger range

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2997,12 +2997,16 @@
       if (player.emergencyVentingCooldown > 0) return;
 
       const sideOffsets = [-140, -104, -68, 68, 104, 140];
-      const ventHotboxes = sideOffsets.map(offsetX => ({
-        x: player.x + offsetX - 48,
-        y: player.y - 104 + rand(-10, 14),
-        width: 96,
-        height: 232
-      }));
+      const ventReachExtension = 22;
+      const ventHotboxes = sideOffsets.map(offsetX => {
+        const side = Math.sign(offsetX) || 1;
+        return {
+          x: player.x + offsetX - 48 - (side < 0 ? ventReachExtension : 0),
+          y: player.y - 104 + rand(-10, 14),
+          width: 96 + ventReachExtension,
+          height: 232
+        };
+      });
 
       const steamParticles = [];
       sideOffsets.forEach(offsetX => {


### PR DESCRIPTION
### Motivation
- Expand Shunky Rooster’s Emergency Venting area so the ability can catch and push enemies that are slightly farther away, triggering a bit earlier without changing the effect behavior.

### Description
- Introduced `ventReachExtension = 22` and updated `ventHotboxes` creation inside `maybeTriggerEmergencyVenting` to increase hotbox width and shift x positions outward for the outer sides while leaving particle generation, timer, and `pushForce` unchanged in `bayou-brawlers/index.html`.

### Testing
- Ran `npm test -- --runInBand __tests__/shuffle.test.js` and the test suite passed (1 file, 2 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4053b2a04832991b4d6ba1b331250)