### PR TITLE
Fix Emergency Venting HUD overlap in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2862,6 +2862,15 @@
       else ready.textContent = 'Charging';
     }
 
+    function layoutEmergencyVentingHud() {
+      const wrap = document.getElementById('emergencyVentingStatus');
+      const hud = document.getElementById('hud');
+      if (!wrap || !hud) return;
+      const hudTop = hud.offsetTop;
+      const hudBottom = hudTop + hud.offsetHeight;
+      wrap.style.top = `${hudBottom + 8}px`;
+    }
+
     function updateEmergencyVentingHud(player) {
       const wrap = document.getElementById('emergencyVentingStatus');
       const fill = document.getElementById('emergencyVentingFill');
@@ -2875,6 +2884,7 @@
       );
       wrap.style.display = show ? 'inline-flex' : 'none';
       if (!show) return;
+      layoutEmergencyVentingHud();
       const cooldown = Math.max(0, player.emergencyVentingCooldown || 0);
       const progress = 1 - (cooldown / EMERGENCY_VENTING_RECHARGE_FRAMES);
       fill.style.width = `${Math.round(clamp(progress, 0, 1) * 100)}%`;
@@ -6110,6 +6120,10 @@
         directionPad.addEventListener('lostpointercapture', resetDirectionInput);
       }
     }
+
+    window.addEventListener('resize', () => {
+      layoutEmergencyVentingHud();
+    });
 
     function initCharacterSelection() {
       const grid = document.getElementById('characterGrid');


### PR DESCRIPTION
### Motivation

- The Emergency Venting recharge strip for Shunky Rooster was overlapping the HUD readout chips on some viewport sizes and HUD wrap states, obscuring information.

### Description

- Added a helper `layoutEmergencyVentingHud()` that positions `#emergencyVentingStatus` immediately below the live `#hud` bounds based on `offsetTop`/`offsetHeight`. 
- Updated `updateEmergencyVentingHud()` to call `layoutEmergencyVentingHud()` whenever the strip is shown so the position is recalculated during gameplay updates. 
- Added a `window.addEventListener('resize', ...)` handler to call `layoutEmergencyVentingHud()` so the strip repositions when viewport/HUD layout changes. 
- Changes applied to `bayou-brawlers/index.html`.

### Testing

- Ran `npm test -- --runInBand`, and all test suites passed (`3` test suites, `6` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c41ef1a45083298b1773721598c2d2)