### PR TITLE
Adaptive viewport layout to prevent mobile controls being clipped on iPhone Chrome

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -22,11 +22,13 @@
       --ui: rgba(0, 0, 0, 0.82);
       --crimson: #ff4d6d;
       --emerald: #2dd4bf;
+      --app-height: 100dvh;
+      --viewport-offset-bottom: 0px;
     }
     * { box-sizing: border-box; }
     html, body {
       height: 100%;
-      min-height: 100dvh;
+      min-height: var(--app-height);
     }
     body {
       margin: 0;
@@ -41,7 +43,7 @@
     }
     .wrap {
       position: relative;
-      height: 100dvh;
+      height: var(--app-height);
       min-height: 100svh;
       width: 100%;
       min-height: 100vh;
@@ -419,7 +421,7 @@
     .levelup-tag { display: inline-block; margin-bottom: 6px; font-size: 9px; letter-spacing: 0.08em; color: #f3d28a; text-transform: uppercase; }
     .controls {
       position: absolute;
-      bottom: calc(18px + env(safe-area-inset-bottom));
+      bottom: calc(18px + env(safe-area-inset-bottom) + var(--viewport-offset-bottom));
       left: calc(16px + env(safe-area-inset-left));
       right: calc(16px + env(safe-area-inset-right));
       display: flex;
@@ -549,6 +551,25 @@
       height: clamp(44px, 7.2vw, 54px);
       font-size: clamp(8px, 1.5vw, 10px);
     }
+    .controls.compact .direction-pad {
+      width: 88px;
+      height: 88px;
+    }
+    .controls.compact .direction-pad-knob {
+      width: 34px;
+      height: 34px;
+    }
+    .controls.compact .action-pad {
+      gap: 4px;
+    }
+    .controls.compact .action-pad .pad-btn {
+      width: 40px;
+      height: 40px;
+      font-size: 8px;
+    }
+    .controls.compact .direction-label {
+      font-size: 8px;
+    }
     .instructions {
       font-size: clamp(7px, 1.2vh, 9px);
       color: #9fd6cf;
@@ -575,7 +596,7 @@
         height: min(94dvh, 780px);
         padding: 12px;
       }
-      .controls { flex-direction: row; align-items: center; gap: 8px; bottom: calc(24px + env(safe-area-inset-bottom)); }
+      .controls { flex-direction: row; align-items: center; gap: 8px; bottom: calc(24px + env(safe-area-inset-bottom) + var(--viewport-offset-bottom)); }
       .direction-pad { width: 104px; height: 104px; }
       .direction-pad-knob { width: 40px; height: 40px; }
       .pad-btn { width: 38px; height: 38px; font-size: 10px; }
@@ -608,7 +629,7 @@
       .controls {
         left: calc(10px + env(safe-area-inset-left));
         right: calc(10px + env(safe-area-inset-right));
-        bottom: calc(26px + env(safe-area-inset-bottom));
+        bottom: calc(26px + env(safe-area-inset-bottom) + var(--viewport-offset-bottom));
       }
       .panel h2 { font-size: 13px; }
       .panel p { font-size: 9px; }
@@ -6168,9 +6189,37 @@
       }
     }
 
+    function updateAdaptiveViewportLayout() {
+      const root = document.documentElement;
+      const controls = document.getElementById('mobileControls');
+      const viewport = window.visualViewport;
+      const viewportHeight = viewport ? viewport.height : window.innerHeight;
+      const viewportWidth = viewport ? viewport.width : window.innerWidth;
+      const viewportBottom = viewport ? (viewport.offsetTop + viewport.height) : window.innerHeight;
+      const bottomOverlap = Math.max(0, window.innerHeight - viewportBottom);
+
+      root.style.setProperty('--app-height', `${Math.max(1, Math.round(viewportHeight))}px`);
+      root.style.setProperty('--viewport-offset-bottom', `${Math.round(bottomOverlap)}px`);
+
+      if (!controls) return;
+      const touchPreferred = matchMedia('(pointer: coarse)').matches;
+      const compactLayout = touchPreferred && (
+        viewportHeight <= 460
+        || viewportWidth <= 760
+      );
+      controls.classList.toggle('compact', compactLayout);
+    }
+
     window.addEventListener('resize', () => {
+      updateAdaptiveViewportLayout();
       layoutEmergencyVentingHud();
     });
+
+    window.addEventListener('orientationchange', updateAdaptiveViewportLayout);
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', updateAdaptiveViewportLayout);
+      window.visualViewport.addEventListener('scroll', updateAdaptiveViewportLayout);
+    }
 
     function initCharacterSelection() {
       const grid = document.getElementById('characterGrid');
@@ -6728,6 +6777,7 @@
     }
 
     async function init() {
+      updateAdaptiveViewportLayout();
       await loadAssets();
       document.getElementById('loadingOverlay').classList.remove('show');
       document.getElementById('startOverlay').classList.add('show');

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -551,6 +551,44 @@
       height: clamp(44px, 7.2vw, 54px);
       font-size: clamp(8px, 1.5vw, 10px);
     }
+    .wrap.tight-ui header {
+      top: calc(4px + env(safe-area-inset-top));
+      gap: 4px;
+    }
+    .wrap.tight-ui .title h1 {
+      font-size: 11px;
+    }
+    .wrap.tight-ui .btn {
+      padding: 6px 8px;
+      font-size: 8px;
+    }
+    .wrap.tight-ui .hud {
+      top: calc(78px + env(safe-area-inset-top));
+      gap: 4px;
+      padding: 4px 6px;
+    }
+    .wrap.tight-ui .status-strip {
+      top: calc(106px + env(safe-area-inset-top));
+    }
+    .wrap.tight-ui .chip {
+      font-size: 8px;
+      padding: 3px 6px;
+    }
+    .wrap.tight-ui .hp-bar {
+      width: 84px;
+    }
+    .wrap.tight-ui .stage {
+      padding: calc(104px + env(safe-area-inset-top)) 10px calc(96px + env(safe-area-inset-bottom)) 10px;
+    }
+    .wrap.tight-ui .controls {
+      bottom: calc(8px + env(safe-area-inset-bottom) + var(--viewport-offset-bottom));
+    }
+    .wrap.tight-ui .dpad {
+      gap: 3px;
+    }
+    .wrap.tight-ui .direction-label {
+      display: none;
+    }
     .controls.compact .direction-pad {
       width: 88px;
       height: 88px;
@@ -6192,6 +6230,7 @@
     function updateAdaptiveViewportLayout() {
       const root = document.documentElement;
       const controls = document.getElementById('mobileControls');
+      const wrap = document.querySelector('.wrap');
       const viewport = window.visualViewport;
       const viewportHeight = viewport ? viewport.height : window.innerHeight;
       const viewportWidth = viewport ? viewport.width : window.innerWidth;
@@ -6208,6 +6247,14 @@
         || viewportWidth <= 760
       );
       controls.classList.toggle('compact', compactLayout);
+
+      if (wrap) {
+        const tightUiLayout = touchPreferred && (
+          viewportHeight <= 780
+          || viewportWidth <= 920
+        );
+        wrap.classList.toggle('tight-ui', tightUiLayout);
+      }
     }
 
     window.addEventListener('resize', () => {


### PR DESCRIPTION
### Motivation
- Mobile browsers (notably Chrome on iPhone) can expose browser UI that reduces the visible viewport and causes on-screen controls to be clipped below the window, so the game needs to detect the visible viewport and adapt layout accordingly.
- Provide a compact touch layout for small/tall/short viewports so the D-pad and action buttons remain reachable on constrained devices.

### Description
- Added CSS variables `--app-height` and `--viewport-offset-bottom` and switched `html`/`body` and `.wrap` sizing from fixed `100dvh` to `--app-height` so the UI tracks the visible viewport height instead of a static device height.
- Adjusted `.controls` positioning (base and media queries) to include `var(--viewport-offset-bottom)` so the on-screen controls are offset above browser chrome/safe-area overlap.
- Added a `.controls.compact` style set to reduce D-pad and button sizes and spacing for tight touch viewports, and toggle this mode based on `matchMedia('(pointer: coarse)')` and viewport dimensions.
- Implemented `updateAdaptiveViewportLayout()` which uses `window.visualViewport` (with `window.innerHeight` fallbacks), updates the CSS variables, toggles compact mode on `#mobileControls`, and is hooked to `resize`, `orientationchange`, and `visualViewport` `resize`/`scroll` events and invoked at init.

### Testing
- No automated test harness exists for this static HTML game, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c456ffa85083298f660aa012dd665c)