### PR TITLE
Implement Shrapnel Protocol radial shrapnel visuals for Rustbucket

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1347,7 +1347,7 @@
         { id: 'gyro-stabilizers', name: 'Gyro Stabilizers', tag: 'Special', description: 'Take less damage while in turret mode.' },
         { id: 'bullet-storm-max', name: 'Bullet Storm Max', tag: 'Super', description: 'Super fires more shots.' },
         { id: 'targeting-upgrade', name: 'Targeting Upgrade', tag: 'Super', description: 'Super tracks enemies more reliably.' },
-        { id: 'shrapnel-protocol', name: 'Shrapnel Protocol', tag: 'Super', description: 'Super hits create secondary splash projectiles.' },
+        { id: 'shrapnel-protocol', name: 'Shrapnel Protocol', tag: 'Super', description: 'Heavy, special, and super-special hits fire secondary shrapnel projectiles in all directions.' },
         { id: 'auto-loader', name: 'Auto Loader', tag: 'Utility', description: 'Gain attack speed boost after heavy attack.' },
         { id: 'ricochet-logic', name: 'Ricochet Logic', tag: 'Utility', description: 'Basic shots have a chance to bounce to another enemy.' },
         { id: 'power-recycler', name: 'Power Recycler', tag: 'Utility', description: 'Gain extra power meter from kills.' },
@@ -3314,7 +3314,7 @@
       state.pickups.push({ x, y, timer: 600 });
     }
 
-    function spawnProjectile(owner, speed, damage, friendly, color = '#f5d07a') {
+    function spawnProjectile(owner, speed, damage, friendly, color = '#f5d07a', options = null) {
       const dir = owner.facing;
       const ownerId = owner?.charData?.id || null;
       state.projectiles.push({
@@ -3330,7 +3330,8 @@
         turnRate: 0,
         ownerId,
         trailEvery: 0,
-        ricochetRemaining: ownerId === 'rustbucket' ? 1 : 0
+        ricochetRemaining: ownerId === 'rustbucket' ? 1 : 0,
+        attackKind: options?.attackKind || null
       });
     }
 
@@ -3375,10 +3376,54 @@
         trailEvery: 3,
         burstRadius: heavy ? 18 : 12,
         ricochetRemaining: id === 'rustbucket' ? 1 : 0,
+        attackKind: heavy ? 'heavy' : 'basic',
         passThroughEnemies: id === 'rustbucket' && heavy && hasUpgrade(player, 'piercing-shot'),
         hitEnemyUids: []
       };
       state.projectiles.push(projectile);
+    }
+
+    function spawnRustbucketShrapnelProjectiles(player, originX, originY, baseDamage, options = null) {
+      if (!player || player.charData.id !== 'rustbucket' || !hasUpgrade(player, 'shrapnel-protocol')) return;
+      const shardCount = options?.shardCount || 10;
+      const speedMin = options?.speedMin || 4.2;
+      const speedMax = options?.speedMax || 7.6;
+      const lifeMin = options?.lifeMin || 24;
+      const lifeMax = options?.lifeMax || 42;
+      const damageScale = options?.damageScale || 0.24;
+      const excludeEnemyUid = options?.excludeEnemyUid || null;
+      const shrapnelDamage = Math.max(2, baseDamage * damageScale);
+      for (let i = 0; i < shardCount; i += 1) {
+        const angle = ((Math.PI * 2 * i) / shardCount) + rand(-0.22, 0.22);
+        const speed = rand(speedMin, speedMax);
+        state.projectiles.push({
+          x: originX + rand(-2, 2),
+          y: originY + rand(-2, 2),
+          vx: Math.cos(angle) * speed,
+          vy: Math.sin(angle) * speed,
+          damage: shrapnelDamage,
+          friendly: true,
+          life: Math.round(rand(lifeMin, lifeMax)),
+          color: 'rgba(255, 222, 146, 0.95)',
+          tracking: false,
+          turnRate: 0,
+          ownerId: 'rustbucket',
+          trailEvery: 0,
+          burstRadius: 8,
+          ricochetRemaining: 0,
+          shrapnel: true,
+          drawSize: 4,
+          hitEnemyUids: excludeEnemyUid ? [excludeEnemyUid] : []
+        });
+      }
+      state.effects.push({
+        x: originX,
+        y: originY,
+        timer: 16,
+        radius: 14,
+        type: 'projectile-burst',
+        color: 'rgba(255, 224, 160, 0.95)'
+      });
     }
 
     function getShunkyLaserOrigin(player) {
@@ -3775,7 +3820,18 @@
       const radiusBoost = player.specialEffectMultiplier || 1;
       if (isSuper) {
         state.shake = 10;
-        state.effects.push({ x: player.x, y: player.y - 80, radius: 220 * radiusBoost, timer: 36, damage: 30 * radiusBoost, knockback: 30, stun: 70, type: 'shock' });
+        state.effects.push({
+          x: player.x,
+          y: player.y - 80,
+          radius: 220 * radiusBoost,
+          timer: 36,
+          damage: 30 * radiusBoost,
+          knockback: 30,
+          stun: 70,
+          type: 'shock',
+          owner: player,
+          shrapnelSource: id === 'rustbucket' ? 'super-special' : null
+        });
       }
       if (id === 'green-fairy') {
         const applyRegular = () => {
@@ -3804,7 +3860,21 @@
         }
       } else if (id === 'rustbucket') {
         player.sentryTimer = 150;
-        if (isSuper) state.effects.push({ x: player.x, y: player.y, radius: 260 * radiusBoost, timer: 30, damage: 24 * radiusBoost, knockback: 25, stun: 40, type: 'shock' });
+        player.sentrySuperTimer = isSuper ? 150 : 0;
+        if (isSuper) {
+          state.effects.push({
+            x: player.x,
+            y: player.y,
+            radius: 260 * radiusBoost,
+            timer: 30,
+            damage: 24 * radiusBoost,
+            knockback: 25,
+            stun: 40,
+            type: 'shock',
+            owner: player,
+            shrapnelSource: 'super-special'
+          });
+        }
       } else if (id === 'shunky-rooster') {
         state.effects.push({
           x: player.x + player.facing * 90,
@@ -3946,6 +4016,8 @@
       player.specialCooldown = Math.max(0, player.specialCooldown - 1);
       player.jumpCooldown = Math.max(0, player.jumpCooldown - 1);
       player.shieldTimer = Math.max(0, player.shieldTimer - 1);
+      player.sentryTimer = Math.max(0, (player.sentryTimer || 0) - 1);
+      player.sentrySuperTimer = Math.max(0, (player.sentrySuperTimer || 0) - 1);
       player.emergencyVentingCooldown = Math.max(0, (player.emergencyVentingCooldown || 0) - 1);
       player.actionLock = Math.max(0, player.actionLock - 1);
       player.passiveCooldown = Math.max(0, player.passiveCooldown - 1);
@@ -3979,7 +4051,11 @@
       } else {
         player.perfectGlamourPlusTimer = 0;
       }
-      if (player.sentryTimer > 0 && player.sentryTimer % 18 === 0) spawnProjectile(player, 11, hasLevel(player, 7) ? 9 : 7, true, '#ffe8aa');
+      if (player.sentryTimer > 0 && player.sentryTimer % 18 === 0) {
+        spawnProjectile(player, 11, hasLevel(player, 7) ? 9 : 7, true, '#ffe8aa', {
+          attackKind: player.sentrySuperTimer > 0 ? 'super-special' : 'special'
+        });
+      }
       if (player.tempestTimer > 0) {
         player.tempestTimer -= 1;
         player.x += player.facing * 3.5;
@@ -4516,6 +4592,17 @@
               projectile.y < enemyBody.y + enemyBody.height
             ) {
               damageEnemy(enemy, projectile.damage, 20);
+              if (
+                projectile.ownerId === 'rustbucket'
+                && !projectile.shrapnel
+                && ['heavy', 'special', 'super-special'].includes(projectile.attackKind || '')
+              ) {
+                spawnRustbucketShrapnelProjectiles(state.player, projectile.x, projectile.y, projectile.damage, {
+                  excludeEnemyUid: enemy.uid,
+                  shardCount: projectile.attackKind === 'super-special' ? 12 : 9,
+                  damageScale: projectile.attackKind === 'heavy' ? 0.24 : 0.2
+                });
+              }
               if (projectile.hitEnemyUids) projectile.hitEnemyUids.push(enemy.uid);
               state.effects.push({ x: projectile.x, y: projectile.y, timer: 16, radius: projectile.burstRadius || 12, type: 'projectile-burst', color: projectile.color });
               if (
@@ -4683,6 +4770,18 @@
             if (distance < effect.radius) {
               if (!canPlayerAffectEnemy(enemy)) return;
               damageEnemy(enemy, effect.damage, effect.stun || 0);
+              if (
+                effect.type === 'shock'
+                && effect.owner
+                && effect.owner.charData.id === 'rustbucket'
+                && effect.shrapnelSource
+              ) {
+                spawnRustbucketShrapnelProjectiles(effect.owner, enemy.x, enemy.y - 16, effect.damage, {
+                  excludeEnemyUid: enemy.uid,
+                  shardCount: effect.shrapnelSource === 'super-special' ? 12 : 9,
+                  damageScale: effect.shrapnelSource === 'super-special' ? 0.25 : 0.2
+                });
+              }
               enemy.x += Math.sign(enemy.x - effect.x) * (effect.knockback || 0);
               if (effect.type === 'root' || effect.type === 'root-poison') applyStatus(enemy, 'ROOT', 110, 1);
               if (effect.type === 'root-poison') applyStatus(enemy, 'POISON', 240, 1);
@@ -5612,8 +5711,9 @@
           ctx.restore();
           return;
         }
+        const drawSize = projectile.drawSize || 8;
         ctx.fillStyle = projectile.color;
-        ctx.fillRect(projectile.x - state.cameraX - 4, projectile.y - state.cameraY - 4, 8, 8);
+        ctx.fillRect(projectile.x - state.cameraX - (drawSize * 0.5), projectile.y - state.cameraY - (drawSize * 0.5), drawSize, drawSize);
       });
 
       state.effects.forEach(effect => {


### PR DESCRIPTION
### Motivation
- Add the visual and gameplay effect for the `Shrapnel Protocol` upgrade so Rustbucket's heavy, special, and super-special hits spawn small secondary projectiles that can hit other enemies.

### Description
- Updated the upgrade text in `bayou-brawlers/index.html` to reflect that `Shrapnel Protocol` triggers on heavy, special, and super-special hits.
- Extended `spawnProjectile` to accept an `options` arg and added per-projectile metadata `attackKind` so projectiles can be identified as `heavy`, `special`, or `super-special` when they hit.
- Added `spawnRustbucketShrapnelProjectiles(...)` which emits a radial spread of small shrapnel projectiles with tuned speed, life, damage, color, and `drawSize` for distinct visuals.
- Wired shrapnel spawning into the engine: rustbucket heavy projectile impacts now spawn shrapnel; sentry shots are tagged (`special` / `super-special`) so sentry impacts spawn shrapnel; rustbucket super shock effects spawn shrapnel on their hit ticks.
- Added `sentrySuperTimer` and ensured `player.sentryTimer` / `player.sentrySuperTimer` tick down each frame so sentry firing windows and `super-special` tagging behave correctly.
- Render code now respects `projectile.drawSize` so shrapnel pieces draw smaller than regular projectiles and the burst effect is added to `state.effects` for visual feedback.

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all tests passed (`3` test suites, `6` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c53ad0fb348329943a91894c1a2ac6)