### PR TITLE
bayou-brawlers: Ricochet Logic — enable basic & heavy shot ricochet visuals

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1349,7 +1349,7 @@
         { id: 'targeting-upgrade', name: 'Targeting Upgrade', tag: 'Super', description: 'Super tracks enemies more reliably.' },
         { id: 'shrapnel-protocol', name: 'Shrapnel Protocol', tag: 'Super', description: 'Heavy, special, and super-special hits fire secondary shrapnel projectiles in all directions.' },
         { id: 'auto-loader', name: 'Auto Loader', tag: 'Utility', description: 'Gain attack speed boost after heavy attack.' },
-        { id: 'ricochet-logic', name: 'Ricochet Logic', tag: 'Utility', description: 'Basic shots have a chance to bounce to another enemy.' },
+        { id: 'ricochet-logic', name: 'Ricochet Logic', tag: 'Utility', description: 'Basic and heavy shots have a 25% chance to ricochet to another enemy on hit.' },
         { id: 'power-recycler', name: 'Power Recycler', tag: 'Utility', description: 'Gain extra power meter from kills.' },
         { id: 'steel-sheriff', name: 'Steel Sheriff', tag: 'Utility', description: 'Reduced damage taken.' },
         { id: 'quick-reboot', name: 'Quick Reboot', tag: 'Utility', description: 'Recover from stun faster.' }
@@ -3335,6 +3335,9 @@
       });
     }
 
+    const RUSTBUCKET_RICOCHET_CHANCE = 0.25;
+    const RUSTBUCKET_RICOCHET_MAX_BOUNCES = 8;
+
     function spawnPlayerAttackProjectile(player, heavy, tuning) {
       const id = player.charData.id;
       const paletteByCharacter = {
@@ -3375,7 +3378,7 @@
         ownerId: id,
         trailEvery: 3,
         burstRadius: heavy ? 18 : 12,
-        ricochetRemaining: id === 'rustbucket' ? 1 : 0,
+        ricochetRemaining: id === 'rustbucket' && hasUpgrade(player, 'ricochet-logic') ? RUSTBUCKET_RICOCHET_MAX_BOUNCES : 0,
         attackKind: heavy ? 'heavy' : 'basic',
         passThroughEnemies: id === 'rustbucket' && heavy && hasUpgrade(player, 'piercing-shot'),
         hitEnemyUids: []
@@ -4608,9 +4611,10 @@
               if (
                 player
                 && projectile.ownerId === 'rustbucket'
-                && hasLevel5SignaturePassive(player)
+                && hasUpgrade(player, 'ricochet-logic')
+                && ['basic', 'heavy'].includes(projectile.attackKind || '')
                 && (projectile.ricochetRemaining || 0) > 0
-                && Math.random() < 0.25
+                && Math.random() < RUSTBUCKET_RICOCHET_CHANCE
               ) {
                 const ricochetTarget = state.enemies
                   .filter(other => other.hp > 0 && other.uid !== enemy.uid && canPlayerAffectEnemy(other))
@@ -4636,7 +4640,8 @@
                     burstRadius: projectile.burstRadius || 12,
                     ricochetRemaining: (projectile.ricochetRemaining || 1) - 1,
                     passThroughEnemies: false,
-                    hitEnemyUids: []
+                    attackKind: projectile.attackKind || null,
+                    hitEnemyUids: [enemy.uid]
                   });
                 }
               }


### PR DESCRIPTION
### Motivation
- Make the Rustbucket `ricochet-logic` upgrade behave and read as intended by applying ricochet visuals to both basic and heavy attacks with a 25% chance per hit.

### Description
- Updated the upgrade text for `ricochet-logic` to: "Basic and heavy shots have a 25% chance to ricochet to another enemy on hit." in `bayou-brawlers/index.html`.
- Added constants `RUSTBUCKET_RICOCHET_CHANCE` and `RUSTBUCKET_RICOCHET_MAX_BOUNCES` and gated ricochet-enabled projectiles so the chaining is only active when `hasUpgrade(player, 'ricochet-logic')` is true.
- When spawning player projectiles, set `ricochetRemaining` only if the player has the `ricochet-logic` upgrade and preserve `attackKind` (`'basic'` or `'heavy'`) on ricocheted projectiles so the behavior continues to match the original attack type.
- Adjusted hit-resolution so ricochet triggers use the 25% chance constant, only apply for `basic`/`heavy` attack kinds, and avoid immediately targeting the enemy that was just hit by including that enemy in `hitEnemyUids`.

### Testing
- Ran the automated test suite with `npm test -- --runInBand` and all tests passed.
- Tests executed: `__tests__/paddleBuff.test.js`, `__tests__/shuffleSoundtrack.test.js`, and `__tests__/shuffle.test.js`, all reported `PASS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56213e4cc8329b506ec58361900c6)