### PR TITLE
Double Garden of Thorns patch size and duration

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2339,13 +2339,13 @@
         const x = clamp(player.x + offsetX + (player.facing * 24), 48, getWaveBarrierPlayerMaxX() - 20);
         const yBounds = getPlayerVerticalBounds(player);
         const y = clamp(player.y + offsetY, yBounds.minY + 6, yBounds.maxY + 2);
-        const lifetime = rand(8 * 60, 12 * 60);
+        const lifetime = rand(8 * 60, 12 * 60) * 2;
         state.hazards.push({
           kind: 'thorn-patch',
           x,
           y,
-          w: rand(68, 110),
-          h: rand(32, 52),
+          w: rand(68, 110) * 2,
+          h: rand(32, 52) * 2,
           frames: lifetime,
           maxFrames: lifetime,
           damage: Math.max(5, Math.round(baseDamage * 0.42)),


### PR DESCRIPTION
### Motivation
- Make Scarlett Glumpkin’s damaging hazard patches from the Garden of Thorns twice as large and persist twice as long to increase their battlefield presence.

### Description
- Updated `spawnGardenOfThornsPatches` in `bayou-brawlers/index.html` to set `lifetime` to `rand(8 * 60, 12 * 60) * 2` so patches last twice as long.
- Doubled generated patch dimensions by multiplying `w: rand(68, 110)` and `h: rand(32, 52)` by `2` so patches are twice their previous size.
- All other patch properties (damage, `hitInterval`, etc.) remain unchanged.

### Testing
- Ran the unit test suite with `npm test -- --watch=false` and all test suites passed (`3` test suites, `6` tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5917f194083299d9bb0cc98afdec5)