### PR TITLE
Make level-up choices unclickable for 1s to avoid accidental selection

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2841,6 +2841,7 @@
       const auto = document.getElementById('levelUpAuto');
       const choicesWrap = document.getElementById('levelUpChoices');
       const choiceList = pickUpgradeChoices(player, 3);
+      const choicesUnlockAt = performance.now() + 1000;
       state.currentLevelUp = { level, choices: choiceList };
       title.textContent = `Level ${level} Reached`;
       auto.innerHTML = `<strong>Auto gains:</strong><br>• ${getAutoLevelGainLines(level, player).join('<br>• ')}<br><br><strong>Choose one:</strong>`;
@@ -2850,6 +2851,7 @@
         button.className = 'btn';
         button.textContent = 'Continue';
         button.addEventListener('click', () => {
+          if (performance.now() < choicesUnlockAt) return;
           overlay.classList.remove('show');
           state.paused = false;
           state.currentLevelUp = null;
@@ -2869,6 +2871,7 @@
               <p>${upgrade.description}</p>
             </div>`;
           button.addEventListener('click', () => {
+            if (performance.now() < choicesUnlockAt) return;
             applyChosenUpgrade(player, upgrade);
             overlay.classList.remove('show');
             state.paused = false;


### PR DESCRIPTION
### Motivation
- Prevent accidental activation of level-up choices immediately when the overlay appears (e.g., from clicks that happen at the same time an enemy kill spawns the overlay). 

### Description
- Add a 1-second input lock in `showLevelUpOverlay` by setting `choicesUnlockAt = performance.now() + 1000` and ignore clicks on both the fallback `Continue` button and each `.levelup-choice` until that time in `bayou-brawlers/index.html`.

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all test suites passed (3 passed, 6 tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a817934c832987804fd67eee718f)