### PR TITLE
Halve Sidewinder damage in Mirewatch (level 2)

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2083,6 +2083,7 @@
       const stage = STAGED_ENEMY_TYPES.has(typeId) ? (options.stage || 3) : 1;
       const stats = STAGED_ENEMY_TYPES.has(typeId) ? getStagedStats(typeId, stage) : base;
       const animationTracks = assets.enemyAnimations[typeId] || assets.enemyAnimations.swamp || null;
+      const damageMultiplier = Number.isFinite(options.damageMultiplier) ? options.damageMultiplier : 1;
       const enemy = {
         uid: ++state.enemyUid,
         type: typeId,
@@ -2093,7 +2094,7 @@
         hp: stats.hp * (isBoss ? 1.15 : 1),
         maxHp: stats.hp * (isBoss ? 1.15 : 1),
         speed: stats.speed * ENEMY_SPEED_MULTIPLIER,
-        damage: stats.damage,
+        damage: stats.damage * damageMultiplier,
         range: stats.range,
         score: stats.score,
         sprite: base.sprite === 'boss' ? assets.boss : assets.enemies[base.sprite],
@@ -2582,7 +2583,10 @@
         const spawnX = isLeftGroup
           ? (leftBaseX - laneOffset + rand(-35, 35))
           : (rightBaseX + laneOffset + rand(-35, 35));
-        const enemy = createEnemy(typeId, spawnX, rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y));
+        const spawnOptions = (level.id === 'mirewatch' && typeId === 'sidewinder')
+          ? { damageMultiplier: 0.5 }
+          : {};
+        const enemy = createEnemy(typeId, spawnX, rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y), false, spawnOptions);
         state.enemies.push(enemy);
       }
       state.waveIndex = waveIndex;


### PR DESCRIPTION
### Motivation
- Reduce difficulty on the Mirewatch (level id `mirewatch`) by halving damage dealt by `sidewinder` enemies in that level without changing global enemy stats.

### Description
- Add an optional per-spawn `damageMultiplier` option in `createEnemy` and apply it to the enemy `damage` value when constructing the enemy object in `bayou-brawlers/index.html`.
- Update the regular wave spawn loop to pass `{ damageMultiplier: 0.5 }` for `sidewinder` spawns when `level.id === 'mirewatch'` so only those sidewinders are affected.
- Changes are limited to `bayou-brawlers/index.html` and use the existing `options` parameter of `createEnemy` so other levels and uses remain unchanged.

### Testing
- Ran `git diff --check` to validate patch formatting and it completed with no issues (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c60cd1fd348329b14de63f38138685)