### PR TITLE
Nerf Sidewinder damage in Mirewatch by 75%

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1411,6 +1411,11 @@
       sidewinder: 3,
       stingy: 3
     };
+    const LEVEL_ENEMY_DAMAGE_MULTIPLIERS = {
+      mirewatch: {
+        sidewinder: 0.25
+      }
+    };
 
     function toAssetCamelCase(value) {
       if (!value) return '';
@@ -1451,6 +1456,14 @@
         };
       }
       return { hp: base.hp, speed: base.speed, damage: base.damage, range: base.range, score: base.score };
+    }
+
+    function getEnemyDamageForLevel(typeId, baseDamage) {
+      const level = levels[state.levelIndex];
+      const levelMultipliers = level ? LEVEL_ENEMY_DAMAGE_MULTIPLIERS[level.id] : null;
+      const damageMultiplier = levelMultipliers ? levelMultipliers[typeId] : null;
+      if (typeof damageMultiplier !== 'number') return baseDamage;
+      return baseDamage * damageMultiplier;
     }
 
     function getEnemyRenderScale(typeId, stage, isBoss) {
@@ -2093,7 +2106,7 @@
         hp: stats.hp * (isBoss ? 1.15 : 1),
         maxHp: stats.hp * (isBoss ? 1.15 : 1),
         speed: stats.speed * ENEMY_SPEED_MULTIPLIER,
-        damage: stats.damage,
+        damage: getEnemyDamageForLevel(typeId, stats.damage),
         range: stats.range,
         score: stats.score,
         sprite: base.sprite === 'boss' ? assets.boss : assets.enemies[base.sprite],


### PR DESCRIPTION
### Motivation
- Reduce the damage output of `sidewinder` enemies on the Mirewatch level by 75% while leaving other levels unchanged.
- Provide a small, extensible mechanism to configure per-level enemy damage overrides for future tuning.

### Description
- Added a `LEVEL_ENEMY_DAMAGE_MULTIPLIERS` table and configured `mirewatch.sidewinder` to `0.25` in `bayou-brawlers/index.html`.
- Implemented `getEnemyDamageForLevel(typeId, baseDamage)` to safely look up and apply level-specific damage multipliers.
- Updated enemy construction to use `damage: getEnemyDamageForLevel(typeId, stats.damage)` instead of the raw `stats.damage` so the multiplier is applied at spawn.

### Testing
- Ran `git diff --check` to validate the change and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c61116a49c83299adad43df7ce6d58)