### PR TITLE
Rework Sidewinder into low-damage barrage attacker

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1121,7 +1121,7 @@
       ranged: { hp: 30, speed: 1.4, damage: 7, range: 140, score: 95, sprite: 'fey', ranged: true, tier: 'medium' },
       hiredGun: { hp: 34, speed: 1.45, damage: 8, range: 155, score: 100, sprite: 'hiredGun', ranged: true, tier: 'medium' },
       stingy: { hp: 28, speed: 2.15, damage: 7, range: 20, score: 105, sprite: 'stingy', tier: 'medium' },
-      sidewinder: { hp: 32, speed: 2.35, damage: 11, range: 26, score: 115, sprite: 'sidewinder', tier: 'medium' },
+      sidewinder: { hp: 32, speed: 2.35, damage: 2, range: 72, score: 115, sprite: 'sidewinder', tier: 'medium' },
       elite: { hp: 70, speed: 1.5, damage: 14, range: 22, score: 140, sprite: 'automaton', tier: 'elite' },
       brute: { hp: 120, speed: 1.1, damage: 18, range: 24, score: 200, sprite: 'thug', tier: 'elite' },
       mage: { hp: 90, speed: 1.3, damage: 16, range: 120, score: 180, sprite: 'fey', ranged: true, tier: 'elite' },
@@ -4350,27 +4350,33 @@
             }
           }
         } else if (enemy.type === 'sidewinder') {
-          enemy.dashCooldown = Math.max(0, enemy.dashCooldown - 1);
-          if (enemy.dashFrames > 0) {
-            enemy.dashFrames -= 1;
-            enemy.x += enemy.facing * moveSpeed * 2.7;
-            enemy.y += Math.sign(dy) * moveSpeed * 0.2;
+          const barrageRadius = enemy.range;
+          const preferredDistance = Math.max(36, barrageRadius - 18);
+          const barrageTickRate = 5;
+          const barrageDamage = Math.max(1, Math.round(enemy.damage * 0.6));
+
+          if (distance > preferredDistance + 8) {
+            enemy.x += Math.sign(dx) * moveSpeed * 0.92;
+            enemy.y += Math.sign(dy) * moveSpeed * 0.52;
             enemy.isMoving = true;
-            if (rectsOverlap({ x: enemyBody.x - 14, y: enemyBody.y - 2, width: enemyBody.width + 28, height: enemyBody.height + 4 }, playerBody)) {
-              damagePlayer(enemy.damage, enemy);
-            }
-            if (enemy.dashFrames <= 0) {
-              enemy.cooldown = rand(45, 70);
-              enemy.dashCooldown = rand(95, 150);
-            }
-          } else if (enemy.dashCooldown <= 0 && distance < 260) {
-            enemy.facing = dx >= 0 ? 1 : -1;
-            enemy.dashFrames = rand(16, 24);
-            enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 16);
           } else {
-            enemy.x += Math.sign(dx) * moveSpeed * 0.7;
-            enemy.y += Math.sign(dy) * moveSpeed * 0.35;
+            const strafeDirection = enemy.facing >= 0 ? 1 : -1;
+            enemy.x += (-Math.sign(dy) || strafeDirection) * moveSpeed * 0.72;
+            enemy.y += Math.sign(dx) * moveSpeed * 0.38;
             enemy.isMoving = true;
+          }
+
+          enemy.facing = dx >= 0 ? 1 : -1;
+
+          if (distance <= barrageRadius) {
+            enemy.cooldown = Math.max(0, enemy.cooldown - 1);
+            if (enemy.cooldown <= 0) {
+              damagePlayer(barrageDamage, enemy);
+              enemy.cooldown = barrageTickRate;
+              enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 8);
+            }
+          } else {
+            enemy.cooldown = Math.min(enemy.cooldown, barrageTickRate);
           }
         } else if (enemy.type === 'sweetykins') {
           enemy.dashCooldown = Math.max(0, enemy.dashCooldown - 1);


### PR DESCRIPTION
### Motivation
- Change Sidewinder from a single high-impact dash attacker to a persistent-area-pressure enemy that deals many small hits in a radius.  
- This makes its threat about sustained proximity rather than burst damage windows, matching a design goal for continuous area pressure.

### Description
- Lowered Sidewinder base damage and increased its effective range by changing `damage` from `11` to `2` and `range` from `26` to `72` in `enemyTypes` (`bayou-brawlers/index.html`).
- Replaced the dash-impact logic with a barrage mechanic that uses `enemy.range` as the `barrageRadius` and applies repeated small damage ticks on a short cadence (`barrageTickRate = 5`).
- Implemented movement to keep the Sidewinder near a `preferredDistance` from the player and to strafe while maintaining pressure, and set `enemy.facing` from player direction to orient the barrage.
- Barrage damage is computed as `Math.max(1, Math.round(enemy.damage * 0.6))` and uses `enemy.cooldown` to schedule recurring hits and drive attack animation timing.

### Testing
- No automated tests were available or run for this static game logic change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c615b3a58083298157bafe1879c0e5)