### PR TITLE
Retune Sweetykins: lower damage and implement charge/assault boss pattern

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1125,7 +1125,7 @@
       elite: { hp: 70, speed: 1.5, damage: 14, range: 22, score: 140, sprite: 'automaton', tier: 'elite' },
       brute: { hp: 120, speed: 1.1, damage: 18, range: 24, score: 200, sprite: 'thug', tier: 'elite' },
       mage: { hp: 90, speed: 1.3, damage: 16, range: 120, score: 180, sprite: 'fey', ranged: true, tier: 'elite' },
-      sweetykins: { hp: 210, speed: 1.55, damage: 19, range: 32, score: 560, sprite: 'sweetykins', tier: 'boss' },
+      sweetykins: { hp: 210, speed: 1.55, damage: 13, range: 32, score: 560, sprite: 'sweetykins', tier: 'boss' },
       'mud-monster': { hp: 160, speed: 1.15, damage: 18, range: 34, score: 520, sprite: 'mud-monster', tier: 'boss' },
       boss: { hp: 200, speed: 1.2, damage: 20, range: 26, score: 350, sprite: 'boss', tier: 'boss' }
     };
@@ -2413,6 +2413,7 @@
       const anim = enemy.animation;
       const facingName = enemy.facing >= 0 ? 'right' : 'left';
       let nextState = enemy.isMoving ? 'walk' : 'idle';
+      if (enemy.forceIdleAnimation) nextState = 'idle';
 
       if (enemy.hp <= 0 || enemy.deathHoldFrames > 0) {
         nextState = 'death';
@@ -4379,30 +4380,65 @@
             enemy.cooldown = Math.min(enemy.cooldown, barrageTickRate);
           }
         } else if (enemy.type === 'sweetykins') {
-          enemy.dashCooldown = Math.max(0, enemy.dashCooldown - 1);
-          if (enemy.dashFrames > 0) {
-            enemy.dashFrames -= 1;
-            enemy.x += enemy.facing * moveSpeed * 2.9;
-            enemy.y += Math.sign(dy) * moveSpeed * 0.25;
-            enemy.isMoving = true;
-            if (rectsOverlap({ x: enemyBody.x - 18, y: enemyBody.y - 8, width: enemyBody.width + 36, height: enemyBody.height + 16 }, playerBody)) {
-              damagePlayer(Math.round(enemy.damage * 1.2), enemy);
+          enemy.forceIdleAnimation = false;
+          if (!enemy.sweetykinsMode) enemy.sweetykinsMode = 'charge';
+          if (!Number.isFinite(enemy.sweetykinsChargesRemaining)) enemy.sweetykinsChargesRemaining = rand(4, 6);
+          if (!Number.isFinite(enemy.sweetykinsHitsRemaining)) enemy.sweetykinsHitsRemaining = rand(2, 4);
+          if (!Number.isFinite(enemy.sweetykinsRunHitCooldown)) enemy.sweetykinsRunHitCooldown = 0;
+          enemy.sweetykinsRunHitCooldown = Math.max(0, enemy.sweetykinsRunHitCooldown - 1);
+
+          if (enemy.sweetykinsMode === 'charge') {
+            enemy.forceIdleAnimation = true;
+            enemy.windup = 0;
+            enemy.attackAnimTimer = 0;
+            const leftBound = state.cameraX + 42;
+            const rightBound = state.cameraX + canvas.width - 42;
+            if (!Number.isFinite(enemy.sweetykinsChargeDirection)) {
+              enemy.sweetykinsChargeDirection = dx >= 0 ? 1 : -1;
             }
-            if (enemy.dashFrames <= 0) {
-              enemy.cooldown = rand(40, 70);
-              enemy.dashCooldown = rand(60, 110);
+            enemy.facing = enemy.sweetykinsChargeDirection;
+
+            const chargeSpeed = moveSpeed * 4.1;
+            enemy.x += enemy.sweetykinsChargeDirection * chargeSpeed;
+            enemy.y += Math.sign(dy) * moveSpeed * 0.24;
+
+            const runHitbox = {
+              x: enemyBody.x - 22,
+              y: enemyBody.y - 10,
+              width: enemyBody.width + 44,
+              height: enemyBody.height + 20
+            };
+            if (enemy.sweetykinsRunHitCooldown <= 0 && rectsOverlap(runHitbox, playerBody)) {
+              damagePlayer(Math.max(1, Math.round(enemy.damage * 0.9)), enemy);
+              enemy.sweetykinsRunHitCooldown = 16;
             }
-          } else if (enemy.dashCooldown <= 0 && distance < 380) {
-            enemy.facing = dx >= 0 ? 1 : -1;
-            enemy.dashFrames = rand(24, 34);
-            enemy.windup = 8;
-            enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 20);
+
+            let bounced = false;
+            if (enemy.x <= leftBound) {
+              enemy.x = leftBound;
+              enemy.sweetykinsChargeDirection = 1;
+              bounced = true;
+            } else if (enemy.x >= rightBound) {
+              enemy.x = rightBound;
+              enemy.sweetykinsChargeDirection = -1;
+              bounced = true;
+            }
+            if (bounced) {
+              enemy.sweetykinsChargesRemaining -= 1;
+              if (enemy.sweetykinsChargesRemaining <= 0) {
+                enemy.sweetykinsMode = 'assault';
+                enemy.sweetykinsHitsRemaining = rand(2, 4);
+                enemy.cooldown = Math.min(enemy.cooldown, 10);
+              }
+            }
           } else {
-            const closeDistance = 100;
-            if (distance > closeDistance) {
-              enemy.x += Math.sign(dx) * moveSpeed * 0.9;
-              enemy.y += Math.sign(dy) * moveSpeed * 0.45;
+            if (distance > enemy.range * 0.92 && !rectsOverlap(enemyBody, playerBody)) {
+              enemy.x += Math.sign(dx) * moveSpeed * 1.05;
+              enemy.y += Math.sign(dy) * moveSpeed * 0.6;
               enemy.isMoving = true;
+            } else if (enemy.windup <= 0 && enemy.cooldown <= 0) {
+              enemy.windup = 9;
+              enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
             }
           }
         } else if (enemy.type === 'mud-monster' && enemy.isBoss && enemy.stage < 3 && state.levelIndex === 0) {
@@ -4554,7 +4590,18 @@
               };
               if (rectsOverlap(meleeZone, playerAttackBody) || rectsOverlap(enemyAttackBody, playerAttackBody)) damagePlayer(enemy.damage, enemy);
             }
-            enemy.cooldown = rand(40, 80);
+            let attackRecoveryCooldown = rand(40, 80);
+            if (enemy.type === 'sweetykins' && enemy.sweetykinsMode === 'assault') {
+              enemy.sweetykinsHitsRemaining = Math.max(0, (enemy.sweetykinsHitsRemaining || 0) - 1);
+              attackRecoveryCooldown = rand(14, 24);
+              if (enemy.sweetykinsHitsRemaining <= 0) {
+                enemy.sweetykinsMode = 'charge';
+                enemy.sweetykinsChargesRemaining = rand(4, 6);
+                enemy.sweetykinsChargeDirection = enemy.facing || (Math.random() < 0.5 ? -1 : 1);
+                attackRecoveryCooldown = rand(14, 26);
+              }
+            }
+            enemy.cooldown = attackRecoveryCooldown;
             if (enemy.type === 'daphodilus' && enemy.aiState === 'PopAttack') {
               setEnemyState(enemy, 'Approach');
               enemy.burrowCooldown = 300;


### PR DESCRIPTION
### Motivation
- Make Sweetykins' hits less punishing for characters around the end of stage 2 by lowering base damage. 
- Replace the previous dash with a more interesting two-phase boss pattern: rapid back-and-forth charging that damages by contact, then a short close-range assault using attack animations.
- Keep the charge visuals distinct from attack animations so the charge looks like a fast run (waking/idle frames) rather than a normal walk/attack.

### Description
- Lowered Sweetykins base damage in `enemyTypes.sweetykins` from `19` to `13`.
- Replaced the old dash logic with a new two-mode behavior in the enemy update loop for `enemy.type === 'sweetykins'`: a `charge` mode that runs back-and-forth across the screen and deals contact damage, and an `assault` mode that closes on the player and performs several melee swings using `windup`/`attackAnimTimer`.
- Added per-enemy state fields: `sweetykinsMode`, `sweetykinsChargesRemaining`, `sweetykinsHitsRemaining`, `sweetykinsRunHitCooldown`, and `sweetykinsChargeDirection` to control mode transitions, counts, and hit cooldowns.
- Implemented a `forceIdleAnimation` flag checked in `updateEnemyAnimation` so the charge-phase can force the idle/waking animation while still moving.
- Adjusted attack recovery cooldown logic so assault swings have shorter recovery (`rand(14,24)`) and the boss cycles back to charge mode after finishing its assault hits.
- All changes are contained in `bayou-brawlers/index.html` (behavior, tuning, and animation hook updates).

### Testing
- Ran the project's test suite with `npm test -- --runInBand`, and all tests passed (`3` test suites, `6` tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6782fae70832980f8f3f20ecfc0ec)