### PR TITLE
Make Rustbucket shrapnel burst animation oval

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3456,8 +3456,10 @@
         y: originY,
         timer: 16,
         radius: 14,
+        radiusYRatio: 0.62,
         type: 'projectile-burst',
-        color: 'rgba(255, 224, 160, 0.95)'
+        color: 'rgba(255, 224, 160, 0.95)',
+        oval: true
       });
     }
 
@@ -6174,7 +6176,14 @@
         if (effect.type === 'projectile-burst') {
           ctx.strokeStyle = effect.color || 'rgba(255,205,150,0.9)';
           ctx.beginPath();
-          ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY, effect.radius * (effect.timer / 16), 0, Math.PI * 2);
+          const progress = effect.timer / 16;
+          const radiusX = effect.radius * progress;
+          if (effect.oval) {
+            const radiusY = radiusX * (effect.radiusYRatio || 0.62);
+            ctx.ellipse(effect.x - state.cameraX, effect.y - state.cameraY, radiusX, radiusY, 0, 0, Math.PI * 2);
+          } else {
+            ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY, radiusX, 0, Math.PI * 2);
+          }
           ctx.stroke();
         }
         if (effect.type === 'sprinkle') {


### PR DESCRIPTION
### Motivation
- Make Rustbucket’s Shrapnel Protocol burst animation render as an oval AOE to match the intended visual style for that special attack and improve clarity of the effect on-screen.

### Description
- Added `oval: true` and `radiusYRatio: 0.62` to the Rustbucket shrapnel burst effect payload in `bayou-brawlers/index.html` so the effect is flagged as oval when spawned.
- Updated the `projectile-burst` renderer to compute `progress` and `radiusX` and to draw an ellipse with `ctx.ellipse(...)` when `effect.oval` is present, while preserving the circular `ctx.arc(...)` path for non-oval bursts.
- Kept all gameplay/damage logic unchanged by only modifying effect payload fields and the visual rendering code in `projectile-burst` handling.

### Testing
- Ran `git diff --check` and confirmed there were no whitespace/errors in the patch (success).
- Ran `git status --short` to confirm the working tree is clean after the change (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68b0b9a2483298d255470517c4594)