### PR TITLE
Make Rustbucket shrapnel burst animation oval

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3456,6 +3456,7 @@
         y: originY,
         timer: 16,
         radius: 14,
+        radiusYRatio: 0.62,
         type: 'projectile-burst',
         color: 'rgba(255, 224, 160, 0.95)'
       });
@@ -6174,7 +6175,14 @@
         if (effect.type === 'projectile-burst') {
           ctx.strokeStyle = effect.color || 'rgba(255,205,150,0.9)';
           ctx.beginPath();
-          ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY, effect.radius * (effect.timer / 16), 0, Math.PI * 2);
+          const radiusX = effect.radius * (effect.timer / 16);
+          const radiusYRatio = effect.radiusYRatio || 1;
+          const radiusY = radiusX * radiusYRatio;
+          if (radiusYRatio === 1) {
+            ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY, radiusX, 0, Math.PI * 2);
+          } else {
+            ctx.ellipse(effect.x - state.cameraX, effect.y - state.cameraY, radiusX, radiusY, 0, 0, Math.PI * 2);
+          }
           ctx.stroke();
         }
         if (effect.type === 'sprinkle') {


### PR DESCRIPTION
### Motivation
- Make Rustbucket’s Shrapnel Protocol burst visuals match an oval AoE instead of always drawing a circle to better reflect design intent for the burst animation.

### Description
- Add a `radiusYRatio` property (`0.62`) to the `projectile-burst` effect spawned by `spawnRustbucketShrapnelProjectiles` in `bayou-brawlers/index.html` so that the burst can be rendered with a compressed Y axis.
- Update the `projectile-burst` renderer to compute `radiusX = effect.radius * (effect.timer / 16)` and `radiusY = radiusX * (effect.radiusYRatio || 1)` and to draw an ellipse with `ctx.ellipse` when `radiusYRatio !== 1`, while using `ctx.arc` for the default circular case.
- Preserve existing behavior for other burst effects by falling back to the circular rendering when `radiusYRatio` is not provided.

### Testing
- Ran a code search `rg -n "radiusYRatio|projectile-burst" bayou-brawlers/index.html` to verify the new property and the updated rendering code were added and located in the expected places, which succeeded.
- Inspected the modified regions in `bayou-brawlers/index.html` to confirm the `radiusYRatio` insertion at the shrapnel spawn and the ellipse/circle branching in the renderer, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c749dac483298edf83afc13e9ed9)