### PR TITLE
Make Rustbucket shrapnel burst a wide oval

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3455,7 +3455,8 @@
         x: originX,
         y: originY,
         timer: 16,
-        radius: 14,
+        radiusX: 34,
+        radiusY: 11,
         type: 'projectile-burst',
         color: 'rgba(255, 224, 160, 0.95)'
       });
@@ -6172,9 +6173,16 @@
           ctx.restore();
         }
         if (effect.type === 'projectile-burst') {
+          const progress = effect.timer / 16;
+          const radiusX = (effect.radiusX || effect.radius || 12) * progress;
+          const radiusY = (effect.radiusY || effect.radius || 12) * progress;
           ctx.strokeStyle = effect.color || 'rgba(255,205,150,0.9)';
           ctx.beginPath();
-          ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY, effect.radius * (effect.timer / 16), 0, Math.PI * 2);
+          if (effect.radiusX || effect.radiusY) {
+            ctx.ellipse(effect.x - state.cameraX, effect.y - state.cameraY, radiusX, radiusY, 0, 0, Math.PI * 2);
+          } else {
+            ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY, radiusX, 0, Math.PI * 2);
+          }
           ctx.stroke();
         }
         if (effect.type === 'sprinkle') {


### PR DESCRIPTION
### Motivation
- Make Rustbucket’s Shrapnel Protocol burst animation reflect an oval AoE that is much wider than it is tall so shrapnel travels farther left/right than up/down.

### Description
- Emit the projectile-burst effect with separate horizontal/vertical radii by adding `radiusX: 34` and `radiusY: 11` to the Rustbucket shrapnel burst payload.
- Update the `projectile-burst` renderer to support ellipses by reading `radiusX`/`radiusY` and falling back to the existing `radius` for legacy circular bursts.
- Scale the rendered radii by `effect.timer / 16` to preserve the existing burst growth animation.
- Preserve existing behavior for all other effects that only provide `radius` so no other visuals change.

### Testing
- Ran a file diff check with `git diff --check`, which produced no issues.
- Performed a smoke JavaScript parse attempt using `node -e "..."` to validate inline script execution, which failed due to HTML/script extraction assumptions rather than the code edits themselves.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cefd173c8329a6d23d02a65defc3)