### PR TITLE
Rustbucket shrapnel: cloud-style burst with momentum falloff

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3451,13 +3451,56 @@
           hitEnemyUids: excludeEnemyUid ? [excludeEnemyUid] : []
         });
       }
+      spawnRustbucketShrapnelBurst(originX, originY, {
+        shardCount: Math.max(22, Math.floor(shardCount * 2.2)),
+        speedMin: 3.8,
+        speedMax: 10.2,
+        timer: 30,
+        gravity: 0.26,
+        drag: 0.84,
+        lengthMin: 7,
+        lengthMax: 20,
+        thicknessMin: 1.2,
+        thicknessMax: 2.9
+      });
+    }
+
+    function spawnRustbucketShrapnelBurst(x, y, options = null) {
+      const shardCount = options?.shardCount || 20;
+      const timer = options?.timer || 24;
+      const gravity = options?.gravity ?? 0.22;
+      const drag = options?.drag ?? 0.86;
+      const spread = options?.spread ?? 0.2;
+      const speedMin = options?.speedMin || 3.2;
+      const speedMax = options?.speedMax || 8.6;
+      const groundY = options?.groundY || BRAWL_LANE_MAX_Y - rand(2, 10);
+      const pieces = [];
+      for (let i = 0; i < shardCount; i += 1) {
+        const angle = ((Math.PI * 2 * i) / shardCount) + rand(-spread, spread);
+        const speed = rand(speedMin, speedMax);
+        pieces.push({
+          x: x + rand(-2, 2),
+          y: y + rand(-2, 2),
+          vx: Math.cos(angle) * speed,
+          vy: Math.sin(angle) * speed,
+          len: rand(options?.lengthMin || 6, options?.lengthMax || 15),
+          thickness: rand(options?.thicknessMin || 1.1, options?.thicknessMax || 2.4),
+          rotation: rand(0, Math.PI * 2),
+          spin: rand(-0.28, 0.28),
+          alpha: rand(0.65, 1),
+          dead: false
+        });
+      }
       state.effects.push({
-        x: originX,
-        y: originY,
-        timer: 16,
-        radius: 14,
-        type: 'projectile-burst',
-        color: 'rgba(255, 224, 160, 0.95)'
+        type: 'rustbucket-shrapnel-burst',
+        x,
+        y,
+        timer,
+        maxTimer: timer,
+        gravity,
+        drag,
+        groundY,
+        pieces
       });
     }
 
@@ -4688,8 +4731,19 @@
             projectile.vy = clamp(projectile.vy, -4.2, 4.2);
           }
         }
+        if (projectile.shrapnel) {
+          projectile.vx *= 0.92;
+          projectile.vy = (projectile.vy || 0) * 0.9 + 0.24;
+        }
         projectile.x += projectile.vx;
         projectile.y += projectile.vy || 0;
+        if (projectile.shrapnel) {
+          const groundY = BRAWL_LANE_MAX_Y - 4;
+          if (projectile.y >= groundY) {
+            projectile.y = groundY;
+            projectile.life = 0;
+          }
+        }
         projectile.life -= 1;
 
         if (projectile.trailEvery && projectile.life % projectile.trailEvery === 0) {
@@ -4774,6 +4828,23 @@
             projectile.life = 0;
           }
         }
+        if (projectile.shrapnel && projectile.life <= 0 && !projectile.impactBurstSpawned) {
+          projectile.impactBurstSpawned = true;
+          spawnRustbucketShrapnelBurst(projectile.x, projectile.y, {
+            shardCount: rand(8, 12),
+            speedMin: 1.2,
+            speedMax: 4.2,
+            timer: 16,
+            gravity: 0.28,
+            drag: 0.78,
+            lengthMin: 4,
+            lengthMax: 10,
+            thicknessMin: 0.9,
+            thicknessMax: 1.8,
+            spread: 0.5,
+            groundY: BRAWL_LANE_MAX_Y - rand(2, 8)
+          });
+        }
       });
       state.projectiles = state.projectiles.filter(projectile => projectile.life > 0);
     }
@@ -4822,6 +4893,23 @@
           effect.vy = (effect.vy || 0) * 0.92 + (effect.driftY || 0);
           effect.size += effect.growth || 0;
           effect.alpha = Math.max(0, (effect.alpha || 0) * 0.98);
+        }
+        if (effect.type === 'rustbucket-shrapnel-burst') {
+          const groundY = effect.groundY || BRAWL_LANE_MAX_Y - 4;
+          (effect.pieces || []).forEach(piece => {
+            if (piece.dead) return;
+            piece.vx *= effect.drag || 0.86;
+            piece.vy = (piece.vy * (effect.drag || 0.86)) + (effect.gravity || 0.22);
+            piece.x += piece.vx;
+            piece.y += piece.vy;
+            piece.rotation += piece.spin || 0;
+            piece.alpha *= 0.94;
+            if (piece.y >= groundY) {
+              piece.y = groundY;
+              piece.dead = true;
+              piece.alpha *= 0.5;
+            }
+          });
         }
         if (effect.type === 'emergency-venting') {
           const owner = effect.owner;
@@ -6176,6 +6264,40 @@
           ctx.beginPath();
           ctx.arc(effect.x - state.cameraX, effect.y - state.cameraY, effect.radius * (effect.timer / 16), 0, Math.PI * 2);
           ctx.stroke();
+        }
+        if (effect.type === 'rustbucket-shrapnel-burst') {
+          const maxTimer = Math.max(1, effect.maxTimer || 1);
+          const lifePct = clamp(effect.timer / maxTimer, 0, 1);
+          const flareAlpha = (1 - lifePct) * 0.4;
+          const centerX = effect.x - state.cameraX;
+          const centerY = effect.y - state.cameraY;
+
+          ctx.save();
+          ctx.globalCompositeOperation = 'lighter';
+          if (flareAlpha > 0.01) {
+            const glow = ctx.createRadialGradient(centerX, centerY, 0, centerX, centerY, 26 + (1 - lifePct) * 18);
+            glow.addColorStop(0, `rgba(255, 245, 205, ${flareAlpha})`);
+            glow.addColorStop(1, 'rgba(255, 245, 205, 0)');
+            ctx.fillStyle = glow;
+            ctx.beginPath();
+            ctx.arc(centerX, centerY, 26 + (1 - lifePct) * 18, 0, Math.PI * 2);
+            ctx.fill();
+          }
+          (effect.pieces || []).forEach(piece => {
+            if ((piece.alpha || 0) <= 0.02) return;
+            const px = piece.x - state.cameraX;
+            const py = piece.y - state.cameraY;
+            const len = (piece.len || 8) * (0.6 + lifePct * 0.6);
+            const thickness = Math.max(0.6, (piece.thickness || 1.2) * (0.7 + lifePct * 0.5));
+            const colorAlpha = clamp((piece.alpha || 0) * (0.35 + lifePct * 0.85), 0, 1);
+            ctx.save();
+            ctx.translate(px, py);
+            ctx.rotate(piece.rotation || 0);
+            ctx.fillStyle = `rgba(255, 219, 138, ${colorAlpha})`;
+            ctx.fillRect(-len * 0.5, -thickness * 0.5, len, thickness);
+            ctx.restore();
+          });
+          ctx.restore();
         }
         if (effect.type === 'sprinkle') {
           ctx.fillStyle = effect.color || 'rgba(200,255,220,0.9)';


### PR DESCRIPTION
### Motivation
- Make Rustbucket’s `shrapnel-protocol` visual match a large cloud of shrapnel pieces that quickly lose momentum and settle on the ground or hit enemies before disappearing.

### Description
- Replaced the simple `projectile-burst` ring used for Rustbucket shrapnel with a dedicated `rustbucket-shrapnel-burst` effect that spawns many shard pieces with per-piece velocity, rotation, alpha, length, and thickness. 
- Added `spawnRustbucketShrapnelBurst(x,y,options)` to create and manage the shrapnel cloud and updated `spawnRustbucketShrapnelProjectiles` to call it with tuned counts and parameters. 
- Changed shrapnel projectile physics to apply drag + downward velocity, settle to lane ground (`BRAWL_LANE_MAX_Y`) and die on impact, and spawn a smaller impact burst when a shard expires or hits. 
- Implemented update and draw logic for the new effect (drag, gravity, ground settling, glow flare, piece rendering) inside `updateEffects` and the main draw loop.

### Testing
- Extracted the embedded game script with a Python helper and ran `node --check /tmp/bayou-main.js` to verify syntax, which succeeded. 
- Ran `git diff --check` to verify no patch formatting issues, which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6ff61f7908329990ccb1e8793b22a)