### PR TITLE
Raise Rustbucket shrapnel impact burst by 10px

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4830,7 +4830,7 @@
         }
         if (projectile.shrapnel && projectile.life <= 0 && !projectile.impactBurstSpawned) {
           projectile.impactBurstSpawned = true;
-          spawnRustbucketShrapnelBurst(projectile.x, projectile.y, {
+          spawnRustbucketShrapnelBurst(projectile.x, projectile.y - 10, {
             shardCount: rand(8, 12),
             speedMin: 1.2,
             speedMax: 4.2,


### PR DESCRIPTION
### Motivation
- The end-of-life shrapnel impact effect for Rustbucket should appear slightly higher so the small explosion visuals line up better with the enemy hit location.

### Description
- Change the spawn position call from `spawnRustbucketShrapnelBurst(projectile.x, projectile.y, ...)` to `spawnRustbucketShrapnelBurst(projectile.x, projectile.y - 10, ...)` in `bayou-brawlers/index.html` so the burst is rendered 10px higher.

### Testing
- Ran `git diff --check` to verify there are no whitespace or diff issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c70d3445308329b9d783d8b18d3a64)