### PR TITLE
Raise Rustbucket shrapnel burst origin to enemy mid-body

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4984,7 +4984,9 @@
                 && effect.shrapnelSource
               ) {
                 const enemyBody = getEnemyHitbox(enemy);
-                const shrapnelOriginY = enemyBody.y + (enemyBody.height * 0.45);
+                const ownerBody = getPhysicsBody(effect.owner);
+                const extraLift = ownerBody.height * 0.5;
+                const shrapnelOriginY = enemyBody.y + (enemyBody.height * 0.45) - extraLift;
                 spawnRustbucketShrapnelProjectiles(effect.owner, enemy.x, shrapnelOriginY, effect.damage, {
                   excludeEnemyUid: enemy.uid,
                   shardCount: effect.shrapnelSource === 'super-special' ? 12 : 9,

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4983,7 +4983,9 @@
                 && effect.owner.charData.id === 'rustbucket'
                 && effect.shrapnelSource
               ) {
-                spawnRustbucketShrapnelProjectiles(effect.owner, enemy.x, enemy.y - 16, effect.damage, {
+                const enemyBody = getEnemyHitbox(enemy);
+                const shrapnelOriginY = enemyBody.y + (enemyBody.height * 0.45);
+                spawnRustbucketShrapnelProjectiles(effect.owner, enemy.x, shrapnelOriginY, effect.damage, {
                   excludeEnemyUid: enemy.uid,
                   shardCount: effect.shrapnelSource === 'super-special' ? 12 : 9,
                   damageScale: effect.shrapnelSource === 'super-special' ? 0.25 : 0.2


### PR DESCRIPTION
### Motivation
- Move the final mini-explosions produced by Rustbucket's Shrapnel Protocol higher on the struck enemy (closer to the enemy’s mid-body) so the visuals read better.

### Description
- Replace the hardcoded spawn Y (`enemy.y - 16`) with a hitbox-derived Y using `getEnemyHitbox(enemy)` and `shrapnelOriginY = enemyBody.y + (enemyBody.height * 0.45)` when calling `spawnRustbucketShrapnelProjectiles` in `bayou-brawlers/index.html` for shock-triggered hits.

### Testing
- No automated tests were run for this single-coordinate visual/gameplay tweak.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c711878518832988a4477e12d7d24f)