### PR TITLE
Align Rustbucket shrapnel burst to enemy bottom edge

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3427,6 +3427,7 @@
       const lifeMax = options?.lifeMax || 42;
       const damageScale = options?.damageScale || 0.24;
       const excludeEnemyUid = options?.excludeEnemyUid || null;
+      const burstBottomY = Number.isFinite(options?.burstBottomY) ? options.burstBottomY : null;
       const shrapnelDamage = Math.max(2, baseDamage * damageScale);
       for (let i = 0; i < shardCount; i += 1) {
         const angle = ((Math.PI * 2 * i) / shardCount) + rand(-0.22, 0.22);
@@ -3461,7 +3462,8 @@
         lengthMin: 7,
         lengthMax: 20,
         thicknessMin: 1.2,
-        thicknessMax: 2.9
+        thicknessMax: 2.9,
+        y: burstBottomY !== null ? (burstBottomY - 18) : originY
       });
     }
 
@@ -3491,10 +3493,11 @@
           dead: false
         });
       }
+      const burstY = Number.isFinite(options?.y) ? options.y : y;
       state.effects.push({
         type: 'rustbucket-shrapnel-burst',
         x,
-        y,
+        y: burstY,
         timer,
         maxTimer: timer,
         gravity,
@@ -4771,7 +4774,8 @@
                 spawnRustbucketShrapnelProjectiles(state.player, projectile.x, projectile.y, projectile.damage, {
                   excludeEnemyUid: enemy.uid,
                   shardCount: projectile.attackKind === 'super-special' ? 12 : 9,
-                  damageScale: projectile.attackKind === 'heavy' ? 0.24 : 0.2
+                  damageScale: projectile.attackKind === 'heavy' ? 0.24 : 0.2,
+                  burstBottomY: enemy.y
                 });
               }
               if (projectile.hitEnemyUids) projectile.hitEnemyUids.push(enemy.uid);
@@ -4986,7 +4990,8 @@
                 spawnRustbucketShrapnelProjectiles(effect.owner, enemy.x, enemy.y - 16, effect.damage, {
                   excludeEnemyUid: enemy.uid,
                   shardCount: effect.shrapnelSource === 'super-special' ? 12 : 9,
-                  damageScale: effect.shrapnelSource === 'super-special' ? 0.25 : 0.2
+                  damageScale: effect.shrapnelSource === 'super-special' ? 0.25 : 0.2,
+                  burstBottomY: enemy.y
                 });
               }
               enemy.x += Math.sign(enemy.x - effect.x) * (effect.knockback || 0);


### PR DESCRIPTION
### Motivation
- Make the little explosion VFX from Rustbucket's shrapnel-protocol appear visually anchored to the enemy that triggered them by aligning the bottom edge of the burst with the bottom of the enemy animation.

### Description
- Added an optional `burstBottomY` override to `spawnRustbucketShrapnelProjectiles` and convert it into a burst Y when calling `spawnRustbucketShrapnelBurst` so callers can request baseline-aligned bursts.
- Updated `spawnRustbucketShrapnelBurst` to honor an optional `options.y` override (used as the burst center Y) while preserving the existing behavior when no override is supplied.
- Wired both rustbucket trigger paths (projectile impact and `shock`/super-special shock handling) to pass `burstBottomY: enemy.y` so bursts are positioned relative to the triggering enemy.
- Kept defaults intact so existing calls that do not pass the new option behave exactly as before.

### Testing
- Ran `git diff -- bayou-brawlers/index.html` to inspect changes and it reported the expected diff (success).
- Ran `git status --short` to confirm the working tree changes (success).
- Committed the change with `git commit -m "Align Rustbucket shrapnel burst explosions to enemy baseline"` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c72c58758c832989bb52c79ed60731)