### PR TITLE
Bayou Brawlers: make rustbucket shrapnel impact burst 50% when Shrapnel Protocol is active

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4834,20 +4834,27 @@
         }
         if (projectile.shrapnel && projectile.life <= 0 && !projectile.impactBurstSpawned) {
           projectile.impactBurstSpawned = true;
-          spawnRustbucketShrapnelBurst(projectile.x, projectile.y, {
-            shardCount: rand(8, 12),
-            speedMin: 1.2,
-            speedMax: 4.2,
-            timer: 16,
-            gravity: 0.28,
-            drag: 0.78,
-            lengthMin: 4,
-            lengthMax: 10,
-            thicknessMin: 0.9,
-            thicknessMax: 1.8,
-            spread: 0.5,
-            groundY: BRAWL_LANE_MAX_Y - rand(2, 8)
-          });
+          const shrapnelProtocolActive = Boolean(
+            player
+            && projectile.ownerId === 'rustbucket'
+            && hasUpgrade(player, 'shrapnel-protocol')
+          );
+          if (!shrapnelProtocolActive || Math.random() < 0.5) {
+            spawnRustbucketShrapnelBurst(projectile.x, projectile.y, {
+              shardCount: rand(8, 12),
+              speedMin: 1.2,
+              speedMax: 4.2,
+              timer: 16,
+              gravity: 0.28,
+              drag: 0.78,
+              lengthMin: 4,
+              lengthMax: 10,
+              thicknessMin: 0.9,
+              thicknessMax: 1.8,
+              spread: 0.5,
+              groundY: BRAWL_LANE_MAX_Y - rand(2, 8)
+            });
+          }
         }
       });
       state.projectiles = state.projectiles.filter(projectile => projectile.life > 0);


### PR DESCRIPTION
### Motivation
- Reduce the frequency of the shrapnel "explosion" (impact burst) when Rustbucket's Shrapnel Protocol upgrade is active so the secondary visual/particle bursts occur only half the time while preserving existing behavior otherwise.

### Description
- Introduced a `shrapnelProtocolActive` boolean check in `bayou-brawlers/index.html` around shrapnel impact handling to detect `player`, `projectile.ownerId === 'rustbucket'`, and `hasUpgrade(player, 'shrapnel-protocol')`.
- Gate the call to `spawnRustbucketShrapnelBurst` so that when the protocol is active the burst only spawns if `Math.random() < 0.5`, and still spawns normally when the protocol is not active.
- No other projectile or burst parameters were changed; the change only affects the chance that the impact burst is spawned.

### Testing
- Ran `git status --short` to verify the file was modified and `git diff -- bayou-brawlers/index.html` to inspect the applied change, and both commands completed successfully.
- No automated gameplay tests were available in this rollout; verification was limited to code inspection and diff validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74f7cbe8c8329bce1f15675204b52)