### PR TITLE
Rustbucket: 50% proc chance for shrapnel-protocol

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3420,7 +3420,7 @@
 
     function spawnRustbucketShrapnelProjectiles(player, originX, originY, baseDamage, options = null) {
       if (!player || player.charData.id !== 'rustbucket' || !hasUpgrade(player, 'shrapnel-protocol')) return;
-      const procChance = options?.procChance ?? 0.5;
+      const procChance = options?.procChance ?? 0.25;
       if (Math.random() >= procChance) return;
       const shardCount = options?.shardCount || 10;
       const speedMin = options?.speedMin || 4.2;

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3420,6 +3420,8 @@
 
     function spawnRustbucketShrapnelProjectiles(player, originX, originY, baseDamage, options = null) {
       if (!player || player.charData.id !== 'rustbucket' || !hasUpgrade(player, 'shrapnel-protocol')) return;
+      const procChance = options?.procChance ?? 0.5;
+      if (Math.random() >= procChance) return;
       const shardCount = options?.shardCount || 10;
       const speedMin = options?.speedMin || 4.2;
       const speedMax = options?.speedMax || 7.6;


### PR DESCRIPTION
### Motivation
- Make Rustbucket's `shrapnel-protocol` only trigger about half the time on eligible hits so shrapnel bursts sometimes do not occur.

### Description
- Added a `procChance` option (read as `options?.procChance`) with a default value of `0.5` to `spawnRustbucketShrapnelProjectiles` and early-return when `Math.random() >= procChance` to implement the 50% proc behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7660f005c832988aae92db23c8684)