### PR TITLE
Limit Rustbucket piercing shot to 2 penetrations with 50% per-penetration damage falloff

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3413,6 +3413,8 @@
         ricochetRemaining: id === 'rustbucket' && hasUpgrade(player, 'ricochet-logic') ? RUSTBUCKET_RICOCHET_MAX_BOUNCES : 0,
         attackKind: heavy ? 'heavy' : 'basic',
         passThroughEnemies: id === 'rustbucket' && heavy && hasUpgrade(player, 'piercing-shot'),
+        penetrationsRemaining: id === 'rustbucket' && heavy && hasUpgrade(player, 'piercing-shot') ? 2 : 0,
+        penetrationDamageMultiplier: 1,
         hitEnemyUids: []
       };
       state.projectiles.push(projectile);
@@ -4767,7 +4769,8 @@
               projectile.y > enemyBody.y &&
               projectile.y < enemyBody.y + enemyBody.height
             ) {
-              damageEnemy(enemy, projectile.damage, 20);
+              const projectileDamage = projectile.damage * (projectile.penetrationDamageMultiplier || 1);
+              damageEnemy(enemy, projectileDamage, 20);
               if (
                 projectile.ownerId === 'rustbucket'
                 && !projectile.shrapnel
@@ -4819,7 +4822,12 @@
                   });
                 }
               }
-              if (!projectile.passThroughEnemies) projectile.life = 0;
+              if (projectile.passThroughEnemies && (projectile.penetrationsRemaining || 0) > 0) {
+                projectile.penetrationsRemaining -= 1;
+                projectile.penetrationDamageMultiplier = (projectile.penetrationDamageMultiplier || 1) * 0.5;
+              } else {
+                projectile.life = 0;
+              }
             }
           });
         } else if (player) {


### PR DESCRIPTION
### Motivation
- Cap Rustbucket heavy piercing shots so a single bullet can hit at most three enemies total (two penetrations) and make each successive penetration deal 50% less damage to avoid overpowered multi-hit scaling.

### Description
- Add two per-projectile fields in `spawnPlayerAttackProjectile`: `penetrationsRemaining` (set to `2` for Rustbucket heavy shots with `piercing-shot`) and `penetrationDamageMultiplier` (initialized to `1`).
- Use `projectile.penetrationDamageMultiplier` when dealing damage so hit damage is computed as `projectile.damage * (projectile.penetrationDamageMultiplier || 1)`.
- When a piercing projectile passes through an enemy, decrement `penetrationsRemaining` and multiply `penetrationDamageMultiplier` by `0.5`, and otherwise end the projectile by setting `projectile.life = 0`.

### Testing
- Ran `npm test -- --runInBand`, and all test suites passed (3 test suites, 6 tests) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c76d5c437483298720e147ad704358)