### PR TITLE
Double Delving Daphodilus size and hitbox on Level 1

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1411,6 +1411,7 @@
       sidewinder: 3,
       stingy: 3
     };
+    const LEVEL_ONE_DAPHODILUS_SCALE_MULTIPLIER = 2;
 
     function toAssetCamelCase(value) {
       if (!value) return '';
@@ -2083,6 +2084,8 @@
       const stage = STAGED_ENEMY_TYPES.has(typeId) ? (options.stage || 3) : 1;
       const stats = STAGED_ENEMY_TYPES.has(typeId) ? getStagedStats(typeId, stage) : base;
       const animationTracks = assets.enemyAnimations[typeId] || assets.enemyAnimations.swamp || null;
+      const isLevelOneDaphodilus = typeId === 'daphodilus' && state.levelIndex === 0;
+      const levelOneDaphodilusScale = isLevelOneDaphodilus ? LEVEL_ONE_DAPHODILUS_SCALE_MULTIPLIER : 1;
       const enemy = {
         uid: ++state.enemyUid,
         type: typeId,
@@ -2116,8 +2119,8 @@
         stunRetargetTimer: rand(8, 18),
         ranged: base.ranged || false,
         isBoss,
-        renderScale: getEnemyRenderScale(typeId, stage, isBoss),
-        physicsProfileId: `enemy-${typeId}`,
+        renderScale: getEnemyRenderScale(typeId, stage, isBoss) * levelOneDaphodilusScale,
+        physicsProfileId: isLevelOneDaphodilus ? 'enemy-daphodilus-level1' : `enemy-${typeId}`,
         targetBodyAimBias: rand(35, 85) / 100,
         invulnFrames: options.invulnFrames || 0,
         spawnFadeFrames: options.spawnFadeFrames || 0,
@@ -7144,6 +7147,9 @@
           : createDirectionalAnimationTracks(config.states, ({ stateName, facingName, img, frames }) => {
             if (stateName === 'idle' && facingName === 'left') {
               createPhysicsProfile(config.profileId, img, frames[0], ENEMY_DRAW_SIZE * config.sizeMultiplier);
+              if (enemyKey === 'daphodilus') {
+                createPhysicsProfile('enemy-daphodilus-level1', img, frames[0], ENEMY_DRAW_SIZE * config.sizeMultiplier * LEVEL_ONE_DAPHODILUS_SCALE_MULTIPLIER);
+              }
               if (config.bossProfileId) {
                 createPhysicsProfile(config.bossProfileId, img, frames[0], BOSS_DRAW_SIZE * BOSS_RENDER_SCALE_MULTIPLIER);
               }


### PR DESCRIPTION
### Motivation
- Make Delving Daphodilus in level 1 visually larger and ensure its physics/hitbox match the new visual size.

### Description
- Add `LEVEL_ONE_DAPHODILUS_SCALE_MULTIPLIER` and apply it when creating a `daphodilus` with `state.levelIndex === 0` so the `renderScale` is doubled. 
- Select a dedicated physics profile (`enemy-daphodilus-level1`) for level-1 Daphodilus during enemy creation so collision geometry matches the scaled sprite. 
- Create the enlarged physics profile during enemy animation/profile setup by calling `createPhysicsProfile('enemy-daphodilus-level1', ...)` with the scaled draw size.

### Testing
- Ran `git diff --check` to validate patch formatting and found no issues (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c770dde3348329bedb318fbce387e8)