### PR TITLE
Scale level 1 Daphodilus size and hitbox by 1.5x

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1477,6 +1477,11 @@
       return isBoss ? BOSS_RENDER_SCALE_MULTIPLIER : 1;
     }
 
+    function getDaphodilusLevelOneScale(typeId) {
+      if (typeId !== 'daphodilus') return 1;
+      return state.levelIndex === 0 ? 1.5 : 1;
+    }
+
     function countUndergroundDaphodilus() {
       return state.enemies.filter(e => e.hp > 0 && e.type === 'daphodilus' && e.aiState === 'Underground').length;
     }
@@ -1738,11 +1743,14 @@
 
     function getPhysicsBody(entity) {
       const profile = getPhysicsProfile(entity.physicsProfileId);
+      const hitboxScale = entity.hitboxScale || 1;
+      const width = profile.width * hitboxScale;
+      const height = profile.height * hitboxScale;
       return {
-        x: entity.x + profile.centerOffsetX - (profile.width / 2),
-        y: entity.y - profile.footOffsetY - profile.height,
-        width: profile.width,
-        height: profile.height
+        x: entity.x + profile.centerOffsetX - (width / 2),
+        y: entity.y - profile.footOffsetY - height,
+        width,
+        height
       };
     }
 
@@ -2116,7 +2124,8 @@
         stunRetargetTimer: rand(8, 18),
         ranged: base.ranged || false,
         isBoss,
-        renderScale: getEnemyRenderScale(typeId, stage, isBoss),
+        renderScale: getEnemyRenderScale(typeId, stage, isBoss) * getDaphodilusLevelOneScale(typeId),
+        hitboxScale: getDaphodilusLevelOneScale(typeId),
         physicsProfileId: `enemy-${typeId}`,
         targetBodyAimBias: rand(35, 85) / 100,
         invulnFrames: options.invulnFrames || 0,


### PR DESCRIPTION
### Motivation
- Increase the visual size and collision hitbox of the Delving Daphodilus on level 1 so the enemy appears larger and has a matching hitbox in that stage.

### Description
- Added `getDaphodilusLevelOneScale` which returns `1.5` when `state.levelIndex === 0` and `1` otherwise to make the scale level-aware.
- Applied the multiplier to the enemy `renderScale` when creating enemies by updating the `renderScale` assignment in `createEnemy` to multiply by `getDaphodilusLevelOneScale(typeId)`.
- Added a new `hitboxScale` property to enemies and updated `getPhysicsBody` to use `entity.hitboxScale` to scale physics `width`/`height` and position, so the enlarged sprite has a proportionally larger hitbox.
- Change is scoped to the `daphodilus` enemy type and only affects level 1 behavior; other enemies are unchanged.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and it succeeded.
- Verified repository status with `git status --short` and committed the change with a descriptive message, both succeeding.
- No in-game runtime screenshots or automated game tests were available in this environment, so gameplay validation should be performed in a local browser to confirm visual and collision behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c772399ce883299b57644d5a945fdb)