### PR TITLE
Limit Bayou Brawlers backtracking to half-screen progress

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2510,7 +2510,19 @@
     function getBacktrackPlayerMinX() {
       const halfScreenBacktrack = canvas.width * 0.5;
       const minFromProgress = state.lastForwardX - halfScreenBacktrack;
-      return clamp(minFromProgress, 40, state.levelWidth - 40);
+      let minFromLootOrBodies = minFromProgress;
+
+      state.pickups.forEach(pickup => {
+        if (!pickup || pickup.timer <= 0) return;
+        minFromLootOrBodies = Math.min(minFromLootOrBodies, pickup.x - 28);
+      });
+
+      state.enemies.forEach(enemy => {
+        if (!enemy || enemy.hp > 0 || enemy.deathHoldFrames <= 0) return;
+        minFromLootOrBodies = Math.min(minFromLootOrBodies, enemy.x - 40);
+      });
+
+      return clamp(minFromLootOrBodies, 40, state.levelWidth - 40);
     }
 
     function getWaveBarrierCameraMaxX() {

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2507,6 +2507,12 @@
       return clamp(barrierX - WAVE_BARRIER_PLAYER_MARGIN, 40, state.levelWidth - 40);
     }
 
+    function getBacktrackPlayerMinX() {
+      const halfScreenBacktrack = canvas.width * 0.5;
+      const minFromProgress = state.lastForwardX - halfScreenBacktrack;
+      return clamp(minFromProgress, 40, state.levelWidth - 40);
+    }
+
     function getWaveBarrierCameraMaxX() {
       const barrierX = getWaveBarrierX();
       if (barrierX === null) return state.levelWidth - canvas.width;
@@ -4125,8 +4131,9 @@
         player.vz = 0;
       }
 
+      const playerMinX = getBacktrackPlayerMinX();
       const playerMaxX = getWaveBarrierPlayerMaxX();
-      player.x = clamp(player.x, 40, playerMaxX);
+      player.x = clamp(player.x, playerMinX, playerMaxX);
       const playerVerticalBounds = getPlayerVerticalBounds(player);
       player.y = clamp(player.y, playerVerticalBounds.minY, playerVerticalBounds.maxY);
       applyMovementMaskClamp(player, prevX, prevY);


### PR DESCRIPTION
### Motivation
- Prevent players from fully backtracking out of boss/final encounter areas while still allowing natural forward movement through the level. 
- Ensure the point-of-no-return is a rolling limit (about half a play screen) based on the player’s farthest forward progress without teleporting or auto-moving the player.

### Description
- Added `getBacktrackPlayerMinX()` in `bayou-brawlers/index.html` which computes a dynamic minimum X as `state.lastForwardX - (canvas.width * 0.5)` and clamps it to valid level bounds. 
- Updated player movement clamping in `updatePlayer` to use the dynamic backtrack floor together with the existing forward barrier by replacing the fixed left clamp with `player.x = clamp(player.x, playerMinX, playerMaxX)`. 
- Kept existing wave/boss forward barrier and movement behavior intact so the change only restricts backward movement relative to the player’s progress.

### Testing
- Ran the project's test suite with `npm test -- --runInBand` and all automated tests passed. 
- Test results: `Test Suites: 3 passed, 3 total; Tests: 6 passed, 6 total`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c97e53c7b483299fa1e5d335064747)