### PR TITLE
Use BB_bg_docks001 for Bayou Brawlers stage 3 background

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7001,7 +7001,7 @@
         'background-casino': 'assets/background-casino.svg',
         'background-mansion': 'assets/background-mansion.svg',
         'background-emberfall': 'assets/background-emberfall.svg',
-        'background-docks': 'assets/background-docks.svg',
+        'background-docks': 'assets/BB_bg_docks001.png',
         'background-world-tree': 'assets/background-world-tree.svg',
         'background-goblin-tower': 'assets/background-goblin-tower.svg',
         'background-final-theatre': 'assets/background-final-theatre.svg'


### PR DESCRIPTION
### Motivation
- Align the Docks level with other Bayou Brawlers stages by using the stage-specific PNG background instead of the generic SVG so stage 3 renders the same way as previous stages.

### Description
- Updated the background asset mapping in `bayou-brawlers/index.html` to set `'background-docks'` to `assets/BB_bg_docks001.png`, which will be loaded and normalized like the other stage PNG backgrounds.

### Testing
- Ran `npm test -- --runInBand __tests__/shuffle.test.js` and it passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca715d98dc8329bdc573707e4c59d4)