### PR TITLE
bayou-brawlers: wire levels 3-10 enemy rosters, add enemy types & shapeshifter behavior

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1048,46 +1048,46 @@
         { types: ['hiredGun', 'stingy'], count: 6 },
         { types: ['hiredGun', 'sidewinder', 'stingy'], count: 6 }
       ], boss: { name: 'Sweetykins', type: 'sweetykins' } },
-      { id: 'mirewatch-docks', name: 'Mirewatch Docks', background: 'background-mirewatch-docks', waves: [
-        { types: ['fey', 'ranged'], count: 5 },
-        { types: ['fey'], count: 6 },
-        { types: ['fey', 'automaton'], count: 6 }
-      ], boss: { name: 'Riftcaller Nyx', type: 'mage' } },
-      { id: 'haunted-bayou', name: 'Haunted Bayou', background: 'background-haunted-bayou', waves: [
-        { types: ['fey'], count: 6 },
-        { types: ['fey', 'swamp'], count: 7 },
-        { types: ['fey', 'ranged'], count: 7 }
-      ], boss: { name: 'Spriggan Trickster', type: 'elite' } },
-      { id: 'haunted-house', name: 'Haunted House', background: 'background-haunted-house', waves: [
-        { types: ['automaton', 'thug'], count: 6 },
-        { types: ['automaton'], count: 7 },
-        { types: ['automaton', 'fey'], count: 7 }
-      ], boss: { name: 'Rootcrusher', type: 'brute' } },
+      { id: 'docks-river-market', name: 'Docks and River Market', background: 'background-mirewatch-docks', waves: [
+        { types: ['hiredGun', 'sentroid'], count: 5 },
+        { types: ['hiredGun', 'sidewinder'], count: 6 },
+        { types: ['sentroid', 'sidewinder', 'telematron'], count: 6 }
+      ], boss: { name: 'The Slais', type: 'theSlais' } },
+      { id: 'worthington-manor', name: 'Worthington Manor', background: 'background-mansion', waves: [
+        { types: ['vengefulGhost', 'chainedSpirit'], count: 6 },
+        { types: ['lurkerInTheHalls', 'silentOne'], count: 7 },
+        { types: ['riverDweller', 'vengefulGhost', 'silentOne'], count: 7 }
+      ], boss: { name: 'Lady Evangeline Worthington', type: 'ladyWorthington' } },
+      { id: 'factory-that-laughs', name: 'Tom’s Workshop, the Factory that Laughs', background: 'background-goblin-tower', waves: [
+        { types: ['automatick', 'tickles', 'sentroid'], count: 7 },
+        { types: ['bulwarkBernie', 'sidewinder', 'stingy'], count: 7 },
+        { types: ['telematron', 'automatick', 'tickles'], count: 8 }
+      ], boss: { name: 'Mr. Nibbles', type: 'mrNibbles' } },
       { id: 'mirror-realm', name: 'The Mirror Realm', background: 'background-mirror-realm', waves: [
-        { types: ['automaton'], count: 7 },
-        { types: ['automaton', 'ranged'], count: 7 },
-        { types: ['automaton', 'elite'], count: 6 }
-      ], boss: { name: 'Tockman Prime', type: 'elite' } },
+        { types: ['hatred', 'malice'], count: 7 },
+        { types: ['revulsion', 'disgust'], count: 7 },
+        { types: ['arrogance', 'malice', 'revulsion'], count: 8 }
+      ], boss: { name: 'Mirror Master', type: 'mirrorMaster' } },
       { id: 'airship', name: 'The Airship', background: 'background-airship', waves: [
-        { types: ['fey', 'elite'], count: 7 },
-        { types: ['fey', 'ranged'], count: 8 },
-        { types: ['fey', 'elite'], count: 8 }
-      ], boss: { name: 'Unseelie Captain', type: 'elite' } },
-      { id: 'hell-gate', name: 'Hell Gate', background: 'background-hell-gate', waves: [
-        { types: ['goblin', 'thug'], count: 7 },
-        { types: ['goblin', 'ranged'], count: 8 },
-        { types: ['goblin', 'elite'], count: 8 }
-      ], boss: { name: 'Lash LeGrim', type: 'boss' } },
-      { id: 'mansion', name: 'The Sunken Mansion', background: 'background-mansion', waves: [
-        { types: ['swamp', 'fey'], count: 8 },
-        { types: ['swamp', 'ranged'], count: 8 },
-        { types: ['automaton', 'swamp'], count: 8 }
-      ], boss: { name: 'Drowned Count', type: 'brute' } },
-      { id: 'emberfall', name: 'Emberfall Trade District', background: 'background-emberfall', waves: [
-        { types: ['thug', 'ranged'], count: 8 },
-        { types: ['thug', 'automaton'], count: 9 },
-        { types: ['elite', 'thug'], count: 9 }
-      ], boss: { name: 'Mercantile Reaper', type: 'elite' } },
+        { types: ['shapeshifter', 'rat', 'snake'], count: 8 },
+        { types: ['tiger', 'hiredGun', 'sentroid'], count: 8 },
+        { types: ['sidewinder', 'snake', 'rat'], count: 8 }
+      ], boss: { name: 'The King of Thieves', type: 'kingOfThieves' } },
+      { id: 'hell-gate-crash', name: 'Crash at the Hell Gate', background: 'background-hell-gate', waves: [
+        { types: ['lesserDemon', 'zombie'], count: 8 },
+        { types: ['skulkingDemon', 'succubus'], count: 8 },
+        { types: ['lesserDemon', 'skulkingDemon', 'zombie'], count: 9 }
+      ], boss: { name: 'Lodicrust', type: 'lodicrust' } },
+      { id: 'gatorglass-vault', name: 'Approach to the Gatorglass Vault', background: 'background-docks', waves: [
+        { types: ['origami_crane', 'origami_toad'], count: 8 },
+        { types: ['origami_dragon', 'origami_crane'], count: 9 },
+        { types: ['origami_toad', 'origami_dragon', 'origami_crane'], count: 9 }
+      ], boss: { name: 'Origami Master', type: 'origamiMaster' } },
+      { id: 'toms-machine', name: 'Tom’s Machine', background: 'background-final-theatre', waves: [
+        { types: ['sentroid', 'telematron'], count: 10 },
+        { types: ['automatick', 'sidewinder', 'hatred'], count: 10 },
+        { types: ['zombie', 'origami_dragon', 'riverDweller'], count: 10 }
+      ], boss: { name: 'Tinkering Tom', type: 'tinkeringTom' } },
       { id: 'docks', name: 'The Docks', background: 'background-docks', waves: [
         { types: ['thug', 'goblin'], count: 9 },
         { types: ['ranged', 'goblin'], count: 9 },
@@ -1120,13 +1120,47 @@
       fey: { hp: 38, speed: 1.9, damage: 9, range: 18, score: 85, sprite: 'fey', tier: 'small' },
       ranged: { hp: 30, speed: 1.4, damage: 7, range: 140, score: 95, sprite: 'fey', ranged: true, tier: 'medium' },
       hiredGun: { hp: 34, speed: 1.45, damage: 8, range: 155, score: 100, sprite: 'hiredGun', ranged: true, tier: 'medium' },
+      sentroid: { hp: 42, speed: 1.55, damage: 9, range: 95, score: 110, sprite: 'sentroid', tier: 'medium' },
       stingy: { hp: 28, speed: 2.15, damage: 7, range: 20, score: 105, sprite: 'stingy', tier: 'medium' },
       sidewinder: { hp: 32, speed: 2.35, damage: 2, range: 72, score: 115, sprite: 'sidewinder', tier: 'medium' },
+      telematron: { hp: 64, speed: 1.65, damage: 12, range: 98, score: 150, sprite: 'telematron', tier: 'elite' },
+      vengefulGhost: { hp: 36, speed: 1.85, damage: 10, range: 30, score: 118, sprite: 'vengefulGhost', tier: 'medium' },
+      chainedSpirit: { hp: 45, speed: 1.5, damage: 11, range: 26, score: 122, sprite: 'chainedSpirit', tier: 'medium' },
+      lurkerInTheHalls: { hp: 48, speed: 1.6, damage: 12, range: 24, score: 128, sprite: 'lurkerInTheHalls', tier: 'medium' },
+      silentOne: { hp: 34, speed: 2.05, damage: 10, range: 22, score: 126, sprite: 'silentOne', tier: 'medium' },
+      riverDweller: { hp: 62, speed: 1.25, damage: 13, range: 26, score: 145, sprite: 'riverDweller', tier: 'elite' },
+      automatick: { hp: 52, speed: 1.32, damage: 12, range: 24, score: 120, sprite: 'automatick', tier: 'medium' },
+      tickles: { hp: 35, speed: 2.05, damage: 9, range: 20, score: 116, sprite: 'tickles', tier: 'medium' },
+      bulwarkBernie: { hp: 72, speed: 1.18, damage: 14, range: 26, score: 156, sprite: 'bulwarkBernie', tier: 'elite' },
+      hatred: { hp: 50, speed: 1.82, damage: 13, range: 24, score: 132, sprite: 'hatred', tier: 'medium' },
+      malice: { hp: 46, speed: 1.9, damage: 12, range: 24, score: 130, sprite: 'malice', tier: 'medium' },
+      revulsion: { hp: 52, speed: 1.55, damage: 13, range: 24, score: 132, sprite: 'revulsion', tier: 'medium' },
+      disgust: { hp: 54, speed: 1.45, damage: 14, range: 25, score: 134, sprite: 'disgust', tier: 'medium' },
+      arrogance: { hp: 58, speed: 1.4, damage: 15, range: 28, score: 138, sprite: 'arrogance', tier: 'elite' },
+      shapeshifter: { hp: 72, speed: 1.65, damage: 15, range: 30, score: 180, sprite: 'shapeshifter', tier: 'elite' },
+      rat: { hp: 30, speed: 2.25, damage: 8, range: 20, score: 104, sprite: 'rat', tier: 'small' },
+      snake: { hp: 34, speed: 2.05, damage: 9, range: 22, score: 110, sprite: 'snake', tier: 'small' },
+      tiger: { hp: 60, speed: 1.82, damage: 14, range: 26, score: 152, sprite: 'tiger', tier: 'elite' },
+      lesserDemon: { hp: 44, speed: 1.75, damage: 12, range: 24, score: 126, sprite: 'lesserDemon', tier: 'medium' },
+      skulkingDemon: { hp: 48, speed: 1.62, damage: 13, range: 25, score: 134, sprite: 'skulkingDemon', tier: 'medium' },
+      succubus: { hp: 42, speed: 1.95, damage: 12, range: 24, score: 138, sprite: 'succubus', tier: 'medium' },
+      zombie: { hp: 56, speed: 1.1, damage: 12, range: 22, score: 118, sprite: 'zombie', tier: 'medium' },
+      origami_crane: { hp: 34, speed: 1.9, damage: 9, range: 22, score: 124, sprite: 'origami_crane', tier: 'small' },
+      origami_dragon: { hp: 62, speed: 1.55, damage: 14, range: 30, score: 158, sprite: 'origami_dragon', tier: 'elite' },
+      origami_toad: { hp: 24, speed: 2.35, damage: 6, range: 18, score: 96, sprite: 'origami_toad', tier: 'small' },
       elite: { hp: 70, speed: 1.5, damage: 14, range: 22, score: 140, sprite: 'automaton', tier: 'elite' },
       brute: { hp: 120, speed: 1.1, damage: 18, range: 24, score: 200, sprite: 'thug', tier: 'elite' },
       mage: { hp: 90, speed: 1.3, damage: 16, range: 120, score: 180, sprite: 'fey', ranged: true, tier: 'elite' },
       sweetykins: { hp: 210, speed: 1.55, damage: 13, range: 32, score: 560, sprite: 'sweetykins', tier: 'boss' },
       'mud-monster': { hp: 160, speed: 1.15, damage: 18, range: 34, score: 520, sprite: 'mud-monster', tier: 'boss' },
+      theSlais: { hp: 220, speed: 1.5, damage: 16, range: 36, score: 600, sprite: 'theSlais', tier: 'boss' },
+      ladyWorthington: { hp: 230, speed: 1.42, damage: 17, range: 34, score: 620, sprite: 'ladyWorthington', tier: 'boss' },
+      mrNibbles: { hp: 250, speed: 1.55, damage: 18, range: 36, score: 660, sprite: 'mrNibbles', tier: 'boss' },
+      mirrorMaster: { hp: 260, speed: 1.5, damage: 18, range: 38, score: 680, sprite: 'mirrorMaster', tier: 'boss' },
+      kingOfThieves: { hp: 275, speed: 1.62, damage: 19, range: 40, score: 720, sprite: 'kingOfThieves', tier: 'boss' },
+      lodicrust: { hp: 290, speed: 1.45, damage: 20, range: 40, score: 760, sprite: 'lodicrust', tier: 'boss' },
+      origamiMaster: { hp: 300, speed: 1.5, damage: 20, range: 42, score: 800, sprite: 'origamiMaster', tier: 'boss' },
+      tinkeringTom: { hp: 340, speed: 1.55, damage: 22, range: 44, score: 920, sprite: 'tinkeringTom', tier: 'boss' },
       boss: { hp: 200, speed: 1.2, damage: 20, range: 26, score: 350, sprite: 'boss', tier: 'boss' }
     };
 
@@ -1143,6 +1177,7 @@
     const EMERGENCY_VENTING_RECHARGE_FRAMES = 5 * 60;
     const MAX_FRAME_DELTA_MS = 1000;
     const MAX_CATCH_UP_STEPS = 6;
+    const SHAPESHIFTER_MIMIC_POOL = ['hiredGun', 'sentroid', 'sidewinder', 'vengefulGhost', 'chainedSpirit', 'silentOne', 'riverDweller', 'automatick', 'tickles', 'bulwarkBernie', 'lesserDemon', 'skulkingDemon', 'succubus', 'zombie'];
     const ENTITY_DISPLAY_SCALE_BOOST = 1.2;
     const PLAYER_SCALE_MULTIPLIER = 4;
     const PLAYER_DRAW_SIZE = (56 * PLAYER_SCALE_MULTIPLIER) * ENTITY_DISPLAY_SCALE_BOOST;
@@ -2153,7 +2188,38 @@
       if (state.waveActive && state.lockX !== null) {
         enemy.waveBarrierSpawnSide = x <= state.lockX ? 'left' : 'right';
       }
+      if (typeId === 'shapeshifter') {
+        enemy.shapeshifterDisguiseType = SHAPESHIFTER_MIMIC_POOL[Math.floor(rand(0, SHAPESHIFTER_MIMIC_POOL.length))];
+        enemy.shapeshifterRevealed = false;
+        applyShapeshifterForm(enemy, enemy.shapeshifterDisguiseType, true);
+      }
       return enemy;
+    }
+
+    function applyShapeshifterForm(enemy, formType, isInitialDisguise = false) {
+      const meta = enemyTypes[formType];
+      if (!meta || !enemy) return;
+      const animationTracks = assets.enemyAnimations[formType] || assets.enemyAnimations.shapeshifter || assets.enemyAnimations.swamp || null;
+      enemy.currentFormType = formType;
+      enemy.speed = meta.speed * ENEMY_SPEED_MULTIPLIER;
+      enemy.damage = meta.damage;
+      enemy.range = meta.range;
+      enemy.ranged = meta.ranged || false;
+      enemy.renderScale = getEnemyRenderScale(formType, 1, enemy.isBoss);
+      enemy.physicsProfileId = `enemy-${formType}`;
+      if (animationTracks) {
+        enemy.animation = {
+          state: 'idle',
+          facing: 'left',
+          frameIndex: 0,
+          elapsedMs: 0,
+          complete: false,
+          tracks: animationTracks
+        };
+      }
+      if (!isInitialDisguise) {
+        enemy.type = 'shapeshifter';
+      }
     }
 
     function getEnemyHitbox(enemy) {
@@ -3942,7 +4008,7 @@
       registerMechanizedMomentumHit(player, enemy);
       const id = player.charData.id;
       if (id === 'billy-boxby') {
-        const isIncorporeal = enemy.type.includes('ghost');
+        const isIncorporeal = enemy.type.toLowerCase().includes('ghost');
         const slowChance = heavy
           ? (isIncorporeal ? 1 : 0.75)
           : (isIncorporeal ? 0.8 : 0.4);
@@ -4275,6 +4341,10 @@
         const dx = player.x - enemy.x;
         const dy = getEnemyAimTargetY(enemy, player) - enemy.y;
         const distance = Math.hypot(dx, dy);
+        if (enemy.type === 'shapeshifter' && !enemy.shapeshifterRevealed && enemy.currentFormType && enemy.currentFormType !== 'shapeshifter' && enemy.hp <= enemy.maxHp * 0.55) {
+          enemy.shapeshifterRevealed = true;
+          applyShapeshifterForm(enemy, 'shapeshifter');
+        }
         const spacing = getEnemySpacingAdjustment(enemy);
         const isSlowed = (enemy.statuses?.SLOW?.duration || 0) > 0;
         const moveSpeed = enemy.speed * spacing.moveScale * (isSlowed ? 0.5 : 1);
@@ -7127,6 +7197,32 @@
         }));
       });
 
+      const makeEnemyStates = (baseName, {
+        walk = 'walking',
+        idle = 'controlSquare',
+        attack = 'attack',
+        hurt = 'damaged',
+        death = 'killed',
+        walkFrames = 8,
+        attackFrames = 7,
+        hurtFrames = 5,
+        deathFrames = 6
+      } = {}) => {
+        const build = (action) => `assets/animation_${baseName}_red_${action}_left.png`;
+        const walkPath = build(walk);
+        const idlePath = idle ? build(idle) : walkPath;
+        const attackPath = attack ? build(attack) : walkPath;
+        const hurtPath = hurt ? build(hurt) : walkPath;
+        const deathPath = death ? build(death) : hurtPath;
+        return {
+          idle: { left: [idlePath, 1], fps: 0, loop: false },
+          walk: { left: [walkPath, walkFrames], fps: 10, loop: true },
+          hurt: { left: [hurtPath, hurtFrames], fps: 12, loop: false },
+          attack: { left: [attackPath, attackFrames], fps: 14, loop: false },
+          death: { left: [deathPath, deathFrames], fps: 8, loop: false }
+        };
+      };
+
       const enemySpriteSheets = {
         swamp: {
           profileId: 'enemy-swamp',
@@ -7251,6 +7347,78 @@
             death: { left: ['assets/animation_sidewinder_red_killed_left.png', 6], fps: 8, loop: false }
           }
         },
+        sentroid: {
+          profileId: 'enemy-sentroid',
+          sizeMultiplier: ENEMY_SIZE_BOOST_BY_TYPE.sentroid || 1,
+          states: makeEnemyStates('sentroid', { walk: 'move', walkFrames: 6 })
+        },
+        telematron: {
+          profileId: 'enemy-telematron',
+          sizeMultiplier: ENEMY_SIZE_BOOST_BY_TYPE.telematron || 1,
+          states: makeEnemyStates('telematron')
+        },
+        vengefulGhost: { profileId: 'enemy-vengefulGhost', sizeMultiplier: 1, states: makeEnemyStates('vengefulGhost', { idle: 'walking' }) },
+        chainedSpirit: { profileId: 'enemy-chainedSpirit', sizeMultiplier: 1, states: makeEnemyStates('chainedSpirit', { idle: 'walking' }) },
+        lurkerInTheHalls: { profileId: 'enemy-lurkerInTheHalls', sizeMultiplier: 1, states: makeEnemyStates('lurkerInTheHalls', { idle: 'walking' }) },
+        silentOne: { profileId: 'enemy-silentOne', sizeMultiplier: 1, states: makeEnemyStates('silentOne', { idle: 'walking' }) },
+        riverDweller: { profileId: 'enemy-riverDweller', sizeMultiplier: 1, states: makeEnemyStates('riverDweller') },
+        automatick: { profileId: 'enemy-automatick', sizeMultiplier: 1, states: makeEnemyStates('automatick') },
+        tickles: { profileId: 'enemy-tickles', sizeMultiplier: 1, states: makeEnemyStates('tickles') },
+        bulwarkBernie: { profileId: 'enemy-bulwarkBernie', sizeMultiplier: 1, states: makeEnemyStates('bulwarkBernie', { idle: 'walking' }) },
+        hatred: { profileId: 'enemy-hatred', sizeMultiplier: 1, states: makeEnemyStates('hatred', { walk: 'damaged', idle: 'damaged', attack: 'damaged', hurt: 'damaged', death: 'killed', walkFrames: 5, attackFrames: 5, hurtFrames: 5 }) },
+        malice: { profileId: 'enemy-malice', sizeMultiplier: 1, states: makeEnemyStates('malice', { idle: 'walking' }) },
+        revulsion: { profileId: 'enemy-revulsion', sizeMultiplier: 1, states: makeEnemyStates('revulsion', { idle: 'walking' }) },
+        disgust: { profileId: 'enemy-disgust', sizeMultiplier: 1, states: makeEnemyStates('disgust', { idle: 'walking' }) },
+        arrogance: { profileId: 'enemy-arrogance', sizeMultiplier: 1, states: makeEnemyStates('arrogance', { idle: 'walking' }) },
+        shapeshifter: { profileId: 'enemy-shapeshifter', sizeMultiplier: 1, states: makeEnemyStates('shapeshifter', { walk: 'walking', idle: 'walking', attack: 'walking', hurt: 'damaged', death: 'damaged', walkFrames: 8, attackFrames: 8, hurtFrames: 5, deathFrames: 5 }) },
+        rat: {
+          profileId: 'enemy-rat',
+          sizeMultiplier: 1,
+          states: {
+            idle: { left: ['assets/animation_kingOfThieves_rat_red_walking_left.png', 1], fps: 0, loop: false },
+            walk: { left: ['assets/animation_kingOfThieves_rat_red_walking_left.png', 8], fps: 10, loop: true },
+            hurt: { left: ['assets/animation_kingOfThieves_rat_red_damaged_left.png', 5], fps: 12, loop: false },
+            attack: { left: ['assets/animation_kingOfThieves_rat_red_attack_left.png', 7], fps: 14, loop: false },
+            death: { left: ['assets/animation_kingOfThieves_red_killed_left.png', 6], fps: 8, loop: false }
+          }
+        },
+        snake: {
+          profileId: 'enemy-snake',
+          sizeMultiplier: 1,
+          states: {
+            idle: { left: ['assets/animation_kingOfThieves_snake_red_walking_left.png', 1], fps: 0, loop: false },
+            walk: { left: ['assets/animation_kingOfThieves_snake_red_walking_left.png', 8], fps: 10, loop: true },
+            hurt: { left: ['assets/animation_kingOfThieves_snake_red_damaged_left.png', 5], fps: 12, loop: false },
+            attack: { left: ['assets/animation_kingOfThieves_snake_red_attack_left.png', 7], fps: 14, loop: false },
+            death: { left: ['assets/animation_kingOfThieves_snake_red_killed_left.png', 6], fps: 8, loop: false }
+          }
+        },
+        tiger: {
+          profileId: 'enemy-tiger',
+          sizeMultiplier: 1.05,
+          states: {
+            idle: { left: ['assets/animation_kingOfThieves_tiger_red_walking_left.png', 1], fps: 0, loop: false },
+            walk: { left: ['assets/animation_kingOfThieves_tiger_red_walking_left.png', 8], fps: 10, loop: true },
+            hurt: { left: ['assets/animation_kingOfThieves_tiger_red_damaged_left.png', 5], fps: 12, loop: false },
+            attack: { left: ['assets/animation_kingOfThieves_tiger_red_attack_left.png', 7], fps: 14, loop: false },
+            death: { left: ['assets/animation_kingOfThieves_tiger_red_killed_left.png', 6], fps: 8, loop: false }
+          }
+        },
+        lesserDemon: { profileId: 'enemy-lesserDemon', sizeMultiplier: 1, states: makeEnemyStates('lesserDemon') },
+        skulkingDemon: { profileId: 'enemy-skulkingDemon', sizeMultiplier: 1, states: makeEnemyStates('skulkingDemon') },
+        succubus: { profileId: 'enemy-succubus', sizeMultiplier: 1, states: makeEnemyStates('succubus') },
+        zombie: { profileId: 'enemy-zombie', sizeMultiplier: 1, states: makeEnemyStates('zombie') },
+        origami_crane: { profileId: 'enemy-origami_crane', sizeMultiplier: 1, states: makeEnemyStates('origami_crane', { idle: 'walking' }) },
+        origami_dragon: { profileId: 'enemy-origami_dragon', sizeMultiplier: 1.05, states: makeEnemyStates('origami_dragon', { idle: 'walking' }) },
+        origami_toad: { profileId: 'enemy-origami_toad', sizeMultiplier: 0.95, states: makeEnemyStates('origami_toad', { walk: 'walking', idle: 'walking', attack: 'walking', hurt: 'walking', death: 'killed', walkFrames: 8, attackFrames: 8, hurtFrames: 8 }) },
+        theSlais: { profileId: 'enemy-theSlais', sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE, states: makeEnemyStates('theSlais') },
+        ladyWorthington: { profileId: 'enemy-ladyWorthington', sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE, states: makeEnemyStates('ladyWorthington', { walk: 'walking', idle: 'controlSquare' }) },
+        mrNibbles: { profileId: 'enemy-mrNibbles', sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE, states: makeEnemyStates('mrNibbles', { idle: 'walking' }) },
+        mirrorMaster: { profileId: 'enemy-mirrorMaster', sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE, states: makeEnemyStates('mirrorMaster', { idle: 'walking' }) },
+        kingOfThieves: { profileId: 'enemy-kingOfThieves', sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE, states: makeEnemyStates('kingOfThieves', { walk: 'walking', idle: 'controlSquare' }) },
+        lodicrust: { profileId: 'enemy-lodicrust', sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE, states: makeEnemyStates('lodicrust') },
+        origamiMaster: { profileId: 'enemy-origamiMaster', sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE, states: makeEnemyStates('origamiMaster', { walk: 'walking', idle: 'walking', attack: 'attack', hurt: 'walking', death: 'killed', hurtFrames: 8 }) },
+        tinkeringTom: { profileId: 'enemy-tinkeringTom', sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE, states: makeEnemyStates('tinkeringTom') },
         sweetykins: {
           profileId: 'enemy-sweetykins',
           sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE,


### PR DESCRIPTION
### Motivation
- Align level content with the requested designs by wiring the enemy rosters and bosses for levels 3–10 so each stage spawns the intended primary enemies and boss.
- Ensure newly referenced enemy and boss types are defined and renderable so those encounters behave and score correctly.
- Implement the Shapeshifter requirement (mimics an earlier enemy then reveals itself) and make ghost detection robust for new camelCase ghost IDs.

### Description
- Replaced and extended the `levels` entries to add new level IDs and wave compositions for Docks and River Market through Tom’s Machine, and set the specified boss names/types (file: `bayou-brawlers/index.html`).
- Added new `enemyTypes` definitions for all newly referenced enemies and bosses (stats, tiers, sprite keys) so they can be spawned by the wave system (file: `bayou-brawlers/index.html`).
- Introduced `makeEnemyStates` helper and registered animation/sprite-sheet entries for the new enemy types and bosses so their animations and physics profiles are loaded (file: `bayou-brawlers/index.html`).
- Implemented Shapeshifter logic: `SHAPESHIFTER_MIMIC_POOL` selection at spawn, `applyShapeshifterForm` to copy form stats/animations, and reveal behavior that flips the enemy to the real `shapeshifter` form when sufficiently damaged (file: `bayou-brawlers/index.html`).
- Made incorporeal/ghost checks case-insensitive by using `enemy.type.toLowerCase().includes('ghost')` to handle camelCase ghost IDs correctly (file: `bayou-brawlers/index.html`).

### Testing
- Ran the unit test suite with `npm test -- --runInBand` and all tests passed (`3` test suites, `6` tests — PASS).
- Performed a JavaScript inline script syntax check by extracting the main inline script and executing `new Function(...)`, which succeeded (syntax OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbcad147d48329b4268c5f41d62bde)