### PR TITLE
Update Bayou Brawlers stage 9-10 backgrounds

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1078,12 +1078,12 @@
         { types: ['goblin', 'ranged'], count: 8 },
         { types: ['goblin', 'elite'], count: 8 }
       ], boss: { name: 'Lash LeGrim', type: 'boss' } },
-      { id: 'mansion', name: 'The Sunken Mansion', background: 'background-mansion', waves: [
+      { id: 'mansion', name: 'The Approach to the Gatorglass Vault', background: 'background-approach-to-gatorglass-vault', waves: [
         { types: ['swamp', 'fey'], count: 8 },
         { types: ['swamp', 'ranged'], count: 8 },
         { types: ['automaton', 'swamp'], count: 8 }
       ], boss: { name: 'Drowned Count', type: 'brute' } },
-      { id: 'emberfall', name: 'Emberfall Trade District', background: 'background-emberfall', waves: [
+      { id: 'emberfall', name: 'The Gatorglass Vault: Tom’s Machine', background: 'background-toms-machine', waves: [
         { types: ['thug', 'ranged'], count: 8 },
         { types: ['thug', 'automaton'], count: 9 },
         { types: ['elite', 'thug'], count: 9 }
@@ -6999,8 +6999,8 @@
         'background-mirror-realm': 'assets/BB_bg_mirrorRealm001.png',
         'background-airship': 'assets/BB_bg_airship001.png',
         'background-hell-gate': 'assets/BB_bg_hellGate001.png',
-        'background-mansion': 'assets/background-mansion.svg',
-        'background-emberfall': 'assets/background-emberfall.svg',
+        'background-approach-to-gatorglass-vault': 'assets/BB_bg_approachToGatorglassVault001.png',
+        'background-toms-machine': 'assets/BB_bg_tomsMachine.png',
         'background-docks': 'assets/BB_bg_docks001.png',
         'background-world-tree': 'assets/background-world-tree.svg',
         'background-goblin-tower': 'assets/background-goblin-tower.svg',


### PR DESCRIPTION
### Motivation
- Wire stages 9 and 10 to the new background images so they load via the same background system used by earlier levels and display the updated level names.

### Description
- In `bayou-brawlers/index.html` update the `levels` entries: change the display names for the `mansion` and `emberfall` levels and point their `background` fields to `background-approach-to-gatorglass-vault` and `background-toms-machine`, and add those keys to the `backgroundKeys` map mapped to `assets/BB_bg_approachToGatorglassVault001.png` and `assets/BB_bg_tomsMachine.png` respectively.

### Testing
- Ran the test suite with `npm test -- --runInBand` and all Jest tests passed (3 test suites, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6a815ac48329ac3284a35b4062a7)