### PR TITLE
Add barrier mask asset mappings for Bayou Brawlers levels 2-5

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7007,7 +7007,11 @@
         'background-final-theatre': 'assets/background-final-theatre.svg'
       };
       const barrierKeysByLevelId = {
-        swamp: 'assets/BB_bg_swamp001_barrier.png'
+        swamp: 'assets/BB_bg_swamp001_barrier.png',
+        mirewatch: 'assets/BB_bg_mirewatch001_barrier.png',
+        'mirewatch-docks': 'assets/BB_bg_docks001_barrier.png',
+        'haunted-bayou': 'assets/BB_bg_hauntedBayou001_barrier.png',
+        'haunted-house': 'assets/BB_bg_hauntedHouse001_barrier.png'
       };
 
       Object.entries(backgroundKeys).forEach(([key, src]) => {


### PR DESCRIPTION
### Motivation
- Wire the existing barrier overlay images into the game's asset loader so levels 2–5 use their respective collision/walkable masks (`BB_bg_mirewatch001_barrier.png`, `BB_bg_docks001_barrier.png`, `BB_bg_hauntedBayou001_barrier.png`, `BB_bg_hauntedHouse001_barrier.png`).

### Description
- Add new entries to `barrierKeysByLevelId` in `bayou-brawlers/index.html` for `mirewatch`, `mirewatch-docks`, `haunted-bayou`, and `haunted-house` so the loader registers those barrier images under `assets.barriers[levelId]`.

### Testing
- Ran a quick presence check with `node -e "..."` to assert the four barrier keys are in `bayou-brawlers/index.html`, inspected the file diff with `git diff`, and committed the change; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1b89e4848329ba2a1a0744e5485b)