### PR TITLE
Load barrier overlay maps for Bayou Brawlers levels 2–5

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7007,7 +7007,11 @@
         'background-final-theatre': 'assets/background-final-theatre.svg'
       };
       const barrierKeysByLevelId = {
-        swamp: 'assets/BB_bg_swamp001_barrier.png'
+        swamp: 'assets/BB_bg_swamp001_barrier.png',
+        mirewatch: 'assets/BB_bg_mirewatch001_barrier.png',
+        'mirewatch-docks': 'assets/BB_bg_docks001_barrier.png',
+        'haunted-bayou': 'assets/BB_bg_hauntedBayou001_barrier.png',
+        'haunted-house': 'assets/BB_bg_hauntedHouse_barrier.png'
       };
 
       Object.entries(backgroundKeys).forEach(([key, src]) => {


### PR DESCRIPTION
### Motivation
- Enable collision/walkable-area masking for additional Bayou Brawlers stages by registering their barrier overlay images so characters and enemies cannot walk outside the intended red walkable zones.

### Description
- Updated the `barrierKeysByLevelId` map in `bayou-brawlers/index.html` to include mappings for `mirewatch`, `mirewatch-docks`, `haunted-bayou`, and `haunted-house` to their corresponding barrier assets.
- Kept the existing `swamp` mapping unchanged and preserved the existing asset-loading flow that places images into `assets.barriers`.
- Only code was modified; no binary or asset files were added or changed.

### Testing
- Ran the test suite with `npm test -- --runInBand` and all automated tests passed (3 test suites, 6 tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1ca785408329a99ebc3dbca0e982)