### PR TITLE
bayou-brawlers: load Mirewatch movement barrier overlay

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7007,7 +7007,8 @@
         'background-final-theatre': 'assets/background-final-theatre.svg'
       };
       const barrierKeysByLevelId = {
-        swamp: 'assets/BB_bg_swamp001_barrier.png'
+        swamp: 'assets/BB_bg_swamp001_barrier.png',
+        mirewatch: 'assets/BB_bg_mirewatch001_barrier.png'
       };
 
       Object.entries(backgroundKeys).forEach(([key, src]) => {


### PR DESCRIPTION
### Motivation
- Ensure the Mirewatch level uses the same movement-mask overlay as the Swamp so both player and enemies are constrained to the red walkable area defined in the barrier image, without changing collision logic.

### Description
- Add `mirewatch: 'assets/BB_bg_mirewatch001_barrier.png'` to `barrierKeysByLevelId` in `bayou-brawlers/index.html` so the existing barrier-loading pipeline will load the Mirewatch movement mask; no binary assets were added or modified.

### Testing
- Verified the change was staged and recorded with `git show --stat --oneline HEAD`; no automated runtime or unit tests were executed for this small wiring change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd6bfe089883299b050fa011bc3a7c)