### PR TITLE
Load docks movement barrier mask for docks / mirewatch-docks levels

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7008,7 +7008,9 @@
       };
       const barrierKeysByLevelId = {
         swamp: 'assets/BB_bg_swamp001_barrier.png',
-        mirewatch: 'assets/BB_bg_mirewatch001_barrier.png'
+        mirewatch: 'assets/BB_bg_mirewatch001_barrier.png',
+        'mirewatch-docks': 'assets/BB_bg_docks001_barrier.png',
+        docks: 'assets/BB_bg_docks001_barrier.png'
       };
 
       Object.entries(backgroundKeys).forEach(([key, src]) => {


### PR DESCRIPTION
### Motivation
- Ensure the docks / river market background (level 3) uses the existing red-zone movement mask so player and enemies cannot walk outside the intended walkable area.

### Description
- Updated `bayou-brawlers/index.html` to register `assets/BB_bg_docks001_barrier.png` for both the `mirewatch-docks` and `docks` level IDs so the existing movement-mask pipeline enforces the barrier; no binary files were added or modified.

### Testing
- Ran `npm test -- --runInBand` and all test suites passed (3 suites, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd7ab45bb083298fc28b2f1ebdac51)