### PR TITLE
Add Haunted Bayou movement barrier overlay

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7010,6 +7010,7 @@
         swamp: 'assets/BB_bg_swamp001_barrier.png',
         mirewatch: 'assets/BB_bg_mirewatch001_barrier.png',
         'mirewatch-docks': 'assets/BB_bg_docks001_barrier.png',
+        'haunted-bayou': 'assets/BB_bg_hauntedBayou001_barrier.png',
         docks: 'assets/BB_bg_docks001_barrier.png'
       };
 


### PR DESCRIPTION
### Motivation
- Enable the Haunted Bayou (level 4) to use the existing movement-mask overlay so player and enemies are constrained to the red walkable area.

### Description
- Add `'haunted-bayou': 'assets/BB_bg_hauntedBayou001_barrier.png'` to `barrierKeysByLevelId` in `bayou-brawlers/index.html`, reusing the existing movement-mask pipeline without modifying binary assets.

### Testing
- Ran `npm test -- --runInBand __tests__/shuffle.test.js` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda89ccab483298eb4d87e7cdbe60c)