### PR TITLE
bayou-brawlers: wire Haunted House movement barrier map

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7011,6 +7011,7 @@
         mirewatch: 'assets/BB_bg_mirewatch001_barrier.png',
         'mirewatch-docks': 'assets/BB_bg_docks001_barrier.png',
         'haunted-bayou': 'assets/BB_bg_hauntedBayou001_barrier.png',
+        'haunted-house': 'assets/BB_bg_hauntedHouse001_barrier.png',
         docks: 'assets/BB_bg_docks001_barrier.png'
       };
 


### PR DESCRIPTION
### Motivation
- Ensure Level 5 (Haunted House) uses the same movement-mask overlay as other levels so player and enemy movement is constrained by the red walkable zone in the barrier image.

### Description
- Added the mapping `'haunted-house': 'assets/BB_bg_hauntedHouse001_barrier.png'` to `barrierKeysByLevelId` in `bayou-brawlers/index.html` so the existing movement-mask loader will load the Haunted House barrier image.

### Testing
- Ran `git diff --check` which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf4b018d3883298fd0d0f4e9e5bdac)