### PR TITLE
Add barrier overlay mappings for Bayou Brawlers levels 6–10

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7012,6 +7012,11 @@
         'mirewatch-docks': 'assets/BB_bg_docks001_barrier.png',
         'haunted-bayou': 'assets/BB_bg_hauntedBayou001_barrier.png',
         'haunted-house': 'assets/BB_bg_hauntedHouse001_barrier.png',
+        'mirror-realm': 'assets/BB_bg_mirrorRealm001_barrier.png',
+        airship: 'assets/BB_bg_airship001_barrier.png',
+        'hell-gate': 'assets/BB_bg_hellGate001_barrier.png',
+        mansion: 'assets/BB_bg_approachToGatorglassVault001_barrier.png',
+        emberfall: 'assets/BB_bg_tomsMachine_barrier.png',
         docks: 'assets/BB_bg_docks001_barrier.png'
       };
 


### PR DESCRIPTION
### Motivation
- Enable the existing movement-mask system to load barrier overlay images for Bayou Brawlers levels 6–10 so walkable (red) zones in those backgrounds are enforced for players and enemies.

### Description
- Add entries to the `barrierKeysByLevelId` map in `bayou-brawlers/index.html` for `mirror-realm`, `airship`, `hell-gate`, `mansion`, and `emberfall` that point to the corresponding `assets/BB_bg_*_barrier.png` files, relying on the existing asset loader and movement-mask pipeline.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0f97a639c83299199d9c2ab301613)