### PR TITLE
Add Mirror Realm barrier overlay map for level 6

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7012,6 +7012,7 @@
         'mirewatch-docks': 'assets/BB_bg_docks001_barrier.png',
         'haunted-bayou': 'assets/BB_bg_hauntedBayou001_barrier.png',
         'haunted-house': 'assets/BB_bg_hauntedHouse001_barrier.png',
+        'mirror-realm': 'assets/BB_bg_mirrorRealm001_barrier.png',
         docks: 'assets/BB_bg_docks001_barrier.png'
       };
 


### PR DESCRIPTION
### Motivation
- Enable the Mirror Realm level (`mirror-realm`) to use the movement-mask barrier so both player and enemies are constrained to the red walkable area defined by the barrier image.

### Description
- Wire `mirror-realm` to load `assets/BB_bg_mirrorRealm001_barrier.png` by adding `'mirror-realm': 'assets/BB_bg_mirrorRealm001_barrier.png'` to `barrierKeysByLevelId` in `bayou-brawlers/index.html`, leveraging the existing movement-mask system without changing any binary assets.

### Testing
- Ran `npm test -- --runInBand` and all automated tests passed (3 test suites, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0fb9b91308329aa5de44226020f19)