### PR TITLE
Add level 7 (airship) barrier-mask asset loading

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7013,6 +7013,7 @@
         'haunted-bayou': 'assets/BB_bg_hauntedBayou001_barrier.png',
         'haunted-house': 'assets/BB_bg_hauntedHouse001_barrier.png',
         'mirror-realm': 'assets/BB_bg_mirrorRealm001_barrier.png',
+        airship: 'assets/BB_bg_airship001_barrier.png',
         docks: 'assets/BB_bg_docks001_barrier.png'
       };
 


### PR DESCRIPTION
### Motivation
- Enable the Airship (level `airship`) to use the existing movement-mask overlay so both player and enemies are constrained to the red walkable region provided by the barrier image.

### Description
- Added `airship: 'assets/BB_bg_airship001_barrier.png'` to `barrierKeysByLevelId` in `bayou-brawlers/index.html` so the loader will populate `assets.barriers.airship` and the existing movement-mask logic will apply.

### Testing
- Verified the mapping was added with `rg -n "barrierKeysByLevelId|airship: 'assets/BB_bg_airship001_barrier.png'" bayou-brawlers/index.html` and confirmed the asset loader loop will load the barrier into `assets.barriers` (no binary files changed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d144bdfdcc8329b33d7ce490009bf6)