### PR TITLE
Add Hell Gate movement barrier mask for level 8

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7014,6 +7014,7 @@
         'haunted-house': 'assets/BB_bg_hauntedHouse001_barrier.png',
         'mirror-realm': 'assets/BB_bg_mirrorRealm001_barrier.png',
         airship: 'assets/BB_bg_airship001_barrier.png',
+        'hell-gate': 'assets/BB_bg_hellGate001_barrier.png',
         docks: 'assets/BB_bg_docks001_barrier.png'
       };
 


### PR DESCRIPTION
### Motivation
- Ensure level `hell-gate` (level 8) uses the same walkability overlay behavior as other constrained stages so characters cannot leave the red walkable area in the barrier image.

### Description
- Wire up `hell-gate` to load `assets/BB_bg_hellGate001_barrier.png` by adding the mapping to `barrierKeysByLevelId` in `bayou-brawlers/index.html` so the existing movement-mask logic applies to that level.

### Testing
- Ran `git diff --check` to verify no patch-format issues, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d24b2e01d88329b7885b6c8ae2c720)