### PR TITLE
Add barrier mask mapping for 'mansion' (approach-to-gatorglass-vault) level

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7015,6 +7015,7 @@
         'mirror-realm': 'assets/BB_bg_mirrorRealm001_barrier.png',
         airship: 'assets/BB_bg_airship001_barrier.png',
         'hell-gate': 'assets/BB_bg_hellGate001_barrier.png',
+        mansion: 'assets/BB_bg_approachToGatorglassVault001_barrier.png',
         docks: 'assets/BB_bg_docks001_barrier.png'
       };
 


### PR DESCRIPTION
### Motivation
- Enable the existing movement-mask overlay (the red walkable region) for the Approach to the Gatorglass Vault stage so both player and enemies are constrained by the same barrier logic used by other levels.

### Description
- Add `'mansion': 'assets/BB_bg_approachToGatorglassVault001_barrier.png'` to `barrierKeysByLevelId` in `bayou-brawlers/index.html` so the barrier image is loaded into `assets.barriers` at runtime; no binary assets were added or modified.

### Testing
- Ran `npm test -- --runInBand` and all test suites passed (3 passed, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3aec89fe08329b92fc9d151f5cb9c)