### PR TITLE
Add Tom's Machine (emberfall) movement barrier mapping

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -7016,6 +7016,7 @@
         airship: 'assets/BB_bg_airship001_barrier.png',
         'hell-gate': 'assets/BB_bg_hellGate001_barrier.png',
         mansion: 'assets/BB_bg_approachToGatorglassVault001_barrier.png',
+        emberfall: 'assets/BB_bg_tomsMachine_barrier.png',
         docks: 'assets/BB_bg_docks001_barrier.png'
       };
 


### PR DESCRIPTION
### Motivation
- Enable the existing movement-mask pipeline to enforce the walkable-area overlay for level 10 (Tom’s Machine / `emberfall`) so players and enemies are constrained to the red walkable region in the barrier image.

### Description
- Map the level id `emberfall` to the barrier overlay `assets/BB_bg_tomsMachine_barrier.png` in the barrier lookup in `bayou-brawlers/index.html`, allowing the existing mask-loading and sampling code to apply to that level without changing binary assets.

### Testing
- Ran the test suite with `npm test -- --runInBand`; all tests passed (`3` test suites, `6` tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3be6284288329917f3dfa1131ca9b)