### PR TITLE
Territorial Beast: restrict enemy-trigger to bosses and add environmental-hazard pooling

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1196,7 +1196,6 @@
     const MECHANIZED_MOMENTUM_DURATION_FRAMES = 120;
     const TERRITORIAL_BEAST_DAMAGE_MULTIPLIER = 1.22;
     const TERRITORIAL_BEAST_PROXIMITY_RADIUS = 180;
-    const TERRITORIAL_BEAST_HAZARD_SOURCE_TYPES = new Set(['mud-monster', 'choking-blossom', 'daphodilus']);
     const MAX_LEVEL = 20;
     const BASE_MAX_POWER = 100;
     const SPECIAL_COST = BASE_MAX_POWER / 3;
@@ -2751,18 +2750,18 @@
       return Math.hypot(targetX - clampedX, targetY - clampedY) <= proximityRadius;
     }
 
+    function getTerritorialBeastHazards() {
+      const hazardPools = [state.hazards];
+      if (Array.isArray(state.environmentalHazards)) hazardPools.push(state.environmentalHazards);
+      if (Array.isArray(state.pendingEnvironmentalHazards)) hazardPools.push(state.pendingEnvironmentalHazards);
+      return hazardPools.flat().filter(Boolean);
+    }
+
     function isTerritorialBeastDamageBoostActive(player) {
       if (!player || player.charData?.id !== 'old-man-croc' || !hasUpgrade(player, 'territorial-beast')) return false;
 
-      const nearHazard = state.hazards.some(hazard => isNearHazardRect(player.x, player.y, hazard));
+      const nearHazard = getTerritorialBeastHazards().some(hazard => isNearHazardRect(player.x, player.y, hazard));
       if (nearHazard) return true;
-
-      const nearEnemyHazardSource = state.enemies.some(enemy =>
-        enemy.hp > 0
-        && TERRITORIAL_BEAST_HAZARD_SOURCE_TYPES.has(enemy.type)
-        && Math.hypot(enemy.x - player.x, enemy.y - player.y) <= TERRITORIAL_BEAST_PROXIMITY_RADIUS
-      );
-      if (nearEnemyHazardSource) return true;
 
       return state.enemies.some(enemy =>
         enemy.hp > 0


### PR DESCRIPTION
### Motivation
- Make Old Man Croc’s `Territorial Beast` obey design: it should not be activated by proximity to ordinary enemies, only stage bosses, while still activating from hazards (including future environmental-hazard pools) before/after they trigger.

### Description
- Removed the unused `TERRITORIAL_BEAST_HAZARD_SOURCE_TYPES` constant and stopped treating non-boss enemies as hazard sources in the activation logic in `bayou-brawlers/index.html`.
- Added `getTerritorialBeastHazards()` to consolidate hazard pools (`state.hazards`, and optional `state.environmentalHazards` and `state.pendingEnvironmentalHazards`) so proximity checks work both before and after environmental hazards are triggered.
- Updated `isTerritorialBeastDamageBoostActive()` to use the new hazard collector for hazard proximity and to only consider enemies that are bosses for enemy-proximity activation.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues, which succeeded.
- Verified symbol presence/absence with `rg -n "TERRITORIAL_BEAST_HAZARD_SOURCE_TYPES|getTerritorialBeastHazards|isTerritorialBeastDamageBoostActive" bayou-brawlers/index.html`, which confirmed the new function and removal of the old constant.
- Committed the change and validated the resulting diff to ensure only the intended lines in `bayou-brawlers/index.html` were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d46e0dcd9c8329a6688d847ec2787b)