### PR TITLE
Allow player to reach enemy spawn area during wave locks (bayou-brawlers)

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2507,7 +2507,14 @@
     function getWaveBarrierPlayerMaxX() {
       const barrierX = getWaveBarrierX();
       if (barrierX === null) return state.levelWidth - 40;
-      return clamp(barrierX - WAVE_BARRIER_PLAYER_MARGIN, 40, state.levelWidth - 40);
+      const baseMaxX = clamp(barrierX - WAVE_BARRIER_PLAYER_MARGIN, 40, state.levelWidth - 40);
+      const furthestEnemyX = state.enemies.reduce((maxX, enemy) => {
+        if (!enemy || enemy.hp <= 0) return maxX;
+        return Math.max(maxX, enemy.x);
+      }, -Infinity);
+      if (!Number.isFinite(furthestEnemyX)) return baseMaxX;
+      const enemyReachMaxX = clamp(furthestEnemyX + 24, 40, state.levelWidth - 40);
+      return Math.max(baseMaxX, enemyReachMaxX);
     }
 
     function getBacktrackPlayerMinX() {
@@ -2545,7 +2552,8 @@
       const barrierX = getWaveBarrierX();
       if (barrierX === null) return state.levelWidth - canvas.width;
       const cappedMaxX = barrierX - canvas.width + WAVE_BARRIER_SCREEN_MARGIN;
-      return clamp(cappedMaxX, 0, state.levelWidth - canvas.width);
+      const playerReachMaxX = getWaveBarrierPlayerMaxX() - canvas.width + WAVE_BARRIER_SCREEN_MARGIN;
+      return clamp(Math.max(cappedMaxX, playerReachMaxX), 0, state.levelWidth - canvas.width);
     }
 
     function enforceEnemyWaveBarrier(enemy) {


### PR DESCRIPTION
### Motivation
- Waves use a lock X to keep the level constrained, but the previous player max-X/camera bounds could prevent the player from moving into the area where enemies spawn or currently reside.
- The camera also needed to follow the expanded reachable area so the player remains visible when moving to enemy positions.

### Description
- Updated `getWaveBarrierPlayerMaxX()` to include the furthest living enemy X (with a small buffer) and return the larger of the barrier-based max and the enemy-reach max.
- Updated `getWaveBarrierCameraMaxX()` to consider the expanded player reach so the camera’s capped maxX will follow the player into enemy-occupied space.
- Change applied to `bayou-brawlers/index.html` where movement/camera bounds are computed.

### Testing
- Ran `npm test -- --runInBand`, all test suites passed successfully (3 suites, 6 tests).
- No regressions detected by the existing automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5305cd5748329807c69b84f110509)