### PR TITLE
Fix Billy Boxby Whiteout upgrade icon mapping

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1403,7 +1403,7 @@
       },
       upgrade: {
         icebreaker: 'iceBreaker',
-        'white-out': 'whiteOut',
+        whiteout: 'whiteout',
         'ice-in-the-veins': 'iceInTheVanes',
         veilwalker: 'veilWalker'
       }

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1403,7 +1403,7 @@
       },
       upgrade: {
         icebreaker: 'iceBreaker',
-        whiteout: 'whiteout',
+        whiteout: 'whiteOut',
         'ice-in-the-veins': 'iceInTheVanes',
         veilwalker: 'veilWalker'
       }


### PR DESCRIPTION
### Motivation
- Ensure the `whiteout` upgrade for Billy Boxby resolves to the existing asset `assets/upgrade_billyBoxby_whiteout.png` so the upgrade card no longer shows a missing-image question mark.

### Description
- Update `UPGRADE_IMAGE_OVERRIDES.upgrade` in `bayou-brawlers/index.html` by replacing the `'white-out': 'whiteOut'` entry with `whiteout: 'whiteout'` so `getUpgradeImagePath` builds the correct filename; no binary files were added or modified.

### Testing
- No automated tests were run for this mapping-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5512deef0832988a58126dfd157da)