### PR TITLE
Keep XP requirements increasing after level 10 in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2726,7 +2726,7 @@
       const cyclePosition = getLevelCyclePosition(level);
       const cycleIndex = Math.floor((Math.max(1, level) - 1) / 10);
       const idx = clamp(cyclePosition - 1, 0, XP_TABLE.length - 1);
-      const scaledXp = Math.round(XP_TABLE[idx] * (0.7 ** cycleIndex));
+      const scaledXp = Math.round(XP_TABLE[idx] * (1.35 ** cycleIndex));
       return Math.max(20, scaledXp);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent post-cycle level ups (levels 11-20) from resetting to easier XP thresholds by making XP requirements continue to grow as players progress beyond level 10.

### Description
- In `bayou-brawlers/index.html` updated the `xpToNext` calculation to use an increasing cycle multiplier by changing `XP_TABLE[idx] * (0.7 ** cycleIndex)` to `XP_TABLE[idx] * (1.35 ** cycleIndex)` inside the `xpToNext` function. 
- Left the existing guard `Math.max(20, scaledXp)` and `if (level >= MAX_LEVEL) return 0;` behavior intact so final-level handling is unchanged.

### Testing
- Ran `npm test -- --runInBand` and all automated tests passed successfully (3 test suites, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5610e620483299e517dcffb243f9f)