### PR TITLE
Continue XP scaling after level 10 in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2723,11 +2723,25 @@
 
     function xpToNext(level) {
       if (level >= MAX_LEVEL) return 0;
-      const cyclePosition = getLevelCyclePosition(level);
-      const cycleIndex = Math.floor((Math.max(1, level) - 1) / 10);
-      const idx = clamp(cyclePosition - 1, 0, XP_TABLE.length - 1);
-      const scaledXp = Math.round(XP_TABLE[idx] * (0.7 ** cycleIndex));
-      return Math.max(20, scaledXp);
+      const normalizedLevel = Math.max(1, level);
+      const tableLength = XP_TABLE.length;
+      const idx = clamp(normalizedLevel - 1, 0, tableLength - 1);
+      if (normalizedLevel <= tableLength) {
+        return Math.max(20, XP_TABLE[idx]);
+      }
+
+      const safeTable = XP_TABLE.slice(0, tableLength);
+      const lastIdx = safeTable.length - 1;
+      let lastStep = safeTable[lastIdx] - safeTable[lastIdx - 1];
+      const previousStep = safeTable[lastIdx - 1] - safeTable[lastIdx - 2];
+      const stepGrowth = Math.max(0, lastStep - previousStep);
+
+      for (let reqLevel = tableLength + 1; reqLevel <= normalizedLevel; reqLevel += 1) {
+        lastStep += stepGrowth;
+        safeTable.push(safeTable[safeTable.length - 1] + lastStep);
+      }
+
+      return Math.max(20, safeTable[normalizedLevel - 1]);
     }
 
     function hasLevel(player, levelReq) {


### PR DESCRIPTION
### Motivation
- Fix XP progression so that after the level-10/reset point the XP required to level continues to increase rather than shrinking, matching the intended increasing difficulty trajectory established from levels 1–10.

### Description
- Reworked `xpToNext(level)` in `bayou-brawlers/index.html` to preserve the base `XP_TABLE` behavior for early levels and extrapolate requirements for higher levels instead of applying the previous cycle-based shrink.
- The new logic uses the final steps in `XP_TABLE` to compute a non-decreasing step growth and iteratively builds further required XP values so each subsequent level demands more XP.
- The function keeps a floor of `20` XP and returns `0` when `level >= MAX_LEVEL` to preserve existing caps.

### Testing
- Ran `npm test -- --runInBand` which reported all test suites passing (3 suites, 6 tests) with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5c30b2b1c83299add7cf181afaa10)