### PR TITLE
Improve Bayou Brawlers SFX playback responsiveness

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -982,21 +982,32 @@
     }
 
     function collectAllSfxSources() {
-      const allSources = [
-        ...Object.values(PLAYER_CHARACTER_SFX).flatMap((character) => Object.values(character || {})),
-        ...Object.values(ENEMY_CHARACTER_SFX).flatMap((enemy) => Object.values(enemy || {}))
-      ];
-      return Array.from(new Set(allSources.filter(Boolean)));
+      const unique = new Set();
+      const appendSources = (catalog) => {
+        Object.values(catalog || {}).forEach((entry) => {
+          Object.values(entry || {}).forEach((src) => {
+            if (src) unique.add(src);
+          });
+        });
+      };
+
+      appendSources(PLAYER_CHARACTER_SFX);
+      appendSources(ENEMY_CHARACTER_SFX);
+      return Array.from(unique);
     }
 
-    function buildSfxPool(src) {
+    function createSfxAudio(src) {
+      const audio = new Audio(src);
+      audio.preload = 'auto';
+      audio.volume = SFX_VOLUME;
+      return audio;
+    }
+
+    function buildSfxPool(src, initialSize = SFX_POOL_SIZE) {
       const pool = [];
-      for (let i = 0; i < SFX_POOL_SIZE; i += 1) {
-        const audio = new Audio(src);
-        audio.preload = 'auto';
-        audio.volume = SFX_VOLUME;
-        audio.load();
-        pool.push(audio);
+      const size = Math.max(1, initialSize | 0);
+      for (let i = 0; i < size; i += 1) {
+        pool.push(createSfxAudio(src));
       }
       sfxState.pools.set(src, pool);
       return pool;
@@ -1011,14 +1022,19 @@
       if (sfxState.primed) return;
       sfxState.primed = true;
       collectAllSfxSources().forEach((src) => {
-        buildSfxPool(src);
+        buildSfxPool(src, 1);
       });
     }
 
     function playSfx(src) {
       if (soundtrackState.muted || !src) return;
       const pool = getSfxPool(src);
-      const available = pool.find((audio) => audio.paused || audio.ended) || pool[0];
+      let available = pool.find((audio) => audio.paused || audio.ended);
+      if (!available && pool.length < SFX_POOL_SIZE) {
+        available = createSfxAudio(src);
+        pool.push(available);
+      }
+      if (!available) available = pool[0];
       available.currentTime = 0;
       available.volume = SFX_VOLUME;
       available.play().catch(() => {

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -899,6 +899,11 @@
       audio: new Audio(),
       button: null
     };
+    const SFX_POOL_SIZE = 4;
+    const sfxState = {
+      pools: new Map(),
+      primed: false
+    };
     soundtrackState.audio.volume = SOUNDTRACK_VOLUME;
     soundtrackState.audio.preload = 'auto';
     soundtrackState.audio.addEventListener('ended', () => {
@@ -976,28 +981,59 @@
       updateMuteButton();
     }
 
-    function playPlayerSfx(player, action) {
-      if (soundtrackState.muted) return;
-      const characterSfx = PLAYER_CHARACTER_SFX[player?.charData?.id];
-      const src = characterSfx ? characterSfx[action] : null;
-      if (!src) return;
-      const oneShot = new Audio(src);
-      oneShot.volume = SFX_VOLUME;
-      oneShot.play().catch(() => {
+    function collectAllSfxSources() {
+      const allSources = [
+        ...Object.values(PLAYER_CHARACTER_SFX).flatMap((character) => Object.values(character || {})),
+        ...Object.values(ENEMY_CHARACTER_SFX).flatMap((enemy) => Object.values(enemy || {}))
+      ];
+      return Array.from(new Set(allSources.filter(Boolean)));
+    }
+
+    function buildSfxPool(src) {
+      const pool = [];
+      for (let i = 0; i < SFX_POOL_SIZE; i += 1) {
+        const audio = new Audio(src);
+        audio.preload = 'auto';
+        audio.volume = SFX_VOLUME;
+        audio.load();
+        pool.push(audio);
+      }
+      sfxState.pools.set(src, pool);
+      return pool;
+    }
+
+    function getSfxPool(src) {
+      if (sfxState.pools.has(src)) return sfxState.pools.get(src);
+      return buildSfxPool(src);
+    }
+
+    function primeSfxPool() {
+      if (sfxState.primed) return;
+      sfxState.primed = true;
+      collectAllSfxSources().forEach((src) => {
+        buildSfxPool(src);
+      });
+    }
+
+    function playSfx(src) {
+      if (soundtrackState.muted || !src) return;
+      const pool = getSfxPool(src);
+      const available = pool.find((audio) => audio.paused || audio.ended) || pool[0];
+      available.currentTime = 0;
+      available.volume = SFX_VOLUME;
+      available.play().catch(() => {
         // Audio playback can be blocked by browser autoplay policy.
       });
     }
 
+    function playPlayerSfx(player, action) {
+      const characterSfx = PLAYER_CHARACTER_SFX[player?.charData?.id];
+      playSfx(characterSfx ? characterSfx[action] : null);
+    }
+
     function playEnemySfx(enemy, action) {
-      if (soundtrackState.muted) return;
       const enemySfx = ENEMY_CHARACTER_SFX[enemy?.type];
-      const src = enemySfx ? enemySfx[action] : null;
-      if (!src) return;
-      const oneShot = new Audio(src);
-      oneShot.volume = SFX_VOLUME;
-      oneShot.play().catch(() => {
-        // Audio playback can be blocked by browser autoplay policy.
-      });
+      playSfx(enemySfx ? enemySfx[action] : null);
     }
 
     const characters = [
@@ -7553,6 +7589,15 @@
       initCharacterSelection();
       handleMessageButton();
       setupSoundtrackControls();
+      if ('requestIdleCallback' in window) {
+        window.requestIdleCallback(() => {
+          primeSfxPool();
+        }, { timeout: 1500 });
+      } else {
+        setTimeout(() => {
+          primeSfxPool();
+        }, 300);
+      }
       layoutAdaptiveUi();
       state.ready = true;
     }


### PR DESCRIPTION
### Motivation
- Reduce the 1–2s delay the first time an SFX plays by preloading and reusing audio instances instead of creating one-shot `new Audio(src)` objects at action time.

### Description
- Added an SFX pool (`SFX_POOL_SIZE = 4`) and `sfxState` map to maintain reusable Audio objects per sound source.
- Implemented `collectAllSfxSources`, `buildSfxPool`, `getSfxPool`, `primeSfxPool`, and `playSfx` helpers and replaced direct one-shot `new Audio(src)` usage with pooled playback.
- Updated `playPlayerSfx` and `playEnemySfx` to call `playSfx` so effects use the pool and can overlap without waiting for decoding.
- Schedule SFX priming after startup using `requestIdleCallback` with a `setTimeout` fallback so preloading warms files without blocking initialization.

### Testing
- Ran the test suite with `npm test -- --runInBand` and all tests passed (3 test suites, 6 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6997140d88329b70f8a9865271511)