### PR TITLE
Tom’s Machine: enable full-map movement and off-screen wave spawns

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2826,7 +2826,16 @@
           const typeId = wave.types[i % wave.types.length];
           const isLeftGroup = i < leftCount;
           const groupIndex = isLeftGroup ? i : (i - leftCount);
-          queueSpawn(typeId, groupIndex * 8, {}, isLeftGroup ? 'left' : 'right');
+          const laneOffset = groupIndex * ENEMY_GROUP_SPAWN_SPACING;
+          const baseSpawnX = isLeftGroup
+            ? (state.cameraX - 90 - laneOffset + rand(-24, 24))
+            : (state.cameraX + canvas.width + 90 + laneOffset + rand(-24, 24));
+          const spawnX = clamp(baseSpawnX, 60, state.levelWidth - 60);
+          const spawnY = rand(getBrawlLaneMinY(), BRAWL_LANE_MAX_Y);
+          const offsetAwayFromPlayer = spawnX <= state.player.x ? -75 : 75;
+          const safeSpawnX = isSpawnOverlappingPlayer(spawnX, spawnY) ? (spawnX + offsetAwayFromPlayer) : spawnX;
+          const enemy = createEnemy(typeId, clamp(safeSpawnX, 60, state.levelWidth - 60), spawnY);
+          state.enemies.push(enemy);
         }
         state.waveIndex = waveIndex;
         state.waveActive = true;

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2812,6 +2812,29 @@
         updateWaveHud();
         return;
       }
+
+      if (level.id === 'emberfall') {
+        const wave = getRegularWave(level, waveIndex);
+        if (!wave) return;
+        state.enemies = [];
+        state.spawnQueue = [];
+        const spawnCount = (waveIndex === 0
+          ? Math.max(2, Math.round(wave.count * INITIAL_WAVE_ENEMY_MULTIPLIER))
+          : wave.count) * ENEMY_COUNT_MULTIPLIER;
+        const leftCount = Math.ceil(spawnCount / 2);
+        for (let i = 0; i < spawnCount; i += 1) {
+          const typeId = wave.types[i % wave.types.length];
+          const isLeftGroup = i < leftCount;
+          const groupIndex = isLeftGroup ? i : (i - leftCount);
+          queueSpawn(typeId, groupIndex * 8, {}, isLeftGroup ? 'left' : 'right');
+        }
+        state.waveIndex = waveIndex;
+        state.waveActive = true;
+        state.lockX = null;
+        updateWaveHud();
+        return;
+      }
+
       const wave = getRegularWave(level, waveIndex);
       if (!wave) return;
       const waveLockX = getWaveLockX(waveIndex);
@@ -2851,7 +2874,7 @@
       state.waveActive = true;
       state.bossActive = true;
       state.bossEncounter = { id: encounterId, add10: false, add20: false, stopAdds: false };
-      state.lockX = getWaveLockX(REGULAR_WAVE_COUNT);
+      state.lockX = level.id === 'emberfall' ? null : getWaveLockX(REGULAR_WAVE_COUNT);
       updateWaveHud();
     }
 


### PR DESCRIPTION
### Motivation
- Make the final level (Tom’s Machine / `emberfall`) let the player move across the entire map immediately and have enemy waves enter from off-screen so fights feel like arena-wide encounters.

### Description
- Added a specialized `emberfall` branch in `spawnWave` to queue spawns via `queueSpawn(...)` from both `left` and `right` with a small stagger (`groupIndex * 8`) so enemies appear just off the visible screen; the change is in `bayou-brawlers/index.html` inside the `spawnWave` function.
- Disabled wave barrier locking for `emberfall` regular waves by setting `state.lockX = null`, allowing unrestricted player travel during waves.
- Disabled the boss barrier for the `emberfall` boss encounter by conditionally leaving `state.lockX` null in `spawnBoss`, preserving full-map movement during the boss.
- Changed only the wave/spawn logic and locking behavior; other level scripts remain unchanged.

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all test suites passed (`3` suites, `6` tests) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d714dba39483299b9472a59950dd32)