### PR TITLE
Use Bambo SFX and animations for Sidewinder enemy in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -886,7 +886,7 @@
       ranged: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
       hiredGun: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       stingy: { attack: 'assets/BB_sfx_stingy_attack.mp3', hit: 'assets/BB_sfx_stingy_hit.mp3', killed: 'assets/BB_sfx_stingy_killed.mp3', walking: 'assets/BB_sfx_stingy_walking.mp3' },
-      sidewinder: { attack: 'assets/BB_sfx_sidewinder_walking.mp3', hit: 'assets/BB_sfx_sidewinder_hit.mp3', killed: 'assets/BB_sfx_sidewinder_killed.mp3', walking: 'assets/BB_sfx_sidewinder_walking.mp3' },
+      sidewinder: { attack: 'assets/BB_sfx_bambo_attack.wav', hit: 'assets/BB_sfx_bambo_hit.wav', killed: 'assets/BB_sfx_bambo_killed.wav', walking: 'assets/BB_sfx_bambo_walking.wav' },
       elite: { attack: 'assets/BB_sfx_automatick_attack.mp3', hit: 'assets/BB_sfx_automatick_hit.mp3', killed: 'assets/BB_sfx_automatick_killed.mp3', walking: 'assets/BB_sfx_automatick_walking.mp3' },
       brute: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       mage: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
@@ -7573,11 +7573,11 @@
           profileId: 'enemy-sidewinder',
           sizeMultiplier: ENEMY_SIZE_BOOST_BY_TYPE.sidewinder || 1,
           states: {
-            idle: { left: ['assets/animation_sidewinder_red_walking_left.png', 1], fps: 0, loop: false },
-            walk: { left: ['assets/animation_sidewinder_red_walking_left.png', 8], fps: 10, loop: true },
-            hurt: { left: ['assets/animation_sidewinder_red_damaged_left.png', 5], fps: 12, loop: false },
-            attack: { left: ['assets/animation_sidewinder_red_attack_left.png', 7], fps: 14, loop: false },
-            death: { left: ['assets/animation_sidewinder_red_killed_left.png', 6], fps: 8, loop: false }
+            idle: { left: ['assets/animation_bambo_red_walking_left.png', 1], fps: 0, loop: false },
+            walk: { left: ['assets/animation_bambo_red_walking_left.png', 8], fps: 10, loop: true },
+            hurt: { left: ['assets/animation_bambo_red_damaged_left.png', 5], fps: 12, loop: false },
+            attack: { left: ['assets/animation_bambo_red_attack_left.png', 7], fps: 14, loop: false },
+            death: { left: ['assets/animation_bambo_red_killed_left.png', 6], fps: 8, loop: false }
           }
         },
         sweetykins: {


### PR DESCRIPTION
### Motivation
- Pair the enemy that uses Bambo art with the matching Bambo sound assets so enemy audio matches its animation states the same way player characters are handled.

### Description
- Updated the `ENEMY_CHARACTER_SFX` mapping to point the `sidewinder` enemy to `assets/BB_sfx_bambo_attack.wav`, `assets/BB_sfx_bambo_hit.wav`, `assets/BB_sfx_bambo_killed.wav`, and `assets/BB_sfx_bambo_walking.wav`.
- Swapped the `sidewinder` enemy animation references to use the `animation_bambo_red_*` sprite sheets for `idle`, `walk`, `hurt`, `attack`, and `death` states in `bayou-brawlers/index.html`.
- No other gameplay logic was changed; this only remaps asset references so the animations and SFX are consistent.

### Testing
- Ran `rg` to verify the updated `BB_sfx_bambo_` and `animation_bambo_red_` references are present in `bayou-brawlers/index.html`, and the search succeeded.
- Executed a file-existence check for the referenced assets under `bayou-brawlers/assets/` and all referenced `BB_sfx_bambo_*` and `animation_bambo_red_*` files were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7290eef7c8329ba0f46e519c9e4ce)