### PR TITLE
Add Bambo first-boss + Tinkering Tom follow-up for stage 10 and scale enemies on emberfall

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -785,6 +785,7 @@
       waveScript: null,
       spawnQueue: [],
       bossEncounter: null,
+      stageBossPhase: 0,
       hazards: [],
       commandBuffTimer: 0,
       chokeHoldOwnerId: null,
@@ -891,6 +892,8 @@
       brute: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       mage: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
       sweetykins: { attack: 'assets/BB_sfx_tickles_attack.mp3', hit: 'assets/BB_sfx_tickles_hit.mp3', killed: 'assets/BB_sfx_tickles_killed.mp3' },
+      bambo: { attack: 'assets/BB_sfx_bambo_attack.wav', hit: 'assets/BB_sfx_bambo_hit.wav', killed: 'assets/BB_sfx_bambo_killed.wav', walking: 'assets/BB_sfx_bambo_walking.wav' },
+      tinkeringTom: { attack: 'assets/BB_sfx_tinkeringTom_attack.mp3', hit: 'assets/BB_sfx_tinkeringTom_hit.mp3', killed: 'assets/BB_sfx_tinkeringTom_killed.mp3' },
       boss: { attack: 'assets/BB_sfx_mudMonster_attack.mp3', hit: 'assets/BB_sfx_mudMonster_hit.mp3', killed: 'assets/BB_sfx_mudMonster_killed.mp3' }
     };
     const soundtrackState = {
@@ -1282,7 +1285,7 @@
         { types: ['thug', 'ranged'], count: 8 },
         { types: ['thug', 'automaton'], count: 9 },
         { types: ['elite', 'thug'], count: 9 }
-      ], boss: { name: 'Mercantile Reaper', type: 'elite' } },
+      ], boss: { name: 'Bambo', type: 'bambo' }, secondBoss: { name: 'Tinkering Tom', type: 'tinkeringTom' } },
       { id: 'docks', name: 'The Docks', background: 'background-docks', waves: [
         { types: ['thug', 'goblin'], count: 9 },
         { types: ['ranged', 'goblin'], count: 9 },
@@ -1321,6 +1324,8 @@
       brute: { hp: 120, speed: 1.1, damage: 18, range: 24, score: 200, sprite: 'thug', tier: 'elite' },
       mage: { hp: 90, speed: 1.3, damage: 16, range: 120, score: 180, sprite: 'fey', ranged: true, tier: 'elite' },
       sweetykins: { hp: 210, speed: 1.55, damage: 13, range: 32, score: 560, sprite: 'sweetykins', tier: 'boss' },
+      bambo: { hp: 250, speed: 1.35, damage: 17, range: 34, score: 620, sprite: 'bambo', tier: 'boss' },
+      tinkeringTom: { hp: 290, speed: 1.4, damage: 20, range: 36, score: 700, sprite: 'tinkeringTom', tier: 'boss' },
       'mud-monster': { hp: 160, speed: 1.15, damage: 18, range: 34, score: 520, sprite: 'mud-monster', tier: 'boss' },
       boss: { hp: 200, speed: 1.2, damage: 20, range: 26, score: 350, sprite: 'boss', tier: 'boss' }
     };
@@ -1656,6 +1661,9 @@
       const enemyBaseSize = isBoss ? BOSS_DRAW_SIZE : ENEMY_DRAW_SIZE;
       const asPlayerSizeRatio = (ratio) => (playerSize * ratio) / enemyBaseSize;
       const boostedSize = ENEMY_SIZE_BOOST_BY_TYPE[typeId];
+      const level = levels[state.levelIndex];
+
+      if (level && level.id === 'emberfall' && !isBoss) return asPlayerSizeRatio(1);
 
       if (typeId === 'choking-blossom') return asPlayerSizeRatio(1);
       if (typeId === 'swamp') return asPlayerSizeRatio(0.5);
@@ -2839,13 +2847,13 @@
       updateWaveHud();
     }
 
-    function spawnBoss(level) {
-      const bossType = level.boss.type;
+    function spawnBoss(level, bossConfig = level.boss) {
+      const bossType = bossConfig.type;
       const encounterId = `boss-${Date.now()}`;
       const boss = createEnemy(bossType, state.levelWidth - 220, clamp(280, getBrawlLaneMinY(), BRAWL_LANE_MAX_Y), true, { bossEncounterId: encounterId });
       const verticalBounds = getEnemyVerticalBounds(boss);
       boss.y = clamp(boss.y, verticalBounds.minY, verticalBounds.maxY);
-      boss.name = level.boss.name;
+      boss.name = bossConfig.name;
       state.enemies = [boss];
       state.waveIndex = REGULAR_WAVE_COUNT;
       state.waveActive = true;
@@ -5521,6 +5529,12 @@
           if (state.bossEncounter.stopAdds) state.spawnQueue = state.spawnQueue.filter(e => !['choking-blossom', 'daphodilus'].includes(e.type));
 
           if (aliveBossLineage.length === 0 && state.spawnQueue.length === 0) {
+            if (level.secondBoss && state.stageBossPhase === 1) {
+              state.stageBossPhase = 2;
+              spawnBoss(level, level.secondBoss);
+              showBossPopup(`${level.secondBoss.name}`, `${level.boss.name} is down. ${level.secondBoss.name} enters the fight!`);
+              return;
+            }
             state.waveActive = false;
             state.bossActive = false;
             state.bossEncounter = null;
@@ -5543,6 +5557,7 @@
           if (state.nextWaveToSpawn < REGULAR_WAVE_COUNT) {
             spawnWave(level, state.nextWaveToSpawn);
           } else {
+            state.stageBossPhase = 1;
             spawnBoss(level);
             showBossPopup(`${level.boss.name}`, 'Boss rush! Brace for impact.');
           }
@@ -5571,6 +5586,7 @@
       const defaultLevelWidth = 2200 + state.levelIndex * 120;
       state.levelWidth = getLevelWorldWidth(level, defaultLevelWidth);
       state.bossActive = false;
+      state.stageBossPhase = 0;
       state.enemies = [];
       state.projectiles = [];
       state.pickups = [];
@@ -7589,6 +7605,28 @@
             hurt: { left: ['assets/animation_sweetykins_red_damaged_left.png', 5], fps: 12, loop: false },
             attack: { left: ['assets/animation_sweetykins_red_attack_left.png', 7], fps: 14, loop: false },
             death: { left: ['assets/animation_sweetykins_red_killed_left.png', 6], fps: 8, loop: false }
+          }
+        },
+        bambo: {
+          profileId: 'enemy-bambo',
+          sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE,
+          states: {
+            idle: { left: ['assets/animation_bambo_red_walking_left.png', 1], fps: 0, loop: false },
+            walk: { left: ['assets/animation_bambo_red_walking_left.png', 8], fps: 10, loop: true },
+            hurt: { left: ['assets/animation_bambo_red_damaged_left.png', 5], fps: 12, loop: false },
+            attack: { left: ['assets/animation_bambo_red_attack_left.png', 7], fps: 14, loop: false },
+            death: { left: ['assets/animation_bambo_red_killed_left.png', 6], fps: 8, loop: false }
+          }
+        },
+        tinkeringTom: {
+          profileId: 'enemy-tinkeringTom',
+          sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE,
+          states: {
+            idle: { left: ['assets/animation_tinkeringTom_red_controlSquare_left.png', 1], fps: 0, loop: false },
+            walk: { left: ['assets/animation_tinkeringTom_red_walking_left.png', 8], fps: 10, loop: true },
+            hurt: { left: ['assets/animation_tinkeringTom_red_damaged_left.png', 5], fps: 12, loop: false },
+            attack: { left: ['assets/animation_tinkeringTom_red_attack_left.png', 7], fps: 14, loop: false },
+            death: { left: ['assets/animation_tinkeringTom_red_killed_left.png', 6], fps: 8, loop: false }
           }
         },
         boss: {


### PR DESCRIPTION
### Motivation
- Make stage 10 (Tom’s Machine / `emberfall`) present an initial boss fight with **Bambo** that must be defeated before **Tinkering Tom** arrives, and make regular enemies on that stage visually closer to player size.

### Description
- Added `secondBoss` to the `emberfall` level config and made `spawnBoss` accept an override `bossConfig` so a chained boss can spawn after the first is defeated.
- Introduced `stageBossPhase` state tracking to manage the two-phase boss flow and updated the boss-completion logic to spawn `Tinkering Tom` once Bambo's boss lineage is cleared.
- Registered new `enemyTypes` entries for `bambo` and `tinkeringTom`, added SFX mappings in `ENEMY_CHARACTER_SFX`, and wired their animation sheets under `enemySpriteSheets` using the existing `animation_bambo_*` and `animation_tinkeringTom_*` assets.
- Increased non-boss enemy render scale specifically for `emberfall` by returning player-size scale in `getEnemyRenderScale` when `level.id === 'emberfall'`.

### Testing
- Ran the automated test suite with `npm test -- --runInBand`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72c6096a48329b2d6b8f1097e9047)