### PR TITLE
Reduce SFX overhead during enemy crowds in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -903,11 +903,14 @@
       button: null
     };
     const SFX_POOL_SIZE = 3;
+    const SFX_ALLOW_RUNTIME_POOL_GROWTH = false;
     const SFX_MIN_INTERVAL_MS = 70;
     const SFX_GLOBAL_INTERVAL_MS = 25;
     const SFX_WINDOW_MS = 50;
     const SFX_MAX_PLAYS_PER_WINDOW = 8;
     const SFX_MAX_ACTIVE_INSTANCES = 12;
+    const ENEMY_WALKING_SFX_MAX_PER_FRAME = 1;
+    const ENEMY_WALKING_SFX_NEARBY_DISTANCE = 260;
     const sfxState = {
       pools: new Map(),
       primed: false,
@@ -1063,7 +1066,7 @@
 
       const pool = getSfxPool(src);
       let available = pool.find((audio) => audio.paused || audio.ended);
-      if (!available && pool.length < SFX_POOL_SIZE) {
+      if (!available && SFX_ALLOW_RUNTIME_POOL_GROWTH && pool.length < SFX_POOL_SIZE) {
         available = createSfxAudio(src);
         pool.push(available);
       }
@@ -4522,6 +4525,7 @@
       const player = state.player;
       const hasUndergroundDaph = countUndergroundDaphodilus() > 0;
       state.commandBuffTimer = Math.max(0, state.commandBuffTimer - 1);
+      let enemyWalkingSfxPlayedThisFrame = 0;
       state.enemies.forEach(enemy => {
         const prevX = enemy.x;
         const prevY = enemy.y;
@@ -5023,10 +5027,15 @@
         enemy.walkSfxCooldown = Math.max(0, (enemy.walkSfxCooldown || 0) - 1);
         if (enemy.isMoving && enemy.walkSfxCooldown <= 0) {
           const walkingSfx = ENEMY_CHARACTER_SFX[enemy.type]?.walking;
-          if (walkingSfx) {
+          const playerDistance = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+          const tooFarForWalkingSfx = playerDistance > ENEMY_WALKING_SFX_NEARBY_DISTANCE;
+          if (walkingSfx && !tooFarForWalkingSfx && enemyWalkingSfxPlayedThisFrame < ENEMY_WALKING_SFX_MAX_PER_FRAME) {
             playEnemySfx(enemy, 'walking');
-            enemy.walkSfxCooldown = enemy.isBoss ? 22 : 28;
+            enemyWalkingSfxPlayedThisFrame += 1;
           }
+          const crowdingScale = Math.max(0, state.enemies.length - 10);
+          const baseWalkCooldown = enemy.isBoss ? 22 : 28;
+          enemy.walkSfxCooldown = baseWalkCooldown + Math.min(24, crowdingScale);
         }
 
         if (enemy.attackAnimTimer > 0) enemy.attackAnimTimer -= 1;


### PR DESCRIPTION
### Motivation
- Reduce audio-related CPU/memory churn when many enemies trigger sounds at once to eliminate frame lag during large fights.

### Description
- Added `SFX_ALLOW_RUNTIME_POOL_GROWTH = false` to prevent creating new `Audio` objects in the hot `playSfx` path when pools are exhausted, causing excess plays to be dropped instead of allocating at runtime.
- Added `ENEMY_WALKING_SFX_MAX_PER_FRAME` and `ENEMY_WALKING_SFX_NEARBY_DISTANCE` and a per-frame counter to budget walking SFX so only nearby enemies and a capped number of footsteps are emitted per frame.
- Increased enemy walking cooldown dynamically with crowding by scaling `enemy.walkSfxCooldown` using `state.enemies.length` so footstep attempts are further throttled as swarm size grows.

### Testing
- `git diff --check` — passed.
- `git status --short` / commit — changes staged and commit created successfully (one file changed: `bayou-brawlers/index.html`).
- Inline script parse test with `node -e ...` — failed due to the script extraction/regex approach not matching the file structure, not a runtime failure of the game code itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7327edde48329b1d4d3ef3e00bff0)