### PR TITLE
Update Bayou Brawlers character portraits for 256x256 profile images

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -338,8 +338,8 @@
       touch-action: manipulation;
     }
     .thumb-card img {
-      width: clamp(28px, 4.8vh, 44px);
-      height: clamp(28px, 4.8vh, 44px);
+      width: clamp(32px, 5.2vh, 52px);
+      height: clamp(32px, 5.2vh, 52px);
       image-rendering: pixelated;
       border-radius: 6px;
       border: 1px solid rgba(255,255,255,0.2);
@@ -357,7 +357,7 @@
       background: rgba(6,8,11,0.94);
       padding: clamp(8px, 1.4vh, 12px);
       display: grid;
-      grid-template-columns: minmax(130px, 28vh) minmax(0, 1fr);
+      grid-template-columns: minmax(150px, 32vh) minmax(0, 1fr);
       gap: clamp(8px, 1.1vh, 14px);
       align-items: center;
       touch-action: pan-y;
@@ -365,7 +365,7 @@
     }
     .character-hero-img {
       width: 100%;
-      max-width: min(28vh, 220px);
+      max-width: min(32vh, 256px);
       aspect-ratio: 1 / 1;
       object-fit: contain;
       image-rendering: pixelated;
@@ -7119,7 +7119,7 @@
         thumb.type = 'button';
         thumb.className = 'thumb-card';
         thumb.setAttribute('aria-label', `Select ${character.name}`);
-        thumb.innerHTML = `<img src="${character.portrait}" alt="${character.name} portrait">`;
+        thumb.innerHTML = `<img src="${character.portrait}" alt="${character.name} portrait" width="256" height="256">`;
         thumb.addEventListener('click', () => {
           selectCharacter(index);
         });
@@ -7138,7 +7138,7 @@
       const renderDetail = (character) => {
         detailPanel.classList.add('show');
         detailPanel.innerHTML = `
-          <img class="character-hero-img" src="${character.portrait}" alt="${character.name}">
+          <img class="character-hero-img" src="${character.portrait}" alt="${character.name}" width="256" height="256">
           <div class="character-detail-main">
             <h3>${character.name}</h3>
             <p class="stat">Speed ${character.stats.speed.toFixed(1)} | Power ${character.stats.power.toFixed(2)} | Range ${character.stats.range} | Durability ${character.stats.durability}</p>


### PR DESCRIPTION
### Motivation
- The character profile assets were upgraded to 256×256 and the UI needed to be adjusted so thumbnails and the detail portrait display these higher-resolution images cleanly and without layout breakage.

### Description
- Increased thumbnail image display size from `clamp(28px, 4.8vh, 44px)` to `clamp(32px, 5.2vh, 52px)` to better surface the 256px portraits in the selector grid.
- Widened the detail panel image column from `minmax(130px, 28vh)` to `minmax(150px, 32vh)` to allocate more space for the hero portrait.
- Raised the hero portrait `max-width` to `min(32vh, 256px)` so the detail image can render up to the full 256px asset size.
- Added explicit `width="256"` and `height="256"` attributes to the portrait `<img>` tags in both thumbnail and detail views to stabilize layout and sizing for the new assets.

### Testing
- Ran `git diff --check` to validate there are no whitespace or patch-format issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7375d971c8329ab8ddf118a889957)