### PR TITLE
Increase Green Fairy and Scarlett Glumpkin AOE range

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3096,6 +3096,11 @@
       return !!(player && hasLevel(player, 5));
     }
 
+    function getCharacterAoeRangeMultiplier(characterId) {
+      if (characterId === 'green-fairy' || characterId === 'scarlett-glumpkin') return 2;
+      return 1;
+    }
+
     function getStatusDurationMultiplierForPlayer(player, type) {
       if (!hasLevel5SignaturePassive(player)) return 1;
       const id = player.charData.id;
@@ -4296,7 +4301,7 @@
 
       if (aoeAttackers.has(characterId)) {
         const weakAoeDamage = dmg * 0.65;
-        const aoeRadiusMultiplier = characterId === 'green-fairy' ? 2 : 1;
+        const aoeRadiusMultiplier = getCharacterAoeRangeMultiplier(characterId);
         const weakAoeRadius = (heavy ? 90 : 72) * aoeRadiusMultiplier;
         let hitCount = 0;
         state.enemies.forEach(enemy => {
@@ -4406,6 +4411,7 @@
     function castCharacterAbility(player, isSuper) {
       const id = player.charData.id;
       const radiusBoost = player.specialEffectMultiplier || 1;
+      const aoeRangeMultiplier = getCharacterAoeRangeMultiplier(id);
       if (isSuper) {
         state.shake = 10;
         state.effects.push({
@@ -4423,15 +4429,15 @@
       }
       if (id === 'green-fairy') {
         const applyRegular = () => {
-          const target = state.enemies.find(e => e.hp > 0 && Math.sign(e.x - player.x) === player.facing && Math.abs(e.x - player.x) < 220);
+          const target = state.enemies.find(e => e.hp > 0 && Math.sign(e.x - player.x) === player.facing && Math.abs(e.x - player.x) < (220 * aoeRangeMultiplier));
           if (target) applyStatus(target, 'CHARM', hasLevel(player, 10) ? 900 : 360, 1);
-          else state.effects.push({ x: player.x + player.facing * 50, y: player.y - 30, radius: 80, timer: 24, damage: 8, stun: 20, type: 'shock' });
+          else state.effects.push({ x: player.x + player.facing * 50, y: player.y - 30, radius: 80 * aoeRangeMultiplier, timer: 24, damage: 8, stun: 20, type: 'shock' });
         };
         applyRegular();
         if (isSuper) {
           let charmed = 0;
           state.enemies.forEach(enemy => {
-            if (Math.hypot(enemy.x - player.x, enemy.y - player.y) < 180 * radiusBoost && charmed < (hasLevel(player, 9) ? 6 : 4)) {
+            if (Math.hypot(enemy.x - player.x, enemy.y - player.y) < 180 * radiusBoost * aoeRangeMultiplier && charmed < (hasLevel(player, 9) ? 6 : 4)) {
               applyStatus(enemy, 'CHARM', hasLevel(player, 10) ? 900 : 360, 1);
               charmed += 1;
             }
@@ -4497,7 +4503,7 @@
       } else if (id === 'grimma-the-feared') {
         state.effects.push({ x: player.x, y: player.y, radius: isSuper ? 170 * radiusBoost : 96, timer: isSuper ? (hasLevel(player, 9) ? 168 : 120) : 40, damage: isSuper ? 2 : 8, knockback: 0, stun: isSuper ? 8 : 42, type: 'root' });
       } else if (id === 'scarlett-glumpkin') {
-        state.effects.push({ x: player.x + player.facing * 80, y: player.y, radius: isSuper ? 210 * radiusBoost : 120, timer: isSuper ? 100 : 44, damage: isSuper ? 2 : 7, knockback: 8, stun: 18, type: 'root-poison' });
+        state.effects.push({ x: player.x + player.facing * 80, y: player.y, radius: (isSuper ? 210 * radiusBoost : 120) * aoeRangeMultiplier, timer: isSuper ? 100 : 44, damage: isSuper ? 2 : 7, knockback: 8, stun: 18, type: 'root-poison' });
         if (isSuper && hasUpgrade(player, 'garden-of-thorns')) {
           spawnGardenOfThornsPatches(player);
         }


### PR DESCRIPTION
### Motivation
- Double the effective area/range of Green Fairy and Scarlett Glumpkin AOE attacks so their specials and AOE hit logic reach further.
- Centralize the AOE range decision to make it easy to adjust or reuse for other characters.

### Description
- Added a helper `getCharacterAoeRangeMultiplier(characterId)` that returns `2` for `green-fairy` and `scarlett-glumpkin` and `1` otherwise in `bayou-brawlers/index.html`.
- Applied the multiplier to AOE melee logic so the weak AOE radius uses `aoeRadiusMultiplier` (doubling the radius for the two characters).
- Applied the multiplier to `castCharacterAbility` so Green Fairy's special target distance, charm/shock AOE coverage, and Scarlett Glumpkin's special/super `root-poison` radius are scaled by the same 2x multiplier.

### Testing
- Ran the static check `git -C /workspace/ai-game-of-the-day diff --check`, which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d78be1f02483298ddaf8b6dfee3b5f)