### PR TITLE
Nerf Scarlett Glumpkin Garden of Thorns patch damage by 75%

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2723,6 +2723,7 @@
         const yBounds = getPlayerVerticalBounds(player);
         const y = clamp(player.y + offsetY, yBounds.minY + 6, yBounds.maxY + 2);
         const lifetime = rand(8 * 60, 12 * 60) * 2;
+        const thornPatchDamage = Math.max(1, Math.round(Math.max(5, Math.round(baseDamage * 0.42)) * 0.25));
         state.hazards.push({
           kind: 'thorn-patch',
           x,
@@ -2731,7 +2732,7 @@
           h: rand(32, 52) * 2,
           frames: lifetime,
           maxFrames: lifetime,
-          damage: Math.max(5, Math.round(baseDamage * 0.42)),
+          damage: thornPatchDamage,
           hitInterval: 18 + rand(0, 8),
           touchingEnemies: new Set(),
           phase: Math.random() * Math.PI * 2


### PR DESCRIPTION
### Motivation
- Reduce damage dealt by Scarlett Glumpkin's Garden of Thorns hazard patches for gameplay balance while keeping a minimum of `1` damage so patches remain meaningful.

### Description
- In `bayou-brawlers/index.html` the thorn patch damage calculation was replaced with `const thornPatchDamage = Math.max(1, Math.round(Math.max(5, Math.round(baseDamage * 0.42)) * 0.25))` and the hazard `damage` field now uses `thornPatchDamage`, applying a `0.25` multiplier (75% reduction) to the original calculation.

### Testing
- No automated tests were run for this balance-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85a2d99c08329a4c4edd404d97915)