### PR TITLE
Play companion attack SFX in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4736,6 +4736,7 @@
           companion.attackCooldown = companion.charData.id === 'rustbucket' ? 40 : 22;
           companion.attackFacing = companion.facing;
           companion.animationSignals.attack = true;
+          playPlayerSfx(companion, 'attackFast');
           doAttack(companion, false, false, getCharacterTuning(companion));
         }
 


### PR DESCRIPTION
### Motivation
- Companion characters were performing auto-attacks without emitting their attack sound effects, so the audio feedback for companion actions was missing.

### Description
- Call `playPlayerSfx(companion, 'attackFast')` in `updateCompanions` in `bayou-brawlers/index.html` immediately before `doAttack` so companions play the same attack SFX as the main player.

### Testing
- Ran `npm test -- --runInBand` and all test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9404cc000832998476e04437cc326)