### PR TITLE
Add companion health bars in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -6808,6 +6808,24 @@
           ctx.fillRect(enemy.x - state.cameraX - barWidth / 2, barY, barWidth * hpPct, 6);
         });
 
+      state.companions
+        .filter(companion => companion && companion.hp > 0)
+        .forEach(companion => {
+          const barWidth = 34;
+          const barHeight = 5;
+          const hpPct = clamp(companion.hp / companion.maxHp, 0, 1);
+          const topOpaqueWorldY = getEntityWalkTopOpaqueWorldY(companion, PLAYER_DRAW_SIZE);
+          const barY = topOpaqueWorldY - state.cameraY - 12;
+          const barX = companion.x - state.cameraX - (barWidth / 2);
+
+          ctx.fillStyle = 'rgba(0,0,0,0.58)';
+          ctx.fillRect(barX - 1, barY - 1, barWidth + 2, barHeight + 2);
+          ctx.fillStyle = 'rgba(28, 45, 34, 0.95)';
+          ctx.fillRect(barX, barY, barWidth, barHeight);
+          ctx.fillStyle = '#71f1a4';
+          ctx.fillRect(barX, barY, barWidth * hpPct, barHeight);
+        });
+
       if (showCollisionDebug) {
         ctx.save();
         ctx.strokeStyle = 'rgba(255, 75, 75, 0.9)';


### PR DESCRIPTION
### Motivation
- Provide clear, immediate HP feedback for recruited companions by rendering a compact health bar above each companion so players can judge companion survivability during combat.

### Description
- Added a rendering block in `draw()` of `bayou-brawlers/index.html` to iterate `state.companions` and draw a 34x5 health bar for each living companion using `getEntityWalkTopOpaqueWorldY(companion, PLAYER_DRAW_SIZE)` for vertical placement.
- Health is computed with `clamp(companion.hp / companion.maxHp, 0, 1)` and rendered with a semi-transparent black outline, dark backing, and a green fill that scales to the HP percentage.
- The bars only draw for companions with `hp > 0` and use the same camera/world offsets as other HUD elements so they remain aligned with the sprites.

### Testing
- No automated tests were run because this change is strictly a visual/UI update.
- The patch was applied and reviewed by inspecting the modified `bayou-brawlers/index.html` rendering code for correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d948ff8bb48329a9b7bd66b1542017)