### PR TITLE
Increase companion image size in Bayou Brawlers recruit overlay

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -400,6 +400,26 @@
       box-shadow: 0 0 0 1px #5F9EA0, 0 0 14px rgba(95,158,160,0.8);
       transform: translateY(-1px);
     }
+    #companionOverlay .panel {
+      max-width: min(920px, calc(100vw - 28px));
+      width: min(920px, calc(100vw - 28px));
+    }
+    #companionGrid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: clamp(10px, 1.8vh, 16px);
+      width: min(100%, 860px);
+      margin-top: 10px;
+    }
+    #companionGrid .thumb-card {
+      width: 100%;
+      padding: clamp(8px, 1.4vh, 12px);
+    }
+    #companionGrid .thumb-card img {
+      width: min(100%, clamp(108px, 22vh, 172px));
+      height: auto;
+      aspect-ratio: 1 / 1;
+    }
     .character-detail {
       text-align: left;
       border: 2px solid rgba(255,215,0,0.45);
@@ -705,6 +725,9 @@
         width: min(220px, 58vw);
         justify-self: center;
       }
+      #companionGrid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
       .instructions { font-size: 8px; }
     }
 
@@ -727,6 +750,12 @@
       }
       .character-detail {
         padding: 8px;
+      }
+      #companionGrid .thumb-card {
+        padding: 8px;
+      }
+      #companionGrid .thumb-card img {
+        width: min(100%, clamp(100px, 20vh, 142px));
       }
       .character-detail .move:last-of-type {
         display: none;


### PR DESCRIPTION
### Motivation
- Companion portraits in the recruit overlay were too small and did not make good use of available viewport space.
- The selection modal should present larger, clearer portraits on desktop while remaining legible on small screens.
- The change should be scoped to the recruit overlay so other thumbnail sizes remain unchanged.

### Description
- Widened the recruit modal by adding `#companionOverlay .panel { max-width: min(920px, calc(100vw - 28px)); width: min(920px, calc(100vw - 28px)); }` to give portraits more room.
- Converted the selection area to a responsive grid with `#companionGrid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: clamp(10px, 1.8vh, 16px); }` and constrained grid width for consistent layout.
- Increased per-card padding and portrait sizing with `#companionGrid .thumb-card { padding: clamp(8px, 1.4vh, 12px); }` and `#companionGrid .thumb-card img { width: min(100%, clamp(108px, 22vh, 172px)); height: auto; aspect-ratio: 1 / 1; }` so portraits scale and maintain square aspect.
- Added responsive tweaks in existing media queries to set `#companionGrid` columns for mid-width screens and to reduce portrait size/padding on narrow screens while keeping images larger than previous thumbnails; no JavaScript changes were made.

### Testing
- No automated unit tests cover this UI change; there are no existing JS/CSS unit tests for the overlay.
- Verified the change with `git diff -- bayou-brawlers/index.html` and created the commit which succeeded (`git commit` completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96b2035ac832996bb17f6db95f772)