### PR TITLE
Add stage 1 environmental background animation layer

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1104,6 +1104,7 @@
 
     const assets = {
       backgrounds: {},
+      backgroundAnimations: {},
       foregrounds: {},
       barriers: {},
       barrierMasks: {},
@@ -2202,6 +2203,22 @@
       if (!bgMetrics) return null;
       return {
         foreground,
+        drawX: bgMetrics.drawX,
+        drawY: bgMetrics.drawY,
+        drawWidth: bgMetrics.drawWidth,
+        drawHeight: bgMetrics.drawHeight
+      };
+    }
+
+    function getBackgroundAnimationDrawMetrics(level = levels[state.levelIndex]) {
+      const levelId = level ? level.id : '';
+      const frames = assets.backgroundAnimations[levelId];
+      if (!frames || !frames.length) return null;
+      const bgMetrics = getBackgroundDrawMetrics(level);
+      if (!bgMetrics) return null;
+      const frameIndex = Math.floor((performance.now() / 160) % frames.length);
+      return {
+        frame: frames[frameIndex],
         drawX: bgMetrics.drawX,
         drawY: bgMetrics.drawY,
         drawWidth: bgMetrics.drawWidth,
@@ -6061,6 +6078,18 @@
       );
     }
 
+    function drawBackgroundAnimations() {
+      const animationMetrics = getBackgroundAnimationDrawMetrics();
+      if (!animationMetrics) return;
+      ctx.drawImage(
+        animationMetrics.frame,
+        animationMetrics.drawX,
+        animationMetrics.drawY,
+        animationMetrics.drawWidth,
+        animationMetrics.drawHeight
+      );
+    }
+
     const statusTintCanvas = document.createElement('canvas');
     const statusTintCtx = statusTintCanvas.getContext('2d');
     const burnOverlayCanvas = document.createElement('canvas');
@@ -6725,6 +6754,7 @@
       }
 
       drawBackground();
+      drawBackgroundAnimations();
 
       state.hazards.forEach(hazard => {
         const x = hazard.x - state.cameraX;
@@ -7988,6 +8018,15 @@
         'hell-gate': 'assets/BB_bg_hellGate001_foreground.png',
         docks: 'assets/BB_bg_docks001_foreground.png'
       };
+      const backgroundAnimationKeysByLevelId = {
+        swamp: [
+          'assets/BB_bg_swamp001_animation01.png',
+          'assets/BB_bg_swamp001_animation02.png',
+          'assets/BB_bg_swamp001_animation03.png',
+          'assets/BB_bg_swamp001_animation04.png',
+          'assets/BB_bg_swamp001_animation05.png'
+        ]
+      };
 
       Object.entries(backgroundKeys).forEach(([key, src]) => {
         promises.push(loadImage(src).then(img => { assets.backgrounds[key] = normalizeBackgroundImage(img); }));
@@ -7999,6 +8038,13 @@
 
       Object.entries(foregroundKeysByLevelId).forEach(([levelId, src]) => {
         promises.push(loadImage(src).then((img) => { assets.foregrounds[levelId] = img; }));
+      });
+
+      Object.entries(backgroundAnimationKeysByLevelId).forEach(([levelId, frameSources]) => {
+        const framePromises = frameSources.map(src => loadImage(src));
+        promises.push(Promise.all(framePromises).then((frames) => {
+          assets.backgroundAnimations[levelId] = frames;
+        }));
       });
 
       const playerSpriteSheets = {


### PR DESCRIPTION
### Motivation
- Provide support for full-screen, transparent environmental animation overlays (waterfalls, flames, fireflies, etc.) that render in front of the background but behind gameplay and foreground elements. 
- Ensure these overlays stay aligned with level panning/scale so animation frames match the background art as the camera moves. 
- Implement the first level (stage 1 / swamp) animation set consisting of five frames per level as requested.

### Description
- Added a new asset bucket `assets.backgroundAnimations` to store per-level background-sized animation frames and wired it into the existing `assets` structure with no binary file changes. 
- Implemented `getBackgroundAnimationDrawMetrics(level)` which reuses `getBackgroundDrawMetrics()` for pan/scale alignment and cycles frames using `performance.now()` (frame duration ≈ 160ms). 
- Implemented `drawBackgroundAnimations()` and inserted it into the render pipeline immediately after `drawBackground()` so the animation appears between the base background and in-world entities/foreground. 
- Wired asset loading for stage 1 (`swamp`) by adding a `backgroundAnimationKeysByLevelId` entry that loads the five frames `assets/BB_bg_swamp001_animation01.png` through `...05.png` via `Promise.all` into `assets.backgroundAnimations['swamp']`.

### Testing
- Ran automated tests with `npm test -- --runInBand` and all test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c428b4248329a9df02f51b218466)