### PR TITLE
Improve Bayou Brawlers companion combat AI

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4748,6 +4748,21 @@
       updateEmergencyVentingHud(player);
     }
 
+    function selectCompanionTarget(companion, player) {
+      const livingEnemies = state.enemies.filter(enemy => enemy.hp > 0 && canPlayerAffectEnemy(enemy));
+      if (!livingEnemies.length) return null;
+      return livingEnemies
+        .map((enemy) => {
+          const distance = Math.hypot(enemy.x - companion.x, enemy.y - companion.y);
+          const distanceToPlayer = player ? Math.hypot(enemy.x - player.x, enemy.y - player.y) : distance;
+          const hpRatio = clamp(enemy.hp / Math.max(1, enemy.maxHp || enemy.hp), 0, 1);
+          const pressureBonus = (enemy.windup > 0 || enemy.cooldown < 25) ? -30 : 0;
+          const score = distance + (distanceToPlayer * 0.45) + (hpRatio * 65) + (enemy.isBoss ? 60 : 0) + pressureBonus;
+          return { enemy, score };
+        })
+        .sort((a, b) => a.score - b.score)[0]?.enemy || null;
+    }
+
     function updateCompanions(dt) {
       if (!state.companions.length) return;
       const player = state.player;
@@ -4755,41 +4770,66 @@
         if (!companion || companion.hp <= 0) return;
         const prevX = companion.x;
         const prevY = companion.y;
-        const nearestEnemy = state.enemies
-          .filter(enemy => enemy.hp > 0)
-          .sort((a, b) => Math.hypot(a.x - companion.x, a.y - companion.y) - Math.hypot(b.x - companion.x, b.y - companion.y))[0];
+        const targetEnemy = selectCompanionTarget(companion, player);
 
         let targetX = player ? player.x - (28 + index * 24) : companion.x;
         let targetY = player ? player.y : companion.y;
         let attackTargetInRange = false;
-        if (nearestEnemy) {
-          const distanceX = nearestEnemy.x - companion.x;
-          const distanceY = nearestEnemy.y - companion.y;
-          const targetDistance = Math.hypot(distanceX, distanceY);
-          attackTargetInRange = targetDistance < (companion.range + 48);
-          if (!attackTargetInRange) {
-            targetX = nearestEnemy.x - Math.sign(distanceX || 1) * 32;
-            targetY = nearestEnemy.y;
-          } else {
-            companion.facing = distanceX >= 0 ? 1 : -1;
-          }
+        let targetDistance = Infinity;
+
+        if (targetEnemy) {
+          const distanceX = targetEnemy.x - companion.x;
+          const distanceY = targetEnemy.y - companion.y;
+          targetDistance = Math.hypot(distanceX, distanceY);
+          const pursuitFacing = distanceX >= 0 ? 1 : -1;
+          const preferredSpacing = companion.charData.id === 'rustbucket' ? 72 : 44;
+          const attackReach = companion.range + (companion.charData.id === 'rustbucket' ? 76 : 52);
+          attackTargetInRange = targetDistance <= attackReach;
+
+          targetX = targetEnemy.x - (pursuitFacing * preferredSpacing);
+          targetY = targetEnemy.y + clamp(distanceY * 0.28, -24, 24);
+
+          companion.facing = pursuitFacing;
+          companion.attackFacing = pursuitFacing;
         }
 
         const followX = targetX - companion.x;
         const followY = targetY - companion.y;
         const followDistance = Math.hypot(followX, followY);
-        if (followDistance > 3) {
-          companion.x += (followX / followDistance) * companion.speed * 0.82;
-          companion.y += (followY / followDistance) * companion.speed * 0.52;
-          if (Math.abs(followX) > 2) companion.facing = followX > 0 ? 1 : -1;
+        if (followDistance > 2) {
+          const aggressionSpeedBoost = attackTargetInRange ? 1.05 : 1.18;
+          companion.x += (followX / followDistance) * companion.speed * aggressionSpeedBoost;
+          companion.y += (followY / followDistance) * companion.speed * 0.72;
+          if (Math.abs(followX) > 1.5) companion.facing = followX > 0 ? 1 : -1;
         }
 
-        if (attackTargetInRange && companion.attackCooldown <= 0 && companion.stun <= 0) {
-          companion.attackCooldown = companion.charData.id === 'rustbucket' ? 40 : 22;
-          companion.attackFacing = companion.facing;
-          companion.animationSignals.attack = true;
-          playPlayerSfx(companion, 'attackFast');
-          doAttack(companion, false, false, getCharacterTuning(companion));
+        const canAct = companion.stun <= 0 && companion.actionLock <= 0;
+        if (canAct && targetEnemy && attackTargetInRange) {
+          const tuning = getCharacterTuning(companion);
+          const nearbyEnemies = state.enemies.filter(enemy => enemy.hp > 0 && Math.hypot(enemy.x - companion.x, enemy.y - companion.y) < 150).length;
+          const shouldSpecial = companion.specialCooldown <= 0
+            && companion.power >= SPECIAL_COST
+            && (nearbyEnemies >= 2 || targetEnemy.isBoss || targetDistance <= (companion.range + 26));
+
+          if (shouldSpecial) {
+            const castSuper = companion.power >= (companion.maxPower || BASE_MAX_POWER) * 0.92;
+            companion.specialCooldown = castSuper ? 300 : 170;
+            companion.actionLock = Math.max(14, Math.floor(getSpecialAnimationLockFrames(companion, companion.facing) * 0.8));
+            companion.animationSignals.special = true;
+            addPower(companion, -(castSuper ? SUPER_COST : SPECIAL_COST));
+            playPlayerSfx(companion, 'attackSpecial');
+            castCharacterAbility(companion, castSuper);
+          } else if (companion.powerCooldown <= 0 && (targetDistance <= (companion.range + 18) || targetEnemy.isBoss || Math.random() < 0.45)) {
+            companion.powerCooldown = companion.charData.id === 'shunky-rooster' ? 160 : 32;
+            companion.animationSignals.attack = true;
+            playPlayerSfx(companion, 'attackHeavy');
+            doAttack(companion, true, false, tuning);
+          } else if (companion.attackCooldown <= 0) {
+            companion.attackCooldown = companion.charData.id === 'rustbucket' ? 24 : 13;
+            companion.animationSignals.attack = true;
+            playPlayerSfx(companion, 'attackFast');
+            doAttack(companion, false, false, tuning);
+          }
         }
 
         companion.attackCooldown = Math.max(0, companion.attackCooldown - 1);
@@ -4798,6 +4838,7 @@
         companion.jumpCooldown = Math.max(0, companion.jumpCooldown - 1);
         companion.shieldTimer = Math.max(0, companion.shieldTimer - 1);
         companion.actionLock = Math.max(0, companion.actionLock - 1);
+        addPower(companion, 0.1);
 
         const companionHorizontalBounds = getPlayerHorizontalBounds();
         companion.x = clamp(companion.x, companionHorizontalBounds.minX, companionHorizontalBounds.maxX);


### PR DESCRIPTION
### Motivation
- Companions were passive and only used basic attacks; they need more aggressive, reliable combat behavior and better target selection so they meaningfully support the player.
- Improve aiming/facing and ensure companions use all three attack types (fast, heavy, special) when appropriate to increase combat variety and effectiveness.

### Description
- Added a new `selectCompanionTarget` helper that scores enemies by distance, threat (windup/cooldown), HP ratio, and boss status to pick smarter targets (file: `bayou-brawlers/index.html`).
- Replaced the simple nearest-enemy logic in `updateCompanions` with aggressive pursuit/spacing logic (rustbucket-specific spacing), improved facing/attackFacing alignment, and tuned movement speed while pursuing targets.
- Extended companion combat decision-making so companions choose between `fast`, `heavy`, and `special` attacks using context-aware checks (nearby enemy count, power, boss status, distance), and added super-cast support when power is nearly full.
- Added small passive power regeneration (`addPower(companion, 0.1)`) so companions build toward specials, and adjusted cooldown values and action locks to tighten attack cadence.

### Testing
- Ran the repository test suite with `npm test -- --runInBand` and all automated tests passed (`3` test suites, `6` tests) successfully.
- No additional automated tests were added for AI behavior; changes were verified by running existing test suite only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d7d449dc8329beef848ed6254c64)