### PR TITLE
Buff Scarlett Glumpkin: double chain-reaction spores radius and cloud size

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3633,7 +3633,7 @@
 
     function triggerChainReactionSpores(defeatedEnemy) {
       if (!defeatedEnemy) return;
-      const cloudRadius = 170;
+      const cloudRadius = 340;
       state.enemies.forEach(otherEnemy => {
         if (!otherEnemy || otherEnemy === defeatedEnemy || otherEnemy.hp <= 0) return;
         if (!canPlayerAffectEnemy(otherEnemy)) return;
@@ -3653,7 +3653,7 @@
           y: defeatedEnemy.y - 24 + Math.sin(angle) * rand(4, 24),
           vx: Math.cos(angle) * speed,
           vy: Math.sin(angle) * speed * 0.68,
-          size: rand(26, 62),
+          size: rand(52, 124),
           growth: rand(0.22, 0.75),
           driftX: rand(-0.025, 0.025),
           driftY: rand(-0.06, -0.02),


### PR DESCRIPTION
### Motivation
- Implement the requested buff for Scarlett Glumpkin so her `chain-reaction-spores` ability has twice the poison application radius and twice the visual cloud size.

### Description
- Increased `cloudRadius` in `triggerChainReactionSpores` from `170` to `340` in `bayou-brawlers/index.html` to double the poison application range.
- Doubled the particle cloud size by changing `size: rand(26, 62)` to `size: rand(52, 124)` for `chain-reaction-spore-cloud` particles in `bayou-brawlers/index.html`.

### Testing
- Ran the test suite with `npm test -- --runInBand` and all Jest suites passed (3/3).
- No other automated tests were added or modified; the patch only updates gameplay parameters in `bayou-brawlers/index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da6bb5ccf08329ac2495cb4d6893ae)