### PR TITLE
bayou-brawlers: update Bambo and Sweetykins SFX to .mp3

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1054,8 +1054,8 @@
       elite: { attack: 'assets/BB_sfx_automatick_attack.mp3', hit: 'assets/BB_sfx_automatick_hit.mp3', killed: 'assets/BB_sfx_automatick_killed.mp3', walking: 'assets/BB_sfx_automatick_walking.mp3' },
       brute: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       mage: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
-      sweetykins: { attack: 'assets/BB_sfx_tickles_attack.mp3', hit: 'assets/BB_sfx_tickles_hit.mp3', killed: 'assets/BB_sfx_tickles_killed.mp3' },
-      bambo: { attack: 'assets/BB_sfx_bambo_attack.wav', hit: 'assets/BB_sfx_bambo_hit.wav', killed: 'assets/BB_sfx_bambo_killed.wav', walking: 'assets/BB_sfx_bambo_walking.wav' },
+      sweetykins: { attack: 'assets/BB_sfx_sweetykins_attack.mp3', hit: 'assets/BB_sfx_sweetykins_hit.mp3', killed: 'assets/BB_sfx_sweetykins_killed.mp3' },
+      bambo: { attack: 'assets/BB_sfx_bambo_attack.mp3', hit: 'assets/BB_sfx_bambo_hit.mp3', killed: 'assets/BB_sfx_bambo_killed.mp3', walking: 'assets/BB_sfx_bambo_walking.mp3' },
       tinkeringTom: { attack: 'assets/BB_sfx_tinkeringTom_attack.mp3', hit: 'assets/BB_sfx_tinkeringTom_hit.mp3', killed: 'assets/BB_sfx_tinkeringTom_killed.mp3' },
       boss: { attack: 'assets/BB_sfx_mudMonster_attack.mp3', hit: 'assets/BB_sfx_mudMonster_hit.mp3', killed: 'assets/BB_sfx_mudMonster_killed.mp3' }
     };


### PR DESCRIPTION
### Motivation
- Ensure the in-game SFX mapping matches the newly provided MP3 asset naming so the stage 2 boss `Sweetykins` and stage 10 enemy `Bambo` use their dedicated `.mp3` sound effects at runtime.

### Description
- Update `bayou-brawlers/index.html` to point `sweetykins` SFX to `assets/BB_sfx_sweetykins_*.mp3` instead of the `tickles` set, and change `bambo` SFX references from `.wav` to `assets/BB_sfx_bambo_*.mp3`.

### Testing
- Verified the mapping changes with a targeted replacement and diff of `bayou-brawlers/index.html`, and ran file existence checks with `test -f` for the new `BB_sfx_sweetykins_*` and `BB_sfx_bambo_*` MP3 files which reported those asset files as missing in this checkout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db206d09ec83299f7f4d467e41f177)