### PR TITLE
Update Bayou Brawlers Sweetykins SFX asset references

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1054,7 +1054,7 @@
       elite: { attack: 'assets/BB_sfx_automatick_attack.mp3', hit: 'assets/BB_sfx_automatick_hit.mp3', killed: 'assets/BB_sfx_automatick_killed.mp3', walking: 'assets/BB_sfx_automatick_walking.mp3' },
       brute: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       mage: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
-      sweetykins: { attack: 'assets/BB_sfx_tickles_attack.mp3', hit: 'assets/BB_sfx_tickles_hit.mp3', killed: 'assets/BB_sfx_tickles_killed.mp3' },
+      sweetykins: { attack: 'assets/BB_sfx_sweetykins_attack.png', hit: 'assets/BB_sfx_sweetykins_hit.png', killed: 'assets/BB_sfx_sweetykins_killed.png' },
       bambo: { attack: 'assets/BB_sfx_bambo_attack.wav', hit: 'assets/BB_sfx_bambo_hit.wav', killed: 'assets/BB_sfx_bambo_killed.wav', walking: 'assets/BB_sfx_bambo_walking.wav' },
       tinkeringTom: { attack: 'assets/BB_sfx_tinkeringTom_attack.mp3', hit: 'assets/BB_sfx_tinkeringTom_hit.mp3', killed: 'assets/BB_sfx_tinkeringTom_killed.mp3' },
       boss: { attack: 'assets/BB_sfx_mudMonster_attack.mp3', hit: 'assets/BB_sfx_mudMonster_hit.mp3', killed: 'assets/BB_sfx_mudMonster_killed.mp3' }


### PR DESCRIPTION
### Motivation
- Align the Stage 2 boss `sweetykins` sound profile with the newly uploaded asset filenames `BB_sfx_sweetykins_*` because the code previously pointed at `BB_sfx_tickles_*` assets.

### Description
- Updated the `sweetykins` entry in `ENEMY_CHARACTER_SFX` in `bayou-brawlers/index.html` to use `assets/BB_sfx_sweetykins_attack.png`, `assets/BB_sfx_sweetykins_hit.png`, and `assets/BB_sfx_sweetykins_killed.png` instead of the old `BB_sfx_tickles_*.mp3` paths.

### Testing
- Ran repository searches with `rg` to confirm references were updated and verified the modified lines in `bayou-brawlers/index.html` via a diff, and checked the `bayou-brawlers/assets` directory to confirm the corresponding `BB_sfx_sweetykins_*` files exist; all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf8f3a6848329a003565467ae837a)