### PR TITLE
Update Sweetykins SFX mapping to use sweetykins MP3 assets

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1054,7 +1054,7 @@
       elite: { attack: 'assets/BB_sfx_automatick_attack.mp3', hit: 'assets/BB_sfx_automatick_hit.mp3', killed: 'assets/BB_sfx_automatick_killed.mp3', walking: 'assets/BB_sfx_automatick_walking.mp3' },
       brute: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       mage: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
-      sweetykins: { attack: 'assets/BB_sfx_tickles_attack.mp3', hit: 'assets/BB_sfx_tickles_hit.mp3', killed: 'assets/BB_sfx_tickles_killed.mp3' },
+      sweetykins: { attack: 'assets/BB_sfx_sweetykins_attack.mp3', hit: 'assets/BB_sfx_sweetykins_hit.mp3', killed: 'assets/BB_sfx_sweetykins_killed.mp3', walking: 'assets/BB_sfx_sweetykins_walking.mp3' },
       bambo: { attack: 'assets/BB_sfx_bambo_attack.wav', hit: 'assets/BB_sfx_bambo_hit.wav', killed: 'assets/BB_sfx_bambo_killed.wav', walking: 'assets/BB_sfx_bambo_walking.wav' },
       tinkeringTom: { attack: 'assets/BB_sfx_tinkeringTom_attack.mp3', hit: 'assets/BB_sfx_tinkeringTom_hit.mp3', killed: 'assets/BB_sfx_tinkeringTom_killed.mp3' },
       boss: { attack: 'assets/BB_sfx_mudMonster_attack.mp3', hit: 'assets/BB_sfx_mudMonster_hit.mp3', killed: 'assets/BB_sfx_mudMonster_killed.mp3' }


### PR DESCRIPTION
### Motivation
- Replace the stage 2 boss Sweetykins tickle SFX entries so the enemy uses the provided `BB_sfx_sweetykins_*.mp3` assets (attack/hit/killed) and include the `walking` mapping, without adding or changing any binary assets.

### Description
- Updated the `sweetykins` sound mapping in `bayou-brawlers/index.html` to use `assets/BB_sfx_sweetykins_attack.mp3`, `assets/BB_sfx_sweetykins_walking.mp3`, `assets/BB_sfx_sweetykins_hit.mp3`, and `assets/BB_sfx_sweetykins_killed.mp3` in place of the previous `tickles` files.

### Testing
- Automated replacement script (`python` invocation) applied the change to `bayou-brawlers/index.html` and completed successfully.
- File content verification using `nl`/`sed` confirmed the updated `sweetykins` mapping lines are present and reference the new `BB_sfx_sweetykins_*.mp3` assets.
- Repository status and diff checks indicate the change is recorded and the working tree is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2aa79c708329918f4a5c02c600bf)