### PR TITLE
Update Sweetykins stage 2 boss SFX mapping

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1054,7 +1054,7 @@
       elite: { attack: 'assets/BB_sfx_automatick_attack.mp3', hit: 'assets/BB_sfx_automatick_hit.mp3', killed: 'assets/BB_sfx_automatick_killed.mp3', walking: 'assets/BB_sfx_automatick_walking.mp3' },
       brute: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       mage: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
-      sweetykins: { attack: 'assets/BB_sfx_tickles_attack.mp3', hit: 'assets/BB_sfx_tickles_hit.mp3', killed: 'assets/BB_sfx_tickles_killed.mp3' },
+      sweetykins: { attack: 'assets/BB_sfx_sweetykins_attack.mp3', hit: 'assets/BB_sfx_sweetykins_hit.mp3', killed: 'assets/BB_sfx_sweetykins_killed.mp3', walking: 'assets/BB_sfx_sweetykins_walking.mp3' },
       bambo: { attack: 'assets/BB_sfx_bambo_attack.wav', hit: 'assets/BB_sfx_bambo_hit.wav', killed: 'assets/BB_sfx_bambo_killed.wav', walking: 'assets/BB_sfx_bambo_walking.wav' },
       tinkeringTom: { attack: 'assets/BB_sfx_tinkeringTom_attack.mp3', hit: 'assets/BB_sfx_tinkeringTom_hit.mp3', killed: 'assets/BB_sfx_tinkeringTom_killed.mp3' },
       boss: { attack: 'assets/BB_sfx_mudMonster_attack.mp3', hit: 'assets/BB_sfx_mudMonster_hit.mp3', killed: 'assets/BB_sfx_mudMonster_killed.mp3' }


### PR DESCRIPTION
### Motivation
- Replace the Tickles sound assets currently assigned to the stage 2 boss `sweetykins` with the Sweetykins-specific `.mp3` files so the boss uses its proper attack, hit, killed, and walking sounds.

### Description
- Replaced the `sweetykins` entry in `bayou-brawlers/index.html` to use `assets/BB_sfx_sweetykins_attack.mp3`, `assets/BB_sfx_sweetykins_hit.mp3`, and `assets/BB_sfx_sweetykins_killed.mp3` instead of the Tickles files. 
- Added the `walking` mapping `assets/BB_sfx_sweetykins_walking.mp3` for Sweetykins.
- This is a code-only change; no binary assets were added or modified.

### Testing
- Located occurrences with `rg -n "sweetykins|tickle|stage 2|stage2|boss" .` and `rg -n "BB_sfx|sweetykins|tickles|bayou" bayou-brawlers`, and both commands completed successfully. 
- Applied the update via a small Python replace script that modified `bayou-brawlers/index.html`, and the script exited successfully. 
- Verified the updated lines with `nl -ba bayou-brawlers/index.html | sed -n '1048,1062p'`, which showed the new `sweetykins` mapping and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd442d98a8832984225962a22b2978)