### PR TITLE
Update Bayou Brawlers Bambo SFX mapping to Sweetykins MP3s

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1055,7 +1055,7 @@
       brute: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       mage: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
       sweetykins: { attack: 'assets/BB_sfx_sweetykins_attack.mp3', hit: 'assets/BB_sfx_sweetykins_hit.mp3', killed: 'assets/BB_sfx_sweetykins_killed.mp3', walking: 'assets/BB_sfx_sweetykins_walking.mp3' },
-      bambo: { attack: 'assets/BB_sfx_bambo_attack.wav', hit: 'assets/BB_sfx_bambo_hit.wav', killed: 'assets/BB_sfx_bambo_killed.wav', walking: 'assets/BB_sfx_bambo_walking.wav' },
+      bambo: { attack: 'assets/BB_sfx_sweetykins_attack.mp3', hit: 'assets/BB_sfx_sweetykins_hit.mp3', killed: 'assets/BB_sfx_sweetykins_killed.mp3', walking: 'assets/BB_sfx_sweetykins_walking.mp3' },
       tinkeringTom: { attack: 'assets/BB_sfx_tinkeringTom_attack.mp3', hit: 'assets/BB_sfx_tinkeringTom_hit.mp3', killed: 'assets/BB_sfx_tinkeringTom_killed.mp3' },
       boss: { attack: 'assets/BB_sfx_mudMonster_attack.mp3', hit: 'assets/BB_sfx_mudMonster_hit.mp3', killed: 'assets/BB_sfx_mudMonster_killed.mp3' }
     };


### PR DESCRIPTION
### Motivation
- Stage 10 boss `Bambo` should use the Sweetykins MP3 sound assets for `attack`, `walking`, `hit`, and `killed` instead of the previous `.wav` files to match the requested sound design and existing assets.

### Description
- Replaced the `bambo` SFX mapping in `bayou-brawlers/index.html` to use `assets/BB_sfx_sweetykins_attack.mp3`, `assets/BB_sfx_sweetykins_walking.mp3`, `assets/BB_sfx_sweetykins_hit.mp3`, and `assets/BB_sfx_sweetykins_killed.mp3` in place of the old `.wav` paths.

### Testing
- Verified the change with `rg` to locate the `bambo` mapping, inspected the `git diff` showing the replacement in `bayou-brawlers/index.html`, and committed the update; all verification commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd770d7c8083298f6ceada3f9f04fe)