### PR TITLE
Bayou Brawlers: Switch Bambo SFX to MP3

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1055,7 +1055,7 @@
       brute: { attack: 'assets/BB_sfx_hiredGun_attack.mp3', hit: 'assets/BB_sfx_hiredGun_hit.mp3', killed: 'assets/BB_sfx_hiredGun_killed.mp3' },
       mage: { attack: 'assets/BB_sfx_ladyWorthington_attack.mp3', hit: 'assets/BB_sfx_queenOfHearts_hit.mp3', killed: 'assets/BB_sfx_ladyWorthington_dying.mp3' },
       sweetykins: { attack: 'assets/BB_sfx_sweetykins_attack.mp3', hit: 'assets/BB_sfx_sweetykins_hit.mp3', killed: 'assets/BB_sfx_sweetykins_killed.mp3', walking: 'assets/BB_sfx_sweetykins_walking.mp3' },
-      bambo: { attack: 'assets/BB_sfx_bambo_attack.wav', hit: 'assets/BB_sfx_bambo_hit.wav', killed: 'assets/BB_sfx_bambo_killed.wav', walking: 'assets/BB_sfx_bambo_walking.wav' },
+      bambo: { attack: 'assets/BB_sfx_bambo_attack.mp3', hit: 'assets/BB_sfx_bambo_hit.mp3', killed: 'assets/BB_sfx_bambo_killed.mp3', walking: 'assets/BB_sfx_bambo_walking.mp3' },
       tinkeringTom: { attack: 'assets/BB_sfx_tinkeringTom_attack.mp3', hit: 'assets/BB_sfx_tinkeringTom_hit.mp3', killed: 'assets/BB_sfx_tinkeringTom_killed.mp3' },
       boss: { attack: 'assets/BB_sfx_mudMonster_attack.mp3', hit: 'assets/BB_sfx_mudMonster_hit.mp3', killed: 'assets/BB_sfx_mudMonster_killed.mp3' }
     };


### PR DESCRIPTION
### Motivation
- Use the requested MP3 sound effect files for the stage 10 boss `bambo` so the game references `BB_sfx_bambo_attack.mp3`, `BB_sfx_bambo_walking.mp3`, `BB_sfx_bambo_hit.mp3`, and `BB_sfx_bambo_killed.mp3` instead of the previous `.wav` assets.

### Description
- Updated the `bambo` enemy sound mapping in `bayou-brawlers/index.html` to point `attack`, `walking`, `hit`, and `killed` to the corresponding `.mp3` files (no other changes and no binary files added).

### Testing
- Verified the mapping update with `rg -n "bambo: \{ attack" bayou-brawlers/index.html`, inspected the file region, ran `git status --short`, and committed the change with `git commit`, and each step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda6f535f483298dfba110a8a73832)