### PR TITLE
Adjust Level 10 (Tom’s Machine) world size and disable wave barriers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1460,7 +1460,7 @@
         { types: ['swamp', 'ranged'], count: 8 },
         { types: ['automaton', 'swamp'], count: 8 }
       ], boss: { name: 'Drowned Count', type: 'brute' } },
-      { id: 'emberfall', name: 'The Gatorglass Vault: Tom’s Machine', background: 'background-toms-machine', waves: [
+      { id: 'emberfall', name: 'The Gatorglass Vault: Tom’s Machine', background: 'background-toms-machine', useBackgroundSizedWorld: true, disableWaveBarriers: true, waves: [
         { types: ['thug', 'ranged'], count: 8 },
         { types: ['thug', 'automaton'], count: 9 },
         { types: ['elite', 'thug'], count: 9 }
@@ -2165,6 +2165,9 @@
       }
 
       const bgWorldWidth = Math.floor(bg.width * getBackgroundScale(bg));
+      if (level.useBackgroundSizedWorld) {
+        return Math.max(canvas.width + 640, bgWorldWidth + 420);
+      }
       return Math.max(canvas.width + 640, bgWorldWidth + 420, fallbackWidth);
     }
 
@@ -2960,6 +2963,8 @@
     }
 
     function getWaveBarrierX() {
+      const level = levels[state.levelIndex];
+      if (level?.disableWaveBarriers) return null;
       return state.waveActive && state.lockX !== null ? state.lockX : null;
     }
 


### PR DESCRIPTION
### Motivation
- Tom’s Machine uses a much smaller background than other stages, but fallback sizing and wave barrier logic made traversal feel longer and artificially constrained; the change makes movement across the whole map immediate and proportional to its background.

### Description
- Add level flags `useBackgroundSizedWorld: true` and `disableWaveBarriers: true` to the `emberfall` level entry so the stage can opt into background-sized world width and no wave barriers.
- Update `getLevelWorldWidth` to respect `level.useBackgroundSizedWorld` when computing `state.levelWidth`, and update `getWaveBarrierX` to return `null` when `level.disableWaveBarriers` is set so movement is not gated by wave barriers for that level.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4016704c83299af45e3e85722860)