### PR TITLE
bayou-brawlers: change POWER button label to heavy

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -850,7 +850,7 @@
       <div class="action-pad">
         <button class="pad-btn primary" data-input="fast">FAST</button>
         <button class="pad-btn" data-input="jump">JUMP</button>
-        <button class="pad-btn warn" data-input="power">POWER</button>
+        <button class="pad-btn warn" data-input="power">heavy</button>
         <button class="pad-btn" data-input="special">SPEC</button>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Align the on-screen action pad label with the in-game terminology for the heavy attack by changing the mobile button text from `POWER` to `heavy` as requested.

### Description
- Updated the action pad button label in `bayou-brawlers/index.html`, replacing the `>POWER<` label with `>heavy<` for the `data-input="power"` button.

### Testing
- Located occurrences with `rg`, applied the replacement via a small Python script, inspected the changed lines with `nl`, verified the change with `git diff -- bayou-brawlers/index.html`, and committed the update; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9b36aa348329a511d24eca3dc0b7)