### PR TITLE
bayou-brawlers: change heavy attack button label to HEAVY

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -850,7 +850,7 @@
       <div class="action-pad">
         <button class="pad-btn primary" data-input="fast">FAST</button>
         <button class="pad-btn" data-input="jump">JUMP</button>
-        <button class="pad-btn warn" data-input="power">POWER</button>
+        <button class="pad-btn warn" data-input="power">HEAVY</button>
         <button class="pad-btn" data-input="special">SPEC</button>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Rename the on-screen heavy attack label from `POWER` to `HEAVY` to improve clarity while preserving existing input wiring.

### Description
- Updated the button text in `bayou-brawlers/index.html` from `POWER` to `HEAVY` and left the `data-input="power"` attribute unchanged.

### Testing
- Verified the update with `rg -n "data-input=\"power\"" bayou-brawlers/index.html`, confirming the button label now reads `HEAVY`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69decb14e96c83299c47321dd262e4f9)