### PR TITLE
Adjust stage 3 non-boss enemy scale in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1850,7 +1850,7 @@
       const level = levels[state.levelIndex];
 
       if (level && level.id === 'emberfall' && !isBoss) return asPlayerSizeRatio(1);
-      if (!isBoss && stage === 3) return asPlayerSizeRatio(0.95);
+      if (!isBoss && stage === 3) return asPlayerSizeRatio(1.2);
 
       if (typeId === 'choking-blossom') return asPlayerSizeRatio(1);
       if (typeId === 'swamp') return asPlayerSizeRatio(0.5);

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1850,6 +1850,7 @@
       const level = levels[state.levelIndex];
 
       if (level && level.id === 'emberfall' && !isBoss) return asPlayerSizeRatio(1);
+      if (!isBoss && stage === 3) return asPlayerSizeRatio(0.95);
 
       if (typeId === 'choking-blossom') return asPlayerSizeRatio(1);
       if (typeId === 'swamp') return asPlayerSizeRatio(0.5);


### PR DESCRIPTION
### Motivation
- Bring Stage 3 non-boss enemies visually closer to the player by making their render size approximately the same as the player character for better balance and readability.

### Description
- Add an early return in `getEnemyRenderScale` in `bayou-brawlers/index.html` so that when `!isBoss && stage === 3` the function returns `asPlayerSizeRatio(0.95)`, leaving boss sizing and other type-specific scaling unchanged.

### Testing
- Ran `npm test -- --runInBand`, all tests passed (`__tests__/paddleBuff.test.js`, `__tests__/shuffleSoundtrack.test.js`, `__tests__/shuffle.test.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df842bf41c8329979465db6b1e1a62)