### PR TITLE
Halve Bayou Brawlers wave enemy counts after stage 1

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3134,9 +3134,11 @@
       if (!wave) return;
       const waveLockX = getWaveLockX(waveIndex);
       state.enemies = [];
-      const spawnCount = (waveIndex === 0
+      const baseSpawnCount = (waveIndex === 0
         ? Math.max(2, Math.round(wave.count * INITIAL_WAVE_ENEMY_MULTIPLIER))
         : wave.count) * ENEMY_COUNT_MULTIPLIER;
+      const isStageOne = state.levelIndex === 0;
+      const spawnCount = isStageOne ? baseSpawnCount : Math.max(1, Math.ceil(baseSpawnCount / 2));
       const leftCount = Math.ceil(spawnCount / 2);
       const rightBaseX = clamp(waveLockX + 180, waveLockX + 80, state.levelWidth - 160);
       const leftBaseX = clamp(waveLockX - 180, 60, state.levelWidth - 160);


### PR DESCRIPTION
### Motivation
- Reduce wave difficulty for stages after the first by halving the number of enemies spawned per regular wave while preserving stage 1 behavior.

### Description
- In `bayou-brawlers/index.html` updated `spawnWave` to compute `baseSpawnCount` as before and then set `spawnCount` to `baseSpawnCount` when `state.levelIndex === 0`, otherwise to `Math.max(1, Math.ceil(baseSpawnCount / 2))` so non-stage-1 waves spawn roughly half as many enemies.

### Testing
- No automated tests were run in this environment; change was validated by inspecting the `git diff` for `bayou-brawlers/index.html` and committing the patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e37a78fe688329bd8b104b18c8dbff)