### PR TITLE
Tune Bayou Brawlers enemy scaling through stage 10

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1613,6 +1613,12 @@
     const PLAYER_STUN_TYPES = new Set(['brute', 'boss', 'mud-monster', 'sweetykins']);
     const ENEMY_DEATH_HOLD_FRAMES = 240;
     const ENEMY_DAMAGE_MULTIPLIER = 0.75;
+    const ENEMY_BASE_HEALTH_MULTIPLIER = 1.5;
+    const ENEMY_BASE_DAMAGE_MULTIPLIER = 1.5;
+    const STAGE_DIFFICULTY_HEALTH_MIN = 1;
+    const STAGE_DIFFICULTY_HEALTH_MAX = 2.15;
+    const STAGE_DIFFICULTY_DAMAGE_MIN = 1;
+    const STAGE_DIFFICULTY_DAMAGE_MAX = 1.85;
     const MECHANIZED_MOMENTUM_MAX_STACKS = 12;
     const MECHANIZED_MOMENTUM_STACK_MULTIPLIER = 0.03;
     const MECHANIZED_MOMENTUM_DURATION_FRAMES = 120;
@@ -1879,6 +1885,17 @@
         };
       }
       return { hp: base.hp, speed: base.speed, damage: base.damage, range: base.range, score: base.score };
+    }
+
+    function getStageDifficultyScale(levelIndex = state.levelIndex) {
+      const stageNumber = clamp((levelIndex || 0) + 1, 1, CAMPAIGN_STAGE_LIMIT);
+      const progressToFinal = CAMPAIGN_STAGE_LIMIT <= 1
+        ? 1
+        : (stageNumber - 1) / (CAMPAIGN_STAGE_LIMIT - 1);
+      return {
+        hp: lerp(STAGE_DIFFICULTY_HEALTH_MIN, STAGE_DIFFICULTY_HEALTH_MAX, progressToFinal),
+        damage: lerp(STAGE_DIFFICULTY_DAMAGE_MIN, STAGE_DIFFICULTY_DAMAGE_MAX, progressToFinal)
+      };
     }
 
     function clampEnemyRenderScale(scale, isBoss, typeId = null) {
@@ -2600,6 +2617,9 @@
       const base = enemyTypes[typeId];
       const stage = STAGED_ENEMY_TYPES.has(typeId) ? (options.stage || 3) : 1;
       const stats = STAGED_ENEMY_TYPES.has(typeId) ? getStagedStats(typeId, stage) : base;
+      const stageDifficultyScale = getStageDifficultyScale();
+      const hpMultiplier = ENEMY_BASE_HEALTH_MULTIPLIER * stageDifficultyScale.hp;
+      const damageMultiplier = ENEMY_BASE_DAMAGE_MULTIPLIER * stageDifficultyScale.damage;
       const animationTracks = assets.enemyAnimations[typeId] || assets.enemyAnimations.swamp || null;
       const baseRenderScale = getEnemyRenderScale(typeId, stage, isBoss) * getDaphodilusLevelOneScale(typeId);
       const requestedSizeMultiplier = Number.isFinite(options.sizeMultiplier) ? options.sizeMultiplier : 1;
@@ -2612,10 +2632,10 @@
         y,
         z: 0,
         stage,
-        hp: stats.hp * (isBoss ? 1.15 : 1),
-        maxHp: stats.hp * (isBoss ? 1.15 : 1),
+        hp: stats.hp * hpMultiplier * (isBoss ? 1.15 : 1),
+        maxHp: stats.hp * hpMultiplier * (isBoss ? 1.15 : 1),
         speed: stats.speed * ENEMY_SPEED_MULTIPLIER,
-        damage: stats.damage,
+        damage: stats.damage * damageMultiplier,
         range: stats.range,
         score: stats.score,
         sprite: base.sprite === 'boss' ? assets.boss : assets.enemies[base.sprite],


### PR DESCRIPTION
### Motivation
- Raise overall threat from enemies by +50% to HP and damage and make difficulty increase across stages so Stage 10 is a clear peak challenge targeted for a level ~18–20 character.

### Description
- Added new global tuning constants `ENEMY_BASE_HEALTH_MULTIPLIER` and `ENEMY_BASE_DAMAGE_MULTIPLIER` (both 1.5) and stage curve bounds (`STAGE_DIFFICULTY_*_MIN/MAX`) in `bayou-brawlers/index.html`.
- Implemented `getStageDifficultyScale(levelIndex)` to compute a per-stage HP/damage scale that linearly interpolates from Stage 1 to the campaign limit (Stage 10).
- Applied combined scaling inside `createEnemy()` so enemy `hp`, `maxHp`, and `damage` are multiplied by the base +50% multipliers and the stage difficulty scale, with the existing boss HP bonus preserved.
- The change is centralized so it affects normal enemies, staged (`mud-monster`) variants, and bosses consistently.

### Testing
- Ran the project test suite with `npm test -- --runInBand` and all Jest suites passed (`3 passed, 3 total`).
- No automated gameplay/regression tests were added; the change is limited to `bayou-brawlers/index.html` and validated by the existing unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e462e2104c8329909a31b5ee168318)