### PR TITLE
Bayou Brawlers: replace stage advance button with timed typewriter notifications

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3216,12 +3216,16 @@
       showNotification('Invulnerability activated. Score set to zero.');
     }
 
-    function showNotification(message, holdMs = 2400) {
+    function showNotification(message, holdMs = 2400, options = {}) {
       const stack = document.getElementById('notificationStack');
       if (!stack || !message) return;
       const bubble = document.createElement('div');
       bubble.className = 'notification-bubble';
-      bubble.textContent = message;
+      const text = String(message);
+      const typewriterMsPerChar = Number.isFinite(options.typewriterMsPerChar)
+        ? Math.max(0, Number(options.typewriterMsPerChar))
+        : 0;
+      bubble.textContent = typewriterMsPerChar > 0 ? '' : text;
       bubble.dataset.id = String(notificationId += 1);
       stack.appendChild(bubble);
 
@@ -3229,13 +3233,32 @@
         bubble.classList.add('show');
       });
 
-      window.setTimeout(() => {
-        bubble.classList.add('hide');
-      }, holdMs);
+      const beginHide = () => {
+        window.setTimeout(() => {
+          bubble.classList.add('hide');
+        }, holdMs);
+      };
+
+      if (typewriterMsPerChar > 0) {
+        let index = 0;
+        const typeNextCharacter = () => {
+          if (!bubble.isConnected) return;
+          bubble.textContent = text.slice(0, index + 1);
+          index += 1;
+          if (index >= text.length) {
+            beginHide();
+            return;
+          }
+          window.setTimeout(typeNextCharacter, typewriterMsPerChar);
+        };
+        window.setTimeout(typeNextCharacter, typewriterMsPerChar);
+      } else {
+        beginHide();
+      }
 
       window.setTimeout(() => {
         bubble.remove();
-      }, holdMs + 1800);
+      }, holdMs + 1800 + (typewriterMsPerChar > 0 ? (text.length * typewriterMsPerChar) : 0));
     }
 
     function loadProgress() {
@@ -6155,7 +6178,7 @@
             state.pendingCompanionRecruitStage = state.levelIndex;
             showCompanionRecruitOverlay();
           } else {
-            showMessage('Stage Cleared', `${levels[state.levelIndex].name} awaits.`, 'Advance');
+            showNotification(`${levels[state.levelIndex].name} awaits.`, 3000, { typewriterMsPerChar: 24 });
           }
         } else {
           endGame(true);
@@ -6256,7 +6279,7 @@
         state.pendingCompanionRecruitStage = state.levelIndex;
         showCompanionRecruitOverlay();
       } else {
-        showMessage('Stage Skipped', `${levels[state.levelIndex].name} begins now.`, 'Advance');
+        showNotification(`${levels[state.levelIndex].name} begins now.`, 3000, { typewriterMsPerChar: 24 });
       }
     }
 


### PR DESCRIPTION
### Motivation
- Remove the blocking “Advance” button that required player input when transitioning stages and instead present the next-stage text as a transient on-screen notification.
- Make the stage transitions behave like other notifications (appear, hold, fade) and allow the text to appear gradually so the message reads like an in-game notification.

### Description
- Replaced the modal `Advance` flow for normal stage-complete and stage-skip paths with calls to `showNotification(...)` in `bayou-brawlers/index.html` so the game continues without a button click.
- Enhanced `showNotification` to accept an `options` argument and a `typewriterMsPerChar` mode via the new signature `showNotification(message, holdMs = 2400, options = {})` to render text incrementally, hold, then fade out.
- Adjusted notification removal timing to account for the typewriter duration so messages do not disappear prematurely.
- Left the game-over score submission overlay and its button-based flow unchanged.

### Testing
- Ran the test suite with `npm test -- --runInBand`, which passed: `3` test suites and `6` tests all succeeded.
- No visual browser capture was performed in this environment; changes were verified by running unit tests and inspecting the modified `bayou-brawlers/index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ed293244832983e618d3690e2abd)