### PR TITLE
bayou-brawlers: increase global enemy speed by 50%

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1548,7 +1548,7 @@
 
     const INITIAL_WAVE_ENEMY_MULTIPLIER = 0.75;
     const ENEMY_COUNT_MULTIPLIER = 2;
-    const ENEMY_SPEED_MULTIPLIER = 0.82;
+    const ENEMY_SPEED_MULTIPLIER = 1.23;
     const REGULAR_WAVE_COUNT = 8;
     const TOTAL_WAVE_COUNT = 9;
     const CAMPAIGN_STAGE_LIMIT = Math.min(10, levels.length);


### PR DESCRIPTION
### Motivation
- Make enemy movement more challenging by increasing the global enemy speed multiplier so all enemies move 50% faster.

### Description
- Updated the global constant `ENEMY_SPEED_MULTIPLIER` in `bayou-brawlers/index.html` from `0.82` to `1.23`, which is applied as `speed: stats.speed * ENEMY_SPEED_MULTIPLIER` during `createEnemy`.

### Testing
- Applied the change with a small `python` replace script and validated the update and locations with `rg -n "ENEMY_SPEED_MULTIPLIER" bayou-brawlers/index.html` and `nl -ba bayou-brawlers/index.html` and confirmed the multiplier is used in `createEnemy`; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fe2487d883299ea92e6e07dcf517)