### PR TITLE
Convert Bayou Briar to support caster and add briar-support-patch hazard

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2850,7 +2850,7 @@
     function getMudTrailMovementScale(player, targetX, targetY) {
       const slowMultiplier = getEnvironmentalHazardSlowMultiplier(player);
       if (slowMultiplier <= 0) return 1;
-      const touchingMudTrail = state.hazards.some(h => h.kind === 'mud-trail'
+      const touchingMudTrail = state.hazards.some(h => (h.kind === 'mud-trail' || h.kind === 'briar-support-patch')
         && Math.abs(targetX - h.x) < h.w * 0.5
         && Math.abs(targetY - h.y) < h.h * 0.5);
       if (!touchingMudTrail) return 1;
@@ -2872,6 +2872,29 @@
         w: width,
         h: height,
         frames: Number.POSITIVE_INFINITY
+      });
+    }
+
+
+    function spawnBriarSupportPatch(x, y) {
+      const width = rand(90, 132);
+      const height = rand(34, 52);
+      const nearExistingPatch = state.hazards.some(h => h.kind === 'briar-support-patch'
+        && Math.abs(h.x - x) < ((h.w + width) * 0.45)
+        && Math.abs(h.y - y) < ((h.h + height) * 0.45));
+      if (nearExistingPatch) return;
+      state.hazards.push({
+        kind: 'briar-support-patch',
+        x,
+        y,
+        w: width,
+        h: height,
+        frames: rand(10 * 60, 14 * 60),
+        stunChance: 0.08,
+        stunFrames: 32,
+        stunInterval: 22,
+        palette: Math.random() < 0.5 ? 'yellow' : 'green',
+        phase: Math.random() * Math.PI * 2
       });
     }
 
@@ -5290,6 +5313,32 @@
               enemy.attackAnimTimer = 14;
             }
           }
+        } else if (enemy.type === 'bayouBriar') {
+          const supportDistance = 145;
+          const supportDelta = distance - supportDistance;
+          if (Math.abs(supportDelta) > 18) {
+            enemy.x += Math.sign(dx) * moveSpeed * 0.82;
+            enemy.y += Math.sign(dy) * moveSpeed * 0.42;
+            enemy.isMoving = true;
+          } else {
+            const strafeDirection = enemy.uid % 2 === 0 ? 1 : -1;
+            enemy.x += strafeDirection * moveSpeed * 0.28;
+            enemy.y += Math.sign(dx) * moveSpeed * 0.2;
+            enemy.isMoving = true;
+          }
+
+          if (enemy.cooldown <= 0) {
+            enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
+            const targetX = clamp(player.x + rand(-68, 68), state.cameraX + 40, state.cameraX + canvas.width - 40);
+            const targetYBounds = getPlayerVerticalBounds(player);
+            const targetY = clamp(player.y + rand(-42, 42), targetYBounds.minY + 4, targetYBounds.maxY + 4);
+            spawnBriarSupportPatch(targetX, targetY);
+            if (Math.random() < 0.35) {
+              const flankX = clamp(player.x + (enemy.facing >= 0 ? -90 : 90) + rand(-18, 18), state.cameraX + 40, state.cameraX + canvas.width - 40);
+              spawnBriarSupportPatch(flankX, targetY + rand(-18, 18));
+            }
+            enemy.cooldown = rand(52, 92);
+          }
         } else if (enemy.type === 'swamp' || enemy.type === 'choking-blossom') {
           const speedBoost = hasUndergroundDaph ? 1.15 : 1;
           const desired = 75;
@@ -5643,6 +5692,18 @@
         const overlap = Math.abs(player.x - h.x) < h.w * 0.5 && Math.abs(player.y - h.y) < h.h * 0.5;
         if (overlap && h.kind === 'root-snare') {
           player.vx *= 0.7;
+        }
+
+        if (h.kind === 'briar-support-patch') {
+          h.phase = (h.phase || 0) + 0.12;
+          if (overlap) {
+            player.briarPatchStunCooldown = Math.max(0, (player.briarPatchStunCooldown || 0) - 1);
+            if ((player.briarPatchStunCooldown || 0) <= 0 && Math.random() < (h.stunChance || 0.08)) {
+              const stunFrames = Math.round((h.stunFrames || 32) * getEnvironmentalHazardSlowMultiplier(player));
+              if (stunFrames > 0) player.stun = Math.max(player.stun || 0, stunFrames + STUN_DURATION_BONUS_FRAMES);
+              player.briarPatchStunCooldown = h.stunInterval || 22;
+            }
+          }
         }
 
         if (h.kind === 'thorn-patch') {
@@ -7109,6 +7170,31 @@
           ctx.beginPath();
           ctx.ellipse(x, y, hazard.w * 0.5, hazard.h * 0.5, 0, 0, Math.PI * 2);
           ctx.fill();
+          return;
+        }
+        if (hazard.kind === 'briar-support-patch') {
+          const radiusX = hazard.w * 0.5;
+          const radiusY = hazard.h * 0.5;
+          const pulse = 0.9 + (Math.sin(hazard.phase || 0) * 0.08);
+          const useYellow = hazard.palette === 'yellow';
+          const coreColor = useYellow ? 'rgba(246, 231, 109, 0.35)' : 'rgba(126, 229, 138, 0.35)';
+          const edgeColor = useYellow ? 'rgba(230, 196, 72, 0.26)' : 'rgba(70, 180, 116, 0.26)';
+          const rimColor = useYellow ? 'rgba(255, 243, 176, 0.62)' : 'rgba(179, 255, 200, 0.62)';
+          ctx.save();
+          const glow = ctx.createRadialGradient(x, y, radiusY * 0.18, x, y, radiusX);
+          glow.addColorStop(0, coreColor);
+          glow.addColorStop(0.68, edgeColor);
+          glow.addColorStop(1, 'rgba(22, 34, 22, 0)');
+          ctx.fillStyle = glow;
+          ctx.beginPath();
+          ctx.ellipse(x, y, radiusX * pulse, radiusY * pulse, 0, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.strokeStyle = rimColor;
+          ctx.lineWidth = 1.8;
+          ctx.beginPath();
+          ctx.ellipse(x, y, radiusX * 0.94, radiusY * 0.94, 0, 0, Math.PI * 2);
+          ctx.stroke();
+          ctx.restore();
           return;
         }
         if (hazard.kind === 'thorn-patch') {


### PR DESCRIPTION
### Motivation
- Make the Stage 1 `bayouBriar` behave as a support unit that creates persistent ground hazards rather than a direct melee choke attacker. 
- Provide visible yellow/green ground zones that always slow players and have a small chance to briefly stun, enabling new gameplay interactions and counters.

### Description
- Modified `bayou-brawlers/index.html` to add a new hazard type `briar-support-patch` and a factory function `spawnBriarSupportPatch(x, y)` that pushes finite-lifetime patches with randomized yellow/green palettes and stun-related parameters. 
- Integrated `briar-support-patch` into the environmental slowdown logic by updating `getMudTrailMovementScale` so players touching these patches are slowed like other hazards. 
- Reworked the `bayouBriar` AI branch to prefer standoff/strafe positioning and to periodically call `spawnBriarSupportPatch` near and occasionally flanking the player instead of engaging directly. 
- Added hazard update behavior to `state.hazards` processing so overlapping `briar-support-patch` zones can apply a low-probability stun (with a cooldown per-player), and added rendering code to draw yellow/green glow visuals for the patch on the ground. 

### Testing
- Ran the test suite with `npm test -- --runInBand`, and all automated tests passed (`3` test suites, `6` tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e844d829ac83298605d30ef5dfaa32)