### PR TITLE
Add stun-break mash mechanic with shared stun immunity

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1612,6 +1612,9 @@
     const COMPANION_REPOSITION_SPEED_BOOST = 1.28;
     const STUN_CONDITION_THRESHOLD = 28;
     const STUN_DURATION_BONUS_FRAMES = 120;
+    const STUN_BREAK_REQUIRED_INPUTS = 3;
+    const STUN_BREAK_WINDOW_FRAMES = 120;
+    const STUN_BREAK_IMMUNITY_FRAMES = 240;
     const PLAYER_STUN_TYPES = new Set(['brute', 'boss', 'mud-monster', 'sweetykins']);
     const ENEMY_DEATH_HOLD_FRAMES = 240;
     const ENEMY_DAMAGE_MULTIPLIER = 0.75;
@@ -2451,6 +2454,9 @@
         mechanizedMomentumStacks: 0,
         mechanizedMomentumTimer: 0,
         stun: 0,
+        stunImmunityTimer: 0,
+        stunBreakInputCount: 0,
+        stunBreakWindowTimer: 0,
         level: 1,
         xp: 0,
         power: 0,
@@ -2635,6 +2641,7 @@
         attackAnimTimer: 0,
         walkSfxCooldown: 0,
         stun: 0,
+        stunImmunityTimer: 0,
         hitStun: 0,
         stunDirX: rand(-1, 1),
         stunDirY: rand(-1, 1),
@@ -3754,6 +3761,35 @@
       }
     }
 
+    function applyStun(target, stunFrames) {
+      if (!target || target.hp <= 0 || stunFrames <= 0) return false;
+      if ((target.stunImmunityTimer || 0) > 0) return false;
+      target.stun = Math.max(target.stun || 0, stunFrames);
+      return true;
+    }
+
+    function breakStun(target) {
+      if (!target || target.hp <= 0) return false;
+      if ((target.stun || 0) <= 0) return false;
+      target.stun = 0;
+      target.stunImmunityTimer = STUN_BREAK_IMMUNITY_FRAMES;
+      return true;
+    }
+
+    function registerPlayerStunBreakPress(player) {
+      if (!player || player.hp <= 0 || (player.stun || 0) <= 0) return;
+      if ((player.stunBreakWindowTimer || 0) <= 0) {
+        player.stunBreakInputCount = 0;
+      }
+      player.stunBreakInputCount = (player.stunBreakInputCount || 0) + 1;
+      player.stunBreakWindowTimer = STUN_BREAK_WINDOW_FRAMES;
+      if (player.stunBreakInputCount >= STUN_BREAK_REQUIRED_INPUTS) {
+        breakStun(player);
+        player.stunBreakInputCount = 0;
+        player.stunBreakWindowTimer = 0;
+      }
+    }
+
     function damageEnemy(enemy, amount, stun = 0, options = null) {
       if (!enemy || enemy.hp <= 0 || enemy.invulnFrames > 0 || enemy.untargetable) return;
       enemy.hp -= amount;
@@ -3764,7 +3800,7 @@
         const shortHitStun = Math.min(12, Math.round(stun * 0.45));
         enemy.hitStun = Math.max(enemy.hitStun || 0, shortHitStun);
         if (stun >= STUN_CONDITION_THRESHOLD) {
-          enemy.stun = Math.max(enemy.stun, stun + STUN_DURATION_BONUS_FRAMES);
+          applyStun(enemy, stun + STUN_DURATION_BONUS_FRAMES);
         }
       }
       const hurtDurationFrames = enemy.type === 'mud-monster' && enemy.isBoss ? 24 : 12;
@@ -3860,7 +3896,7 @@
         if (isCharmed(otherEnemy)) return;
         const distance = Math.hypot(otherEnemy.x - defeatedEnemy.x, otherEnemy.y - defeatedEnemy.y);
         if (distance > bloomRadius) return;
-        otherEnemy.stun = Math.max(otherEnemy.stun, bloomStunFrames);
+        applyStun(otherEnemy, bloomStunFrames);
       });
 
       const particleCount = 18;
@@ -3908,7 +3944,7 @@
         finalAmount *= 0.9;
       }
       if (sourceEnemy && PLAYER_STUN_TYPES.has(sourceEnemy.type) && rand(0, 1) < (sourceEnemy.isBoss ? 0.4 : 0.18)) {
-        player.stun = Math.max(player.stun, (sourceEnemy.isBoss ? 42 : 24) + STUN_DURATION_BONUS_FRAMES);
+        applyStun(player, (sourceEnemy.isBoss ? 42 : 24) + STUN_DURATION_BONUS_FRAMES);
       }
       player.hp = clamp(player.hp - finalAmount, 0, player.maxHp);
       maybeTriggerEmergencyVenting(player);
@@ -4370,7 +4406,7 @@
       const effectSource = options?.effectSource || existing?.effectSource || null;
       if (effectSource) mergedStatus.effectSource = effectSource;
       enemy.statuses[type] = mergedStatus;
-      if (type === 'ROOT' || type === 'FREEZE') enemy.stun = Math.max(enemy.stun, finalDuration + STUN_DURATION_BONUS_FRAMES);
+      if (type === 'ROOT' || type === 'FREEZE') applyStun(enemy, finalDuration + STUN_DURATION_BONUS_FRAMES);
       if (type === 'FREEZE' && (!existing || existing.duration <= 0)) {
         if (player && player.charData.id === 'billy-boxby' && hasUpgrade(player, 'cold-reservoir')) {
           const bonusPower = hasLevel(player, 10) ? 10 : 6;
@@ -4709,7 +4745,7 @@
       }
       if (id === 'green-fairy') {
         if (!heavy && Math.random() < 0.25) applyStatus(enemy, 'SLOW', 150, 0.2);
-        if (heavy && Math.random() < 0.5) enemy.stun = Math.max(enemy.stun || 0, 72 + STUN_DURATION_BONUS_FRAMES);
+        if (heavy && Math.random() < 0.5) applyStun(enemy, 72 + STUN_DURATION_BONUS_FRAMES);
       }
       if (id === 'grimma-the-feared' && heavy && getEnemyTier(enemy) === 'small') enemy.x += (player.x - enemy.x) * 0.2;
       if (id === 'scarlett-glumpkin') applyStatus(enemy, 'POISON', heavy ? 360 : 240, heavy ? 2 : 1);
@@ -4850,8 +4886,16 @@
       if (!player) return;
       const prevX = player.x;
       const prevY = player.y;
+      player.stunImmunityTimer = Math.max(0, (player.stunImmunityTimer || 0) - 1);
+      player.stunBreakWindowTimer = Math.max(0, (player.stunBreakWindowTimer || 0) - 1);
+      if ((player.stunBreakWindowTimer || 0) <= 0) {
+        player.stunBreakInputCount = 0;
+      }
       if (player.stun > 0) {
         player.stun -= 1;
+      } else {
+        player.stunBreakInputCount = 0;
+        player.stunBreakWindowTimer = 0;
       }
       player.vx = 0;
       let moveY = 0;
@@ -5139,6 +5183,7 @@
           return;
         }
         enemy.invulnFrames = Math.max(0, enemy.invulnFrames - 1);
+        enemy.stunImmunityTimer = Math.max(0, (enemy.stunImmunityTimer || 0) - 1);
         enemy.spawnFadeFrames = Math.max(0, enemy.spawnFadeFrames - 1);
         enemy.noDigUntil = Math.max(0, enemy.noDigUntil - 1);
         enemy.hurtTimer = Math.max(0, enemy.hurtTimer - 1);
@@ -5700,7 +5745,7 @@
             player.briarPatchStunCooldown = Math.max(0, (player.briarPatchStunCooldown || 0) - 1);
             if ((player.briarPatchStunCooldown || 0) <= 0 && Math.random() < (h.stunChance || 0.08)) {
               const stunFrames = Math.round((h.stunFrames || 32) * getEnvironmentalHazardSlowMultiplier(player));
-              if (stunFrames > 0) player.stun = Math.max(player.stun || 0, stunFrames + STUN_DURATION_BONUS_FRAMES);
+              if (stunFrames > 0) applyStun(player, stunFrames + STUN_DURATION_BONUS_FRAMES);
               player.briarPatchStunCooldown = h.stunInterval || 22;
             }
           }
@@ -5992,7 +6037,7 @@
                 const verticalDir = Math.sign(centerY - (owner.y - 44));
                 enemy.x += pushDir * (effect.pushForce || 144);
                 enemy.y += verticalDir * 6;
-                enemy.stun = Math.max(enemy.stun, 20 + STUN_DURATION_BONUS_FRAMES);
+                applyStun(enemy, 20 + STUN_DURATION_BONUS_FRAMES);
               });
             }
           }
@@ -7959,6 +8004,17 @@
         if (normalizedKey === 'l') input.special = true;
         if (key === ' ') input.jump = true;
         if (key === 'Shift') input.block = true;
+        if (
+          key === 'ArrowLeft'
+          || key === 'ArrowRight'
+          || key === 'ArrowUp'
+          || key === 'ArrowDown'
+          || ['a', 'd', 'w', 's', 'j', 'k', 'l'].includes(normalizedKey)
+          || key === ' '
+          || key === 'Shift'
+        ) {
+          registerPlayerStunBreakPress(state.player);
+        }
         if (normalizedKey === 'b') showCollisionDebug = !showCollisionDebug;
         if (normalizedKey === 'r') { localStorage.removeItem(SAVE_SLOT_KEY); if (state.player) { state.player.level = 1; state.player.xp = 0; updateProgressHud(state.player); } }
       });
@@ -7978,6 +8034,7 @@
         const key = button.dataset.input;
         button.addEventListener('pointerdown', () => {
           input[key] = true;
+          registerPlayerStunBreakPress(state.player);
         });
         button.addEventListener('pointerup', () => {
           input[key] = false;
@@ -8018,10 +8075,17 @@
           directionPad.classList.add('active');
           directionKnob.style.transform = `translate(calc(-50% + ${deltaX}px), calc(-50% + ${deltaY}px))`;
 
+          const wasLeft = input.left;
+          const wasRight = input.right;
+          const wasUp = input.up;
+          const wasDown = input.down;
           input.left = deltaX < -deadZone;
           input.right = deltaX > deadZone;
           input.up = deltaY < -deadZone;
           input.down = deltaY > deadZone;
+          if ((input.left && !wasLeft) || (input.right && !wasRight) || (input.up && !wasUp) || (input.down && !wasDown)) {
+            registerPlayerStunBreakPress(state.player);
+          }
         };
 
         directionPad.addEventListener('pointerdown', (event) => {


### PR DESCRIPTION
### Motivation
- Add a player-facing escape from stun where rapid button presses allow immediate recovery, and prevent immediate re-stuns to avoid frustrating stun-chains.
- Apply the same stun-immunity behavior consistently to both players and enemies so stun applications respect a break-immunity window.

### Description
- Introduced configurable constants `STUN_BREAK_REQUIRED_INPUTS`, `STUN_BREAK_WINDOW_FRAMES`, and `STUN_BREAK_IMMUNITY_FRAMES` and new per-entity state fields `stunImmunityTimer` (for enemies and players) and `stunBreakInputCount` / `stunBreakWindowTimer` (for the player).
- Added `applyStun(...)` and `breakStun(...)` helpers so all stun applications go through a central path that respects stun immunity, and wired most existing stun assignments to call `applyStun(...)` instead of setting `stun` directly.
- Implemented `registerPlayerStunBreakPress(...)` to count relevant input presses while stunned and break stun when the required number occurs within the configured window, granting the break-immunity timer when broken.
- Wired input detection for keyboard, on-screen buttons (`[data-input]`) and the direction pad (including directional transitions) to call `registerPlayerStunBreakPress(...)`, and ticked down the new timers in the player and enemy update loops.

### Testing
- Ran an automated inline-script parsing/execution check with Node that loads and `new Function(...)`-evaluates the inline scripts from `bayou-brawlers/index.html`, which completed successfully (`Parsed 3 inline scripts successfully`).
- Ran repository file diff/validation steps and ensured the modified `index.html` parses at runtime with no immediate exceptions during the inline-script execution test, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e85a08d01c83298b0f7fcdc47732a2)