### PR TITLE
Increase stun-break mash requirement to 6 inputs

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1612,7 +1612,7 @@
     const COMPANION_REPOSITION_SPEED_BOOST = 1.28;
     const STUN_CONDITION_THRESHOLD = 28;
     const STUN_DURATION_BONUS_FRAMES = 120;
-    const STUN_BREAK_REQUIRED_INPUTS = 3;
+    const STUN_BREAK_REQUIRED_INPUTS = 6;
     const STUN_BREAK_WINDOW_FRAMES = 120;
     const STUN_BREAK_IMMUNITY_FRAMES = 240;
     const PLAYER_STUN_TYPES = new Set(['brute', 'boss', 'mud-monster', 'sweetykins']);


### PR DESCRIPTION
### Motivation
- Make the stun-break mechanic require a faster mash by requiring `6` inputs within the existing 2-second window so players must press more rapidly to break free.

### Description
- Change `STUN_BREAK_REQUIRED_INPUTS` from `3` to `6` in `bayou-brawlers/index.html` while leaving `STUN_BREAK_WINDOW_FRAMES = 120` (the ~2s window) unchanged.

### Testing
- Ran `npm test -- --runInBand` and all automated tests passed (3 test suites, 3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97c218e1083298ea6ea6a78338460)