### PR TITLE
Bayou Briar: backline support AI and briar-patch damage-over-time

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1501,7 +1501,7 @@
       hiredGun: { hp: 34, speed: 1.45, damage: 8, range: 155, score: 100, sprite: 'hiredGun', ranged: true, tier: 'medium' },
       stingy: { hp: 28, speed: 2.15, damage: 7, range: 20, score: 105, sprite: 'stingy', tier: 'medium' },
       sidewinder: { hp: 32, speed: 2.35, damage: 2, range: 72, score: 115, sprite: 'sidewinder', tier: 'medium' },
-      bayouBriar: { hp: 34, speed: 1.75, damage: 9, range: 22, score: 108, sprite: 'bayouBriar', tier: 'medium' },
+      bayouBriar: { hp: 34, speed: 1.75, damage: 9, range: 34, score: 108, sprite: 'bayouBriar', tier: 'medium' },
       quakes: { hp: 44, speed: 1.2, damage: 12, range: 26, score: 122, sprite: 'quakes', tier: 'medium' },
       riverDweller: { hp: 38, speed: 1.55, damage: 10, range: 26, score: 116, sprite: 'riverDweller', tier: 'medium' },
       automatick: { hp: 56, speed: 1.2, damage: 12, range: 20, score: 96, sprite: 'automatick', tier: 'medium' },
@@ -2900,6 +2900,8 @@
         stunChance: 0.08,
         stunFrames: 32,
         stunInterval: 22,
+        damage: 1,
+        damageInterval: 42,
         palette: Math.random() < 0.5 ? 'yellow' : 'green',
         phase: Math.random() * Math.PI * 2
       });
@@ -5359,30 +5361,37 @@
             }
           }
         } else if (enemy.type === 'bayouBriar') {
-          const supportDistance = 145;
-          const supportDelta = distance - supportDistance;
-          if (Math.abs(supportDelta) > 18) {
-            enemy.x += Math.sign(dx) * moveSpeed * 0.82;
-            enemy.y += Math.sign(dy) * moveSpeed * 0.42;
+          const preferredSupportDistance = 255;
+          const retreatDistance = 210;
+          const supportDelta = distance - preferredSupportDistance;
+          if (distance < retreatDistance) {
+            enemy.x -= Math.sign(dx) * moveSpeed * 1.08;
+            enemy.y -= Math.sign(dy) * moveSpeed * 0.48;
+            enemy.isMoving = true;
+          } else if (supportDelta > 20) {
+            enemy.x += Math.sign(dx) * moveSpeed * 0.42;
+            enemy.y += Math.sign(dy) * moveSpeed * 0.25;
             enemy.isMoving = true;
           } else {
             const strafeDirection = enemy.uid % 2 === 0 ? 1 : -1;
-            enemy.x += strafeDirection * moveSpeed * 0.28;
-            enemy.y += Math.sign(dx) * moveSpeed * 0.2;
+            enemy.x += strafeDirection * moveSpeed * 0.44;
+            enemy.y += (Math.sign(dx) || strafeDirection) * moveSpeed * 0.2;
             enemy.isMoving = true;
           }
 
-          if (enemy.cooldown <= 0) {
+          if (enemy.cooldown <= 0 && distance <= 340) {
             enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
-            const targetX = clamp(player.x + rand(-68, 68), state.cameraX + 40, state.cameraX + canvas.width - 40);
+            const castRange = 320;
+            const behindDirection = -(player.facing || 1);
+            const targetX = clamp(player.x + (behindDirection * castRange) + rand(-20, 20), state.cameraX + 40, state.cameraX + canvas.width - 40);
             const targetYBounds = getPlayerVerticalBounds(player);
-            const targetY = clamp(player.y + rand(-42, 42), targetYBounds.minY + 4, targetYBounds.maxY + 4);
+            const targetY = clamp(player.y + rand(-48, 48), targetYBounds.minY + 4, targetYBounds.maxY + 4);
             spawnBriarSupportPatch(targetX, targetY);
-            if (Math.random() < 0.35) {
-              const flankX = clamp(player.x + (enemy.facing >= 0 ? -90 : 90) + rand(-18, 18), state.cameraX + 40, state.cameraX + canvas.width - 40);
-              spawnBriarSupportPatch(flankX, targetY + rand(-18, 18));
+            if (Math.random() < 0.45) {
+              const offsetX = rand(54, 96) * behindDirection;
+              spawnBriarSupportPatch(clamp(targetX + offsetX, state.cameraX + 40, state.cameraX + canvas.width - 40), targetY + rand(-20, 20));
             }
-            enemy.cooldown = rand(52, 92);
+            enemy.cooldown = rand(60, 100);
           }
         } else if (enemy.type === 'swamp' || enemy.type === 'choking-blossom') {
           const speedBoost = hasUndergroundDaph ? 1.15 : 1;
@@ -5743,10 +5752,15 @@
           h.phase = (h.phase || 0) + 0.12;
           if (overlap) {
             player.briarPatchStunCooldown = Math.max(0, (player.briarPatchStunCooldown || 0) - 1);
+            player.briarPatchDamageCooldown = Math.max(0, (player.briarPatchDamageCooldown || 0) - 1);
             if ((player.briarPatchStunCooldown || 0) <= 0 && Math.random() < (h.stunChance || 0.08)) {
               const stunFrames = Math.round((h.stunFrames || 32) * getEnvironmentalHazardSlowMultiplier(player));
               if (stunFrames > 0) applyStun(player, stunFrames + STUN_DURATION_BONUS_FRAMES);
               player.briarPatchStunCooldown = h.stunInterval || 22;
+            }
+            if ((player.briarPatchDamageCooldown || 0) <= 0) {
+              damagePlayer(Math.max(1, h.damage || 1), null);
+              player.briarPatchDamageCooldown = h.damageInterval || 42;
             }
           }
         }


### PR DESCRIPTION
### Motivation
- Make the Bayou Briar play as a backline support: cast patches from behind the player, keep distance, and avoid rushing the player so she supports other enemies.
- Add a small damage-over-time effect to her support patches so they pose a mild hazard in addition to stun.

### Description
- Increased Bayou Briar effective `range` from `22` to `34` to allow longer-range behavior tuning in `bayou-brawlers/index.html`.
- Reworked Bayou Briar AI in `bayou-brawlers/index.html` so she retreats when too close (`retreatDistance`), advances only when too far relative to a new `preferredSupportDistance`, strafes at the preferred distance, and casts support patches from long range behind the player using a `castRange` of `320` (with spawn probability and cooldown adjustments).
- Added `damage` and `damageInterval` properties to `briar-support-patch` in `spawnBriarSupportPatch` and applied periodic player damage while overlapping the patch using a per-player cooldown (`player.briarPatchDamageCooldown`) while preserving existing stun behavior.
- Adjusted some movement/strafe speed and patch spawn probabilities/cooldowns to fit the new backline role.

### Testing
- Ran the project test suite with `npm test -- --runInBand`, and all tests passed: `3` test suites, `6` tests (PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7da7164c832991fdd493b3cc2eae)