### PR TITLE
Increase attack intervals by 50% for five Bayou Brawlers characters

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4467,6 +4467,25 @@
       return Math.max(20, Math.ceil((specialTrack.frames.length / specialTrack.fps) * 60));
     }
 
+    function getAttackDelayMultiplier(characterId) {
+      const slowerAttackers = new Set(['billy-boxby', 'shunky-rooster', 'rustbucket', 'green-fairy', 'scarlett-glumpkin']);
+      return slowerAttackers.has(characterId) ? 1.5 : 1;
+    }
+
+    function getBasicAttackCooldownFrames(characterId, companion = false) {
+      const baseCooldown = companion
+        ? (characterId === 'rustbucket' ? 24 : 13)
+        : (characterId === 'rustbucket' ? 36 : (characterId === 'shunky-rooster' ? 180 : 18));
+      return Math.round(baseCooldown * getAttackDelayMultiplier(characterId));
+    }
+
+    function getHeavyAttackCooldownFrames(characterId, isAir = false, companion = false) {
+      const baseCooldown = companion
+        ? (characterId === 'shunky-rooster' ? 160 : 32)
+        : (isAir ? 52 : 45);
+      return Math.round(baseCooldown * getAttackDelayMultiplier(characterId));
+    }
+
     function handleAttacks() {
       const player = state.player;
       if (!player) return;
@@ -4483,7 +4502,7 @@
       if ((input.power || heavyByHold) && player.powerCooldown <= 0) {
         player.attackFacing = attackFacing;
         player.facing = attackFacing;
-        player.powerCooldown = isAir ? 52 : 45;
+        player.powerCooldown = getHeavyAttackCooldownFrames(player.charData.id, isAir);
         player.animationSignals.attack = true;
         playPlayerSfx(player, 'attackHeavy');
         doAttack(player, true, isAir, tuning);
@@ -4495,7 +4514,7 @@
       if (input.fast && player.attackCooldown <= 0) {
         player.attackFacing = attackFacing;
         player.facing = attackFacing;
-        player.attackCooldown = player.charData.id === 'rustbucket' ? 36 : (player.charData.id === 'shunky-rooster' ? 180 : 18);
+        player.attackCooldown = getBasicAttackCooldownFrames(player.charData.id);
         player.animationSignals.attack = true;
         playPlayerSfx(player, 'attackFast');
         doAttack(player, false, isAir, tuning);
@@ -5140,12 +5159,12 @@
             playPlayerSfx(companion, 'attackSpecial');
             castCharacterAbility(companion, castSuper);
           } else if (companion.powerCooldown <= 0 && (targetDistance <= (companion.range + 18) || targetEnemy.isBoss || Math.random() < 0.45)) {
-            companion.powerCooldown = companion.charData.id === 'shunky-rooster' ? 160 : 32;
+            companion.powerCooldown = getHeavyAttackCooldownFrames(companion.charData.id, false, true);
             companion.animationSignals.attack = true;
             playPlayerSfx(companion, 'attackHeavy');
             doAttack(companion, true, false, tuning);
           } else if (companion.attackCooldown <= 0) {
-            companion.attackCooldown = companion.charData.id === 'rustbucket' ? 24 : 13;
+            companion.attackCooldown = getBasicAttackCooldownFrames(companion.charData.id, true);
             companion.animationSignals.attack = true;
             playPlayerSfx(companion, 'attackFast');
             doAttack(companion, false, false, tuning);


### PR DESCRIPTION
### Motivation
- Make selected characters attack less frequently by increasing both basic and heavy attack intervals by 50% to tune pacing and balance.

### Description
- Added helper functions `getAttackDelayMultiplier`, `getBasicAttackCooldownFrames`, and `getHeavyAttackCooldownFrames` and applied them in `bayou-brawlers/index.html` to centralize cooldown logic.
- Applied a 1.5x attack delay multiplier for `billy-boxby`, `shunky-rooster`, `rustbucket`, `green-fairy`, and `scarlett-glumpkin` so both basic and heavy cooldowns are increased consistently.
- Replaced inline cooldown assignments in player and companion attack flows with calls to `getBasicAttackCooldownFrames` and `getHeavyAttackCooldownFrames` so companions share the same timing changes.
- Changes are contained to `bayou-brawlers/index.html` and preserve existing per-character exceptions (e.g., rustbucket and shunky-rooster base values).

### Testing
- Verified the modified file diff and that the new helper functions are present and used in both player and companion attack paths; checks succeeded.
- Ran basic repository status and verification steps to ensure the change is staged and present in the current HEAD; checks succeeded.
- No runtime or unit-test suite was available in this rollout, so behavior verification was limited to static inspection of applied changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6d93878c83298f7f43497b6a961a)