### PR TITLE
bayou-brawlers: display integer scores (remove decimals)

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3231,6 +3231,10 @@
       document.getElementById('wave').textContent = String(clamp(state.waveIndex + 1, 1, TOTAL_WAVE_COUNT));
     }
 
+    function getDisplayedScore() {
+      return Math.max(0, Math.floor(state.score));
+    }
+
     function addScore(amount) {
       if (state.cheats.lockScoreToZero) {
         state.score = 0;
@@ -3238,7 +3242,7 @@
         return;
       }
       state.score += amount;
-      document.getElementById('score').textContent = String(state.score);
+      document.getElementById('score').textContent = String(getDisplayedScore());
     }
 
     function activateLogoCheat() {
@@ -6482,8 +6486,8 @@
       soundtrackState.audio.pause();
       const title = victory ? 'Legend of the Bayou!' : 'Brawler Down';
       const body = victory
-        ? `You cleared all ${CAMPAIGN_STAGE_LIMIT} stages with a final score of ${state.score}. The bayou remembers your name.`
-        : `The swamp swallows even legends. Final score: ${state.score}.`;
+        ? `You cleared all ${CAMPAIGN_STAGE_LIMIT} stages with a final score of ${getDisplayedScore()}. The bayou remembers your name.`
+        : `The swamp swallows even legends. Final score: ${getDisplayedScore()}.`;
       showMessage(title, body, 'Submit Score');
     }
 
@@ -6514,7 +6518,7 @@
     async function submitScore() {
       if (state.submitting) return;
       state.submitting = true;
-      const score = Math.max(0, Math.floor(state.score));
+      const score = getDisplayedScore();
       const leaderboardUrl = `../leaderboard.html?gameId=${encodeURIComponent(GAME_ID)}`;
       try {
         const rankRes = await fetch(`/api/leaderboard/rank?gameId=${encodeURIComponent(GAME_ID)}&score=${encodeURIComponent(score)}`);


### PR DESCRIPTION
### Motivation
- Prevent fractional/decimal values from appearing to the player by ensuring the HUD, end-of-run messaging, and leaderboard submission use a whole-number score while keeping internal accumulation unchanged.

### Description
- Add a `getDisplayedScore()` helper that returns `Math.max(0, Math.floor(state.score))`.
- Update `addScore()` to render the HUD value with `String(getDisplayedScore())` instead of the raw `state.score`.
- Update end-of-run message templates to interpolate `${getDisplayedScore()}` for the final score.
- Update `submitScore()` to compute `const score = getDisplayedScore()` before querying/submitting the leaderboard.

### Testing
- Verified the edits with `rg -n "getDisplayedScore|state\.score\)|final score|const score =" bayou-brawlers/index.html`, which located the new helper and updated usages (succeeded).
- Inspected the modified regions with `nl -ba bayou-brawlers/index.html | sed -n '3228,3255p'` and `nl -ba bayou-brawlers/index.html | sed -n '6482,6530p'` to confirm the helper and message/submit changes (succeeded).
- Committed the patch with `git commit` and confirmed the commit message `bayou-brawlers: remove decimal score display` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eceb8d15c4832985691938184cc459)