### PR TITLE
Update Bayou Brawlers HUD to use level bubble progress fill

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -180,6 +180,26 @@
       box-shadow: 0 3px 12px rgba(255,215,0,0.2);
       white-space: nowrap;
     }
+    .level-chip {
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
+      --level-progress: 0;
+    }
+    .level-chip::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      width: calc(var(--level-progress) * 100%);
+      background: linear-gradient(90deg, rgba(255, 77, 109, 0.62), rgba(144, 79, 255, 0.74));
+      transition: width 180ms ease-out;
+      z-index: 0;
+      pointer-events: none;
+    }
+    .level-chip-text {
+      position: relative;
+      z-index: 1;
+    }
     .hp-bar {
       width: 120px;
       height: 10px;
@@ -805,9 +825,8 @@
 
     <div class="hud" id="hud">
       <div class="chip">Score: <span id="score">0</span></div>
-      <div class="chip">Level: <span id="level">1</span></div>
+      <div class="chip level-chip" id="levelChip"><span class="level-chip-text">Level: <span id="level">1</span></span></div>
       <div class="chip">Wave: <span id="wave">1</span></div>
-      <div class="chip">XP: <span id="xp">0</span>/<span id="xpNext">60</span></div>
       <div class="chip" style="display:flex; gap:6px; align-items:center;">HP
         <div class="hp-bar"><div class="hp-fill" id="hpFill"></div></div>
       </div>
@@ -3671,8 +3690,10 @@
     function updateProgressHud(player) {
       if (!player) return;
       document.getElementById('level').textContent = String(player.level);
-      document.getElementById('xp').textContent = String(Math.floor(player.xp));
-      document.getElementById('xpNext').textContent = String(xpToNext(player.level));
+      const levelChip = document.getElementById('levelChip');
+      const xpNeeded = xpToNext(player.level);
+      const levelProgress = xpNeeded > 0 ? clamp(player.xp / xpNeeded, 0, 1) : 1;
+      if (levelChip) levelChip.style.setProperty('--level-progress', levelProgress.toFixed(4));
       refreshCharacterSheetIfVisible();
     }
 


### PR DESCRIPTION
### Motivation
- Replace the standalone XP readout in the HUD with a more compact visual that communicates progress toward the next level inside the Level bubble. 
- Provide a gradual red/violet fill inside the Level chip so players can see XP progress without a separate tracker.

### Description
- Removed the `XP: <span id="xp">...</span>/<span id="xpNext">...</span>` chip from the HUD markup and kept XP state/logic intact. 
- Added `.level-chip`, `.level-chip::before`, and `.level-chip-text` CSS to provide an inset red→violet gradient fill whose width is driven by a `--level-progress` CSS variable. 
- Replaced the Level chip markup with `<div class="chip level-chip" id="levelChip"><span class="level-chip-text">Level: <span id="level">...</span></span></div>`. 
- Updated `updateProgressHud(player)` to compute `levelProgress = clamp(player.xp / xpToNext(player.level), 0, 1)` and set the CSS property on `#levelChip`; removed the previous DOM updates for `xp` and `xpNext` in that function.

### Testing
- Verified presence/absence of XP DOM hooks with ripgrep via `rg -n "id=\"xp\"|id=\"xpNext\"|getElementById\('xp'\)|getElementById\('xpNext'\)" bayou-brawlers/index.html`, which reflects the XP chip removal and remaining references. 
- Confirmed the `updateProgressHud` change and new CSS were applied by code inspection and ensured the `--level-progress` property is set in the code path where XP changes; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6b8493848329a285f4c4528669b5)