### PR TITLE
Remove Bayou Brawlers wave tracker from HUD

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -826,7 +826,6 @@
     <div class="hud" id="hud">
       <div class="chip">Score: <span id="score">0</span></div>
       <div class="chip level-chip" id="levelChip"><span class="level-chip-text">Level: <span id="level">1</span></span></div>
-      <div class="chip">Wave: <span id="wave">1</span></div>
       <div class="chip" style="display:flex; gap:6px; align-items:center;">HP
         <div class="hp-bar"><div class="hp-fill" id="hpFill"></div></div>
       </div>
@@ -3201,7 +3200,6 @@
         });
         state.waveIndex = waveIndex;
         state.waveActive = true;
-        updateWaveHud();
         return;
       }
       const wave = getRegularWave(level, waveIndex);
@@ -3227,7 +3225,6 @@
       state.waveIndex = waveIndex;
       state.waveActive = true;
       state.lockX = waveLockX;
-      updateWaveHud();
     }
 
     function spawnBoss(level, bossConfig = level.boss) {
@@ -3243,11 +3240,6 @@
       state.bossActive = true;
       state.bossEncounter = { id: encounterId, add10: false, add20: false, stopAdds: false };
       state.lockX = getWaveLockX(REGULAR_WAVE_COUNT);
-      updateWaveHud();
-    }
-
-    function updateWaveHud() {
-      document.getElementById('wave').textContent = String(clamp(state.waveIndex + 1, 1, TOTAL_WAVE_COUNT));
     }
 
     function getDisplayedScore() {
@@ -6383,7 +6375,6 @@
         });
       }
       updateCamera();
-      updateWaveHud();
       restartSoundtrackForLevel();
     }
 


### PR DESCRIPTION
### Motivation
- Remove the on-screen "Wave" tracker from the Bayou Brawlers HUD to stop visually displaying wave number and declutter the UI.

### Description
- Deleted the `Wave` HUD chip (`<div class="chip">Wave: <span id="wave">1</span></div>`) from `bayou-brawlers/index.html`.
- Removed calls to `updateWaveHud()` from `spawnWave`, `spawnBoss`, and level restart flows so no code attempts to update the removed element.
- Removed the `updateWaveHud` function body from `bayou-brawlers/index.html` and left gameplay state changes intact so waves still progress internally but are not shown.

### Testing
- Ran a repository search with `rg` to confirm there are no remaining `id="wave"` or `updateWaveHud(` references in `bayou-brawlers/index.html` and found none.
- Attempted to capture a UI screenshot with `npx playwright screenshot` to visually verify the HUD but the command failed due to missing Playwright browser binaries in the environment.
- Attempted `npx playwright install chromium` to resolve the screenshot failure but the browser download failed with a `403 Domain forbidden` error, so no browser-based automated UI test completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efc3483de08329b508d7690061f2f8)