### PR TITLE
Add radial recharge visual for Bayou Brawlers attack buttons

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -647,6 +647,9 @@
       letter-spacing: 0.6px;
     }
     .pad-btn {
+      position: relative;
+      overflow: hidden;
+      isolation: isolate;
       width: clamp(34px, 6.4vw, 42px);
       height: clamp(34px, 6.4vw, 42px);
       border-radius: 12px;
@@ -659,6 +662,30 @@
       user-select: none;
       -webkit-user-select: none;
       touch-action: none;
+    }
+    .pad-btn-label {
+      position: relative;
+      z-index: 2;
+      pointer-events: none;
+    }
+    .pad-btn::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      z-index: 1;
+      opacity: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(circle at center, rgba(0,0,0,0.15) 0 48%, rgba(0,0,0,0) 78%),
+        conic-gradient(
+          from -90deg,
+          rgba(0, 0, 0, 0) calc(var(--recharge-progress, 1) * 1turn),
+          rgba(0, 0, 0, 0.78) 0turn
+        );
+      transition: opacity 100ms linear;
+    }
+    .pad-btn.recharging::before {
+      opacity: 1;
     }
     .pad-btn.primary {
       width: clamp(44px, 7.2vw, 54px);
@@ -866,10 +893,10 @@
         <div class="direction-label">MOVE</div>
       </div>
       <div class="action-pad">
-        <button class="pad-btn primary" data-input="fast">FAST</button>
-        <button class="pad-btn" data-input="jump">JUMP</button>
-        <button class="pad-btn warn" data-input="power">HEAVY</button>
-        <button class="pad-btn" data-input="special">SPEC</button>
+        <button class="pad-btn primary" data-input="fast"><span class="pad-btn-label">FAST</span></button>
+        <button class="pad-btn" data-input="jump"><span class="pad-btn-label">JUMP</span></button>
+        <button class="pad-btn warn" data-input="power"><span class="pad-btn-label">HEAVY</span></button>
+        <button class="pad-btn" data-input="special"><span class="pad-btn-label">SPEC</span></button>
       </div>
     </div>
 
@@ -2457,8 +2484,11 @@
         range: charData.stats.range,
         facing: 1,
         attackCooldown: 0,
+        attackCooldownMax: 0,
         powerCooldown: 0,
+        powerCooldownMax: 0,
         specialCooldown: 0,
+        specialCooldownMax: 0,
         jumpCooldown: 0,
         actionLock: 0,
         block: false,
@@ -3710,6 +3740,23 @@
       refreshCharacterSheetIfVisible();
     }
 
+    function setActionButtonRecharge(buttonInput, cooldown, cooldownMax) {
+      const button = document.querySelector(`.pad-btn[data-input="${buttonInput}"]`);
+      if (!button) return;
+      const remaining = Math.max(0, cooldown || 0);
+      const max = Math.max(1, cooldownMax || 0);
+      const progress = remaining > 0 ? (1 - clamp(remaining / max, 0, 1)) : 1;
+      button.style.setProperty('--recharge-progress', progress.toFixed(4));
+      button.classList.toggle('recharging', remaining > 0);
+    }
+
+    function updateActionButtonRechargeHud(player) {
+      if (!player) return;
+      setActionButtonRecharge('fast', player.attackCooldown, player.attackCooldownMax);
+      setActionButtonRecharge('power', player.powerCooldown, player.powerCooldownMax);
+      setActionButtonRecharge('special', player.specialCooldown, player.specialCooldownMax);
+    }
+
     function layoutEmergencyVentingHud() {
       const wrap = document.getElementById('emergencyVentingStatus');
       const hud = document.getElementById('hud');
@@ -4520,6 +4567,7 @@
         player.attackFacing = attackFacing;
         player.facing = attackFacing;
         player.powerCooldown = getHeavyAttackCooldownFrames(player.charData.id, isAir);
+        player.powerCooldownMax = player.powerCooldown;
         player.animationSignals.attack = true;
         playPlayerSfx(player, 'attackHeavy');
         doAttack(player, true, isAir, tuning);
@@ -4532,6 +4580,7 @@
         player.attackFacing = attackFacing;
         player.facing = attackFacing;
         player.attackCooldown = getBasicAttackCooldownFrames(player.charData.id);
+        player.attackCooldownMax = player.attackCooldown;
         player.animationSignals.attack = true;
         playPlayerSfx(player, 'attackFast');
         doAttack(player, false, isAir, tuning);
@@ -4542,6 +4591,7 @@
         player.attackFacing = attackFacing;
         player.facing = attackFacing;
         player.specialCooldown = castSuper ? 360 : 210;
+        player.specialCooldownMax = player.specialCooldown;
         player.actionLock = getSpecialAnimationLockFrames(player, attackFacing);
         player.animationSignals.special = true;
         addPower(player, -(castSuper ? SUPER_COST : SPECIAL_COST));
@@ -4660,7 +4710,9 @@
         const hitboxWidth = heavy ? 86 : 68;
         applyOverlappingContactHits(contactDamage, contactStun, heavy ? 20 : 12);
         player.attackCooldown = Math.max(player.attackCooldown, 180);
+        player.attackCooldownMax = Math.max(player.attackCooldownMax || 0, player.attackCooldown);
         player.powerCooldown = Math.max(player.powerCooldown, 180);
+        player.powerCooldownMax = Math.max(player.powerCooldownMax || 0, player.powerCooldown);
         state.effects.push({
           type: 'shunky-laser',
           x: beamOrigin.x,
@@ -5060,6 +5112,7 @@
       updatePlayerAnimation(player, dt);
       updateProgressHud(player);
       updatePowerHud(player);
+      updateActionButtonRechargeHud(player);
       updateEmergencyVentingHud(player);
     }
 

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -696,6 +696,10 @@
     .pad-btn.warn {
       background: linear-gradient(45deg, #ff7b7b, #ffb347);
     }
+    .pad-btn.special {
+      background: linear-gradient(45deg, #ff5f6d, #c81d25);
+      border-color: rgba(255, 155, 155, 0.9);
+    }
     .pad-btn.super-ready {
       border-color: rgba(94,241,255,0.95);
       box-shadow:
@@ -896,7 +900,7 @@
         <button class="pad-btn primary" data-input="fast"><span class="pad-btn-label">FAST</span></button>
         <button class="pad-btn" data-input="jump"><span class="pad-btn-label">JUMP</span></button>
         <button class="pad-btn warn" data-input="power"><span class="pad-btn-label">HEAVY</span></button>
-        <button class="pad-btn" data-input="special"><span class="pad-btn-label">SPEC</span></button>
+        <button class="pad-btn special" data-input="special"><span class="pad-btn-label">SPEC</span></button>
       </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Make mobile attack buttons clearly communicate cooldown state by darkening on use and revealing with a smooth 360° radial wipe as they recharge.
- Keep button labels readable while the overlay animates so players always see which action each button maps to.

### Description
- Added CSS to `.pad-btn` including a `::before` overlay that uses a `conic-gradient` driven by `--recharge-progress` to create the 360° radial wipe and a `.pad-btn.recharging` class to show the overlay.
- Wrapped action button text in a `.pad-btn-label` span so labels remain above the overlay layer in the DOM.
- Tracked per-action cooldown maxima on the player object with `attackCooldownMax`, `powerCooldownMax`, and `specialCooldownMax` so progress can be computed relative to the full cooldown.
- Implemented `setActionButtonRecharge(buttonInput, cooldown, cooldownMax)` and `updateActionButtonRechargeHud(player)` to compute progress and toggle the `.recharging` class, and hooked `updateActionButtonRechargeHud` into the main player update tick.
- Set/reset the cooldown-max values at each attack trigger (fast/power/special) and when Shunky Rooster's beam enforces extended cooldowns so the visual reflects forced cooldown extensions.

### Testing
- Ran `node -v && npm -v` to confirm runtime; the command succeeded (`v22.21.1`, `npm 11.4.2`).
- Attempted an automated visual verification with Playwright (`npx playwright screenshot ...`) but it failed because Playwright browser binaries are not installed in this environment, so no screenshot was captured.
- Verified the source diff to confirm the cooldown properties are initialized, assigned at attack trigger points, and consumed by the HUD update logic (inspection of modified file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b5e7f5dc832997d0ab35ee3ba8fb)