### PR TITLE
Adjust Scarlett bramble drone to player size

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2760,7 +2760,7 @@
         hurtTimer: 0,
         deathHoldFrames: 0,
         isMoving: false,
-        renderScale: 0.82,
+        renderScale: 0.75,
         physicsProfileId: 'enemy-scarlettBrambleDrone',
         animation: animationTracks ? {
           state: 'idle',
@@ -9069,7 +9069,7 @@
         },
         scarlettBrambleDrone: {
           profileId: 'enemy-scarlettBrambleDrone',
-          sizeMultiplier: 0.82,
+          sizeMultiplier: 0.75,
           states: {
             idle: { left: ['assets/animation_brambleDrone_red_walking_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_brambleDrone_red_walking_left.png', 8], fps: 10, loop: true },


### PR DESCRIPTION
### Motivation
- Make Scarlett Glumpkin’s summoned bramble drone match the player character size so visual scale and physics/collision stay consistent.

### Description
- Update `renderScale` for drones created by `createScarlettBrambleDrone` from `0.82` to `0.75` and change the `enemy-scarlettBrambleDrone` physics profile `sizeMultiplier` from `0.82` to `0.75` in `bayou-brawlers/index.html`.

### Testing
- Confirmed the changes by running `rg -n "scarlettBrambleDrone|renderScale: 0.75|sizeMultiplier: 0.75" bayou-brawlers/index.html` and validated there are no repository issues with `git diff --check HEAD~1..HEAD`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f102470fd48329b8e803b3dcfcae3d)