### PR TITLE
Scale Scarlett bramble drone and hitbox to player size

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1624,6 +1624,7 @@
     const BOSS_RENDER_SCALE_MULTIPLIER = 4;
     const BOSS_ANIM_FPS_MULTIPLIER = 1;
     const DEFAULT_PLAYER_RENDER_SCALE = 0.75;
+    const SCARLETT_BRAMBLE_DRONE_SCALE_MULTIPLIER = (PLAYER_DRAW_SIZE * DEFAULT_PLAYER_RENDER_SCALE) / ENEMY_DRAW_SIZE;
     const SWAMP_SCALE_MULTIPLIER = ((PLAYER_DRAW_SIZE * DEFAULT_PLAYER_RENDER_SCALE) * 0.5) / ENEMY_DRAW_SIZE;
     const CHOKING_BLOSSOM_SCALE_MULTIPLIER = SWAMP_SCALE_MULTIPLIER * 2;
     const PHYSICS_HITBOX_PADDING = 3;
@@ -2760,7 +2761,7 @@
         hurtTimer: 0,
         deathHoldFrames: 0,
         isMoving: false,
-        renderScale: 0.82,
+        renderScale: SCARLETT_BRAMBLE_DRONE_SCALE_MULTIPLIER,
         physicsProfileId: 'enemy-scarlettBrambleDrone',
         animation: animationTracks ? {
           state: 'idle',
@@ -9069,7 +9070,7 @@
         },
         scarlettBrambleDrone: {
           profileId: 'enemy-scarlettBrambleDrone',
-          sizeMultiplier: 0.82,
+          sizeMultiplier: SCARLETT_BRAMBLE_DRONE_SCALE_MULTIPLIER,
           states: {
             idle: { left: ['assets/animation_brambleDrone_red_walking_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_brambleDrone_red_walking_left.png', 8], fps: 10, loop: true },


### PR DESCRIPTION
### Motivation
- Make Scarlett Glumpkin’s summoned bramble drone visually match the player character size and ensure its collision hitbox matches that visual scale.
- Centralize the drone scale so visual `renderScale` and physics `sizeMultiplier` stay in sync across the codebase.

### Description
- Added `SCARLETT_BRAMBLE_DRONE_SCALE_MULTIPLIER` constant computed as `(PLAYER_DRAW_SIZE * DEFAULT_PLAYER_RENDER_SCALE) / ENEMY_DRAW_SIZE` in `bayou-brawlers/index.html`.
- Updated the bramble drone spawn object to set `renderScale` to `SCARLETT_BRAMBLE_DRONE_SCALE_MULTIPLIER` so the summoned drone is rendered at player size.
- Updated the enemy sprite/physics entry for `scarlettBrambleDrone` to set `sizeMultiplier` to `SCARLETT_BRAMBLE_DRONE_SCALE_MULTIPLIER` so its hitbox scales with the visual size.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10b2f3fdc832991aea3336aa1f358)