### PR TITLE
Use non-stage animations for Scarlett's bramble drone

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -9071,11 +9071,11 @@
           profileId: 'enemy-scarlettBrambleDrone',
           sizeMultiplier: 0.82,
           states: {
-            idle: { left: ['assets/animation_brambleDrone_red_walking_left.png', 1], fps: 0, loop: false },
+            idle: { left: ['assets/animation_brambleDrone_red_controlSquare_left.png', 1], fps: 0, loop: false },
             walk: { left: ['assets/animation_brambleDrone_red_walking_left.png', 8], fps: 10, loop: true },
-            hurt: { left: ['assets/animation_brambleDrone_stage1_red_damaged_left.png', 5], fps: 12, loop: false },
-            attack: { left: ['assets/animation_brambleDrone_stage1_red_attack_left.png', 7], fps: 14, loop: false },
-            death: { left: ['assets/animation_brambleDrone_stage1_red_killed_left.png', 6], fps: 8, loop: false }
+            hurt: { left: ['assets/animation_brambleDrone_red_damaged_left.png', 5], fps: 12, loop: false },
+            attack: { left: ['assets/animation_brambleDrone_red_attack_left.png', 7], fps: 14, loop: false },
+            death: { left: ['assets/animation_brambleDrone_red_killed_left.png', 6], fps: 8, loop: false }
           }
         },
         goblin: {


### PR DESCRIPTION
### Motivation
- The bramble drone summoned by Scarlett Glumpkin referenced `stage`-variant sprite files which produced inconsistent visuals and hitbox alignment, so the drone should use the non-`stage` animation set matching `animation_brambleDrone_red_*_left.png` files.

### Description
- Updated `bayou-brawlers/index.html` to change `scarlettBrambleDrone` animation tracks to non-stage assets by replacing `animation_brambleDrone_stage1_red_*_left.png` with `animation_brambleDrone_red_*_left.png` for `hurt`, `attack`, and `death`.
- Switched the drone `idle` track to `animation_brambleDrone_red_controlSquare_left.png` so the idle/control-square frame and hitbox visuals use the same non-stage set.
- Left the `walk` animation pointed at `animation_brambleDrone_red_walking_left.png` since it already used the correct non-stage asset.
- Changes committed with message `"Update Scarlett bramble drone to non-stage animations"`.

### Testing
- No automated tests were run for this change because it is an asset path/config-only edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f203a87ce4832981add4de15593dbd)