### PR TITLE
Double Scarlett bramble drone renderScale in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2760,7 +2760,7 @@
         hurtTimer: 0,
         deathHoldFrames: 0,
         isMoving: false,
-        renderScale: 0.82,
+        renderScale: 1.64,
         physicsProfileId: 'enemy-scarlettBrambleDrone',
         animation: animationTracks ? {
           state: 'idle',


### PR DESCRIPTION
### Motivation
- Double the visual size of Scarlett's Bramble Drone in the Bayou Brawlers game so the summoned drone appears larger and more visible.

### Description
- Updated `renderScale` from `0.82` to `1.64` in `createScarlettBrambleDrone` inside `bayou-brawlers/index.html` so the drone is rendered at 2x its previous scale.

### Testing
- No automated tests were run for this single-value visual tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f352ee44e483299549c226362b3237)