### PR TITLE
Scale Scarlett super special summon to 150% drone size

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2738,7 +2738,7 @@
       return enemy;
     }
 
-    function createScarlettBrambleDrone(owner) {
+    function createScarlettBrambleDrone(owner, isSuper = false) {
       const animationTracks = assets.enemyAnimations.scarlettBrambleDrone || null;
       return {
         uid: ++state.enemyUid,
@@ -2760,7 +2760,7 @@
         hurtTimer: 0,
         deathHoldFrames: 0,
         isMoving: false,
-        renderScale: 1.64,
+        renderScale: 1.64 * (isSuper ? 1.5 : 1),
         physicsProfileId: 'enemy-scarlettBrambleDrone',
         animation: animationTracks ? {
           state: 'idle',
@@ -2773,11 +2773,11 @@
       };
     }
 
-    function summonScarlettBrambleDrone(player) {
+    function summonScarlettBrambleDrone(player, isSuper = false) {
       if (!player || player.charData?.id !== 'scarlett-glumpkin') return;
       const drone = state.scarlettBrambleDrone;
       if (drone && drone.hp > 0) return;
-      state.scarlettBrambleDrone = createScarlettBrambleDrone(player);
+      state.scarlettBrambleDrone = createScarlettBrambleDrone(player, isSuper);
     }
 
     function getEnemyHitbox(enemy) {
@@ -5012,7 +5012,7 @@
       } else if (id === 'grimma-the-feared') {
         state.effects.push({ x: player.x, y: player.y, radius: isSuper ? 170 * radiusBoost : 96, timer: isSuper ? (hasLevel(player, 9) ? 168 : 120) : 40, damage: isSuper ? 2 : 8, knockback: 0, stun: isSuper ? 8 : 42, type: 'root' });
       } else if (id === 'scarlett-glumpkin') {
-        summonScarlettBrambleDrone(player);
+        summonScarlettBrambleDrone(player, isSuper);
         state.effects.push({ x: player.x + player.facing * 80, y: player.y, radius: (isSuper ? 210 * radiusBoost : 120) * aoeRangeMultiplier, timer: isSuper ? 100 : 44, damage: isSuper ? 2 : 7, knockback: 8, stun: 18, type: 'root-poison' });
         if (isSuper && hasUpgrade(player, 'garden-of-thorns')) {
           spawnGardenOfThornsPatches(player);


### PR DESCRIPTION
### Motivation
- Ensure Scarlett Glumpkin's bramble drone summoned during a super-special appears larger (50% bigger) so super summons are visually distinct and more impactful.

### Description
- Modified `createScarlettBrambleDrone(owner)` to `createScarlettBrambleDrone(owner, isSuper = false)` and applied `renderScale: 1.64 * (isSuper ? 1.5 : 1)` to scale the drone when created in super mode.
- Modified `summonScarlettBrambleDrone(player)` to `summonScarlettBrambleDrone(player, isSuper = false)` and forward the `isSuper` flag to the creator.
- Updated Scarlett's super-special summon path to call `summonScarlettBrambleDrone(player, isSuper)` so the larger scale only applies during supers.
- All changes are in `bayou-brawlers/index.html` around the drone creation and player-special handling code.

### Testing
- Ran `git -C /workspace/ai-game-of-the-day diff -- bayou-brawlers/index.html` to verify the patch and it showed the intended changes.
- Committed the change with `git -C /workspace/ai-game-of-the-day commit` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f369dc6df083299d26528dd23f1a11)