### PR TITLE
Scale Scarlett Glumpkin summon stats and size across 5 levels

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1018,6 +1018,8 @@
     const SCARLETT_BRAMBLE_DRONE_MAX_HP = 95;
     const SCARLETT_BRAMBLE_DRONE_SPEED = 2.8;
     const SCARLETT_BRAMBLE_DRONE_ATTACK_DAMAGE = 11;
+    const SCARLETT_BRAMBLE_DRONE_MAX_LEVEL = 5;
+    const SCARLETT_BRAMBLE_DRONE_LEVEL_SCALE_STEP = 0.1;
     const SCARLETT_BRAMBLE_DRONE_ATTACK_COOLDOWN = 30;
 
     const CHEAT_STREAK_RESET_MS = 2000;
@@ -2742,6 +2744,10 @@
       const animationTracks = useViciousVercosus
         ? (assets.enemyAnimations.scarlettViciousVercosus || null)
         : (assets.enemyAnimations.scarlettBrambleDrone || null);
+      const summonLevel = clamp(owner?.level || 1, 1, SCARLETT_BRAMBLE_DRONE_MAX_LEVEL);
+      const levelMultiplier = 1 + ((summonLevel - 1) * SCARLETT_BRAMBLE_DRONE_LEVEL_SCALE_STEP);
+      const maxHp = Math.round(SCARLETT_BRAMBLE_DRONE_MAX_HP * levelMultiplier);
+      const damage = Math.round(SCARLETT_BRAMBLE_DRONE_ATTACK_DAMAGE * levelMultiplier);
       return {
         uid: ++state.enemyUid,
         type: useViciousVercosus ? 'scarlettViciousVercosus' : 'scarlettBrambleDrone',
@@ -2749,10 +2755,10 @@
         x: owner ? owner.x + (owner.facing * 14) : 80,
         y: owner ? owner.y - 4 : BRAWL_LANE_MAX_Y,
         z: 0,
-        hp: SCARLETT_BRAMBLE_DRONE_MAX_HP,
-        maxHp: SCARLETT_BRAMBLE_DRONE_MAX_HP,
+        hp: maxHp,
+        maxHp,
         speed: SCARLETT_BRAMBLE_DRONE_SPEED,
-        damage: SCARLETT_BRAMBLE_DRONE_ATTACK_DAMAGE,
+        damage,
         range: 22,
         facing: owner?.facing || 1,
         attackCooldown: 0,
@@ -2762,7 +2768,7 @@
         hurtTimer: 0,
         deathHoldFrames: 0,
         isMoving: false,
-        renderScale: useViciousVercosus ? 2.46 : 1.64,
+        renderScale: (useViciousVercosus ? 2.46 : 1.64) * levelMultiplier,
         physicsProfileId: 'enemy-scarlettBrambleDrone',
         animation: animationTracks ? {
           state: 'idle',


### PR DESCRIPTION
### Motivation
- Make Scarlett Glumpkin's special summons (Bramble Drone and Vicious Vercosus) scale with the player's level so they keep their current base values at level 1 and then grow in size, health, and damage across five levels.

### Description
- Added new constants `SCARLETT_BRAMBLE_DRONE_MAX_LEVEL` and `SCARLETT_BRAMBLE_DRONE_LEVEL_SCALE_STEP` to `bayou-brawlers/index.html` to control the max summon level and per-level growth step.
- Updated `createScarlettBrambleDrone` to compute a clamped `summonLevel` from the owner and a `levelMultiplier = 1 + ((level - 1) * step)` and applied it to `hp`, `maxHp`, and `damage` (rounded), and to `renderScale` for both the Bramble Drone and the Vicious Vercosus variants.
- The scaling uses the existing base constants (`SCARLETT_BRAMBLE_DRONE_MAX_HP`, `SCARLETT_BRAMBLE_DRONE_ATTACK_DAMAGE`, etc.) so level 1 behaviour is unchanged and both summon variants are affected via the existing `useViciousVercosus` flag.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42cc88c108329b126b2787928a544)