### PR TITLE
Heal Scarlett's active bramble drone on special and return active summon from helper

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2818,6 +2818,16 @@
       return state.scarlettBrambleDrone;
     }
 
+
+    function healScarlettActiveDrone(drone, amountRatio = 0.04) {
+      if (!drone || drone.hp <= 0) return false;
+      const maxHp = Math.max(1, drone.maxHp || SCARLETT_BRAMBLE_DRONE_MAX_HP);
+      const healAmount = Math.max(1, Math.ceil(maxHp * amountRatio));
+      const beforeHp = drone.hp;
+      drone.hp = clamp(drone.hp + healAmount, 0, maxHp);
+      return drone.hp > beforeHp;
+    }
+
     function getEnemyHitbox(enemy) {
       return getPhysicsBody(enemy);
     }
@@ -5050,11 +5060,10 @@
       } else if (id === 'grimma-the-feared') {
         state.effects.push({ x: player.x, y: player.y, radius: isSuper ? 170 * radiusBoost : 96, timer: isSuper ? (hasLevel(player, 9) ? 168 : 120) : 40, damage: isSuper ? 2 : 8, knockback: 0, stun: isSuper ? 8 : 42, type: 'root' });
       } else if (id === 'scarlett-glumpkin') {
-        const existingDrone = state.scarlettBrambleDrone;
+        const activeDroneBeforeSpecial = state.scarlettBrambleDrone;
         summonScarlettBrambleDrone(player, isSuper);
-        if (existingDrone && existingDrone.hp > 0) {
-          const healAmount = Math.max(1, Math.round((existingDrone.maxHp || SCARLETT_BRAMBLE_DRONE_MAX_HP) * 0.04));
-          existingDrone.hp = Math.min(existingDrone.maxHp || SCARLETT_BRAMBLE_DRONE_MAX_HP, existingDrone.hp + healAmount);
+        if (activeDroneBeforeSpecial && activeDroneBeforeSpecial.hp > 0) {
+          healScarlettActiveDrone(activeDroneBeforeSpecial, 0.04);
         }
         state.effects.push({ x: player.x + player.facing * 80, y: player.y, radius: (isSuper ? 210 * radiusBoost : 120) * aoeRangeMultiplier, timer: isSuper ? 100 : 44, damage: isSuper ? 2 : 7, knockback: 8, stun: 18, type: 'root-poison' });
         if (isSuper && hasUpgrade(player, 'garden-of-thorns')) {

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2810,11 +2810,12 @@
     }
 
     function summonScarlettBrambleDrone(player, useViciousVercosus = false) {
-      if (!player || player.charData?.id !== 'scarlett-glumpkin') return;
+      if (!player || player.charData?.id !== 'scarlett-glumpkin') return null;
       const drone = state.scarlettBrambleDrone;
-      if (drone && drone.hp > 0) return;
+      if (drone && drone.hp > 0) return drone;
       state.scarlettBrambleDrone = createScarlettBrambleDrone(player, useViciousVercosus);
       scaleScarlettBrambleDroneForLevel(state.scarlettBrambleDrone, 1);
+      return state.scarlettBrambleDrone;
     }
 
     function getEnemyHitbox(enemy) {
@@ -5049,7 +5050,12 @@
       } else if (id === 'grimma-the-feared') {
         state.effects.push({ x: player.x, y: player.y, radius: isSuper ? 170 * radiusBoost : 96, timer: isSuper ? (hasLevel(player, 9) ? 168 : 120) : 40, damage: isSuper ? 2 : 8, knockback: 0, stun: isSuper ? 8 : 42, type: 'root' });
       } else if (id === 'scarlett-glumpkin') {
+        const existingDrone = state.scarlettBrambleDrone;
         summonScarlettBrambleDrone(player, isSuper);
+        if (existingDrone && existingDrone.hp > 0) {
+          const healAmount = Math.max(1, Math.round((existingDrone.maxHp || SCARLETT_BRAMBLE_DRONE_MAX_HP) * 0.04));
+          existingDrone.hp = Math.min(existingDrone.maxHp || SCARLETT_BRAMBLE_DRONE_MAX_HP, existingDrone.hp + healAmount);
+        }
         state.effects.push({ x: player.x + player.facing * 80, y: player.y, radius: (isSuper ? 210 * radiusBoost : 120) * aoeRangeMultiplier, timer: isSuper ? 100 : 44, damage: isSuper ? 2 : 7, knockback: 8, stun: 18, type: 'root-poison' });
         if (isSuper && hasUpgrade(player, 'garden-of-thorns')) {
           spawnGardenOfThornsPatches(player);


### PR DESCRIPTION
### Motivation
- Allow Scarlett Glumpkin's special/super to heal an already-present Bramble Drone/Vicious Vercosus instead of attempting to re-summon, and make the summon helper return the active summon so callers can handle it predictably.

### Description
- Modified `summonScarlettBrambleDrone` in `bayou-brawlers/index.html` to return `null` for invalid callers, return the existing active drone when present, and return the newly created drone when spawning one. 
- Changed Scarlett's special/super branch so if an active drone exists it is healed by `Math.max(1, Math.round((existingDrone.maxHp || SCARLETT_BRAMBLE_DRONE_MAX_HP) * 0.04))` (4% max HP, minimum 1) instead of attempting to spawn a replacement, while leaving the existing area effect and `garden-of-thorns` behavior unchanged.

### Testing
- Ran `npm test -- --runInBand __tests__/shuffle.test.js` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50233f0d8832988449ab9e025cab3)