### PR TITLE
Scarlett special now heals active Bramble Drone/Vercosus (25%) instead of re-summoning

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -2817,6 +2817,14 @@
       scaleScarlettBrambleDroneForLevel(state.scarlettBrambleDrone, 1);
     }
 
+    function healScarlettBrambleDrone(healRatio = 0.25) {
+      const drone = state.scarlettBrambleDrone;
+      if (!drone || drone.hp <= 0 || drone.maxHp <= 0) return false;
+      const healAmount = Math.max(1, Math.round(drone.maxHp * healRatio));
+      drone.hp = Math.min(drone.maxHp, drone.hp + healAmount);
+      return true;
+    }
+
     function getEnemyHitbox(enemy) {
       return getPhysicsBody(enemy);
     }
@@ -5049,7 +5057,8 @@
       } else if (id === 'grimma-the-feared') {
         state.effects.push({ x: player.x, y: player.y, radius: isSuper ? 170 * radiusBoost : 96, timer: isSuper ? (hasLevel(player, 9) ? 168 : 120) : 40, damage: isSuper ? 2 : 8, knockback: 0, stun: isSuper ? 8 : 42, type: 'root' });
       } else if (id === 'scarlett-glumpkin') {
-        summonScarlettBrambleDrone(player, isSuper);
+        const droneHealed = healScarlettBrambleDrone(0.25);
+        if (!droneHealed) summonScarlettBrambleDrone(player, isSuper);
         state.effects.push({ x: player.x + player.facing * 80, y: player.y, radius: (isSuper ? 210 * radiusBoost : 120) * aoeRangeMultiplier, timer: isSuper ? 100 : 44, damage: isSuper ? 2 : 7, knockback: 8, stun: 18, type: 'root-poison' });
         if (isSuper && hasUpgrade(player, 'garden-of-thorns')) {
           spawnGardenOfThornsPatches(player);


### PR DESCRIPTION
### Motivation
- Ensure Scarlett Glumpkin's special/super-special heals an existing summoned ally instead of trying to summon another when one is already active.

### Description
- Added `healScarlettBrambleDrone(healRatio = 0.25)` which heals `state.scarlettBrambleDrone` by 25% of its `maxHp`, clamps to `maxHp`, and returns whether a valid active summon was present.
- Updated Scarlett's special handling to call `healScarlettBrambleDrone(0.25)` first and only call `summonScarlettBrambleDrone` when no active summon was healed.
- The heal helper returns `false` for missing/dead summons and ensures at least 1 HP is healed when applicable.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51fa0cc888329a4c1deb5a611127f)