### PR TITLE
Fix Sweetykins stage 2 animation tracks and dash playback in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3168,9 +3168,12 @@
         return;
       }
 
-      const adjustedFps = enemy.isBoss
+      let adjustedFps = enemy.isBoss
         ? track.fps * BOSS_ANIM_FPS_MULTIPLIER
         : track.fps;
+      if (enemy.type === 'sweetykins' && anim.state === 'walk' && enemy.sweetykinsMode === 'charge') {
+        adjustedFps *= 2;
+      }
       const frameTime = 1000 / adjustedFps;
       anim.elapsedMs += dt;
       while (anim.elapsedMs >= frameTime) {
@@ -5685,6 +5688,7 @@
           }
         } else if (enemy.type === 'sweetykins') {
           enemy.forceIdleAnimation = false;
+          enemy.isMoving = false;
           if (!enemy.sweetykinsMode) enemy.sweetykinsMode = 'charge';
           if (!Number.isFinite(enemy.sweetykinsChargesRemaining)) enemy.sweetykinsChargesRemaining = rand(4, 6);
           if (!Number.isFinite(enemy.sweetykinsHitsRemaining)) enemy.sweetykinsHitsRemaining = rand(2, 4);
@@ -5692,7 +5696,8 @@
           enemy.sweetykinsRunHitCooldown = Math.max(0, enemy.sweetykinsRunHitCooldown - 1);
 
           if (enemy.sweetykinsMode === 'charge') {
-            enemy.forceIdleAnimation = true;
+            enemy.forceIdleAnimation = false;
+            enemy.isMoving = true;
             enemy.windup = 0;
             enemy.attackAnimTimer = 0;
             const leftBound = state.cameraX + 42;
@@ -9612,11 +9617,11 @@
           profileId: 'enemy-sweetykins',
           sizeMultiplier: BOSS_DRAW_SIZE / ENEMY_DRAW_SIZE,
           states: {
-            idle: { left: ['assets/animation_sweetykins_red_controlSquare_left.png', 1], fps: 0, loop: false },
-            walk: { left: ['assets/animation_sweetykins_red_walking_left.png', 8], fps: 10, loop: true },
-            hurt: { left: ['assets/animation_sweetykins_red_damaged_left.png', 5], fps: 12, loop: false },
-            attack: { left: ['assets/animation_sweetykins_red_attack_left.png', 7], fps: 14, loop: false },
-            death: { left: ['assets/animation_sweetykins_red_killed_left.png', 6], fps: 8, loop: false }
+            idle: { left: ['assets/animation_sweetykins_red_walking_left.png', 1], fps: 0, loop: false },
+            walk: { left: ['assets/animation_sweetykins_red_walking_left.png', 6], fps: 10, loop: true },
+            hurt: { left: ['assets/animation_sweetykins_red_damaged_left.png', 6], fps: 12, loop: false },
+            attack: { left: ['assets/animation_sweetykins_red_attack_left.png', 9], fps: 14, loop: false },
+            death: { left: ['assets/animation_sweetykins_red_killed_left.png', 7], fps: 8, loop: false }
           }
         },
         bambo: {


### PR DESCRIPTION
### Motivation
- Sweetykins stage-2 boss was not using the intended left-facing sprite sheets and was not showing the walking animation correctly while charging/dashing. 
- The game's animation playback speed should be doubled while Sweetykins is dashing so the walking frames match the expected motion.

### Description
- Updated Sweetykins animation state configuration in `bayou-brawlers/index.html` to use `assets/animation_sweetykins_red_*_left.png` with frame counts: walking 6, attack 9, damaged 6, killed 7, and made the idle fallback use the walking sheet (single frame). 
- Changed `getEnemyAnimTrack`/animation handling to use a mutable `adjustedFps` and added a Sweetykins-specific case that doubles `walk` FPS when `enemy.sweetykinsMode === 'charge'`. 
- Ensured Sweetykins’ movement state is set so the walking animation plays during charge by resetting `enemy.isMoving` and explicitly setting it to `true` while in charge mode.
- All changes are confined to behavior and animation configuration for Sweetykins in `bayou-brawlers/index.html`.

### Testing
- Ran a targeted source search with `rg -n "sweetykins_red_|adjustedFps|sweetykinsMode === 'charge'|forceIdleAnimation" bayou-brawlers/index.html` to verify the updated config and logic and it found the new lines as expected (success). 
- Inspected relevant regions of `bayou-brawlers/index.html` to confirm `adjustedFps` change and charge-mode logic were inserted (automated file checks via `nl`/`sed` outputs succeeded). 
- Performed a repository status check with `git -C /workspace/ai-game-of-the-day status --short` and committed the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6477b3eb483298d22e04386c168b8)