### PR TITLE
Increase hiredGun attack range in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1558,7 +1558,7 @@
       automaton: { hp: 55, speed: 1.2, damage: 12, range: 20, score: 90, sprite: 'automaton', tier: 'medium' },
       fey: { hp: 38, speed: 1.9, damage: 9, range: 18, score: 85, sprite: 'fey', tier: 'small' },
       ranged: { hp: 30, speed: 1.4, damage: 7, range: 140, score: 95, sprite: 'fey', ranged: true, tier: 'medium' },
-      hiredGun: { hp: 34, speed: 1.45, damage: 8, range: 155, score: 100, sprite: 'hiredGun', ranged: true, tier: 'medium' },
+      hiredGun: { hp: 34, speed: 1.45, damage: 8, range: 465, score: 100, sprite: 'hiredGun', ranged: true, tier: 'medium' },
       stingy: { hp: 28, speed: 2.15, damage: 7, range: 20, score: 105, sprite: 'stingy', tier: 'medium' },
       sidewinder: { hp: 32, speed: 2.35, damage: 2, range: 72, score: 115, sprite: 'sidewinder', tier: 'medium' },
       bayouBriar: { hp: 34, speed: 1.75, damage: 9, range: 34, score: 108, sprite: 'bayouBriar', tier: 'medium' },


### PR DESCRIPTION
### Motivation
- Allow the `hiredGun` enemy to engage from much farther away by tripling its configured attack range used for ranged behavior.

### Description
- Updated the `hiredGun` entry in `bayou-brawlers/index.html`, changing the `range` value from `155` to `465` in the `enemyTypes` table.

### Testing
- Ran automated verification steps: the replacement script executed and the change was validated with `git diff` and `nl -ba bayou-brawlers/index.html | sed -n '1556,1564p'`, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f688d6779c8329be02d973a916d005)