### PR TITLE
Aim Bayou Briar support patches at player's predicted position

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -5632,15 +5632,19 @@
 
           if (enemy.cooldown <= 0 && distance <= 340) {
             enemy.attackAnimTimer = Math.max(enemy.attackAnimTimer, 14);
-            const castRange = 320;
-            const behindDirection = -(player.facing || 1);
-            const targetX = clamp(player.x + (behindDirection * castRange) + rand(-20, 20), state.cameraX + 40, state.cameraX + canvas.width - 40);
+            const leadFrames = 24;
+            const leadX = player.vx * leadFrames;
+            const leadYInput = (input.down ? 1 : 0) - (input.up ? 1 : 0);
+            const leadY = leadYInput * player.speed * 0.6 * leadFrames;
+            const predictedX = player.x + leadX;
+            const predictedY = player.y + leadY;
             const targetYBounds = getPlayerVerticalBounds(player);
-            const targetY = clamp(player.y + rand(-48, 48), targetYBounds.minY + 4, targetYBounds.maxY + 4);
+            const targetX = clamp(predictedX + rand(-38, 38), state.cameraX + 40, state.cameraX + canvas.width - 40);
+            const targetY = clamp(predictedY + rand(-30, 30), targetYBounds.minY + 4, targetYBounds.maxY + 4);
             spawnBriarSupportPatch(targetX, targetY);
             if (Math.random() < 0.45) {
-              const offsetX = rand(54, 96) * behindDirection;
-              spawnBriarSupportPatch(clamp(targetX + offsetX, state.cameraX + 40, state.cameraX + canvas.width - 40), targetY + rand(-20, 20));
+              const offsetX = rand(54, 96) * (Math.sign(leadX) || -(player.facing || 1));
+              spawnBriarSupportPatch(clamp(targetX + offsetX, state.cameraX + 40, state.cameraX + canvas.width - 40), clamp(targetY + rand(-20, 20), targetYBounds.minY + 4, targetYBounds.maxY + 4));
             }
             enemy.cooldown = rand(60, 100);
           }


### PR DESCRIPTION
### Motivation
- Bayou Briar support patches were being spawned far behind the player which made them feel disconnected from the player’s movement.
- Patches should land where the player is standing or where they appear to be moving to make hazards feel intentional and fair.
- Improve AI casting so patch placement tracks short-term player movement and vertical input.

### Description
- Replaced the old behind-the-player cast logic with a short-term lead prediction using `player.vx` and vertical input (`input.up`/`input.down`) over `leadFrames = 24` to compute `predictedX` and `predictedY`.
- Compute `targetX`/`targetY` from the predicted position with added randomness and clamp to play bounds using `state.cameraX` and `canvas.width` and `getPlayerVerticalBounds(player)`.
- Adjusted the secondary patch offset to use `Math.sign(leadX)` with a fallback to `-player.facing` so follow-up patches align with predicted movement, and clamped their vertical placement.
- Change applied in `bayou-brawlers/index.html` within the Bayou Briar AI attack block where `spawnBriarSupportPatch` is invoked.

### Testing
- Applied the source patch to `bayou-brawlers/index.html` via an automated script and verified the updated block exists in the file with `rg`/`nl`.
- Inspected the resulting diff to confirm the old behind-direction code was replaced by the prediction-based logic.
- Created the PR entry via the repository automation; all verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8dc1cddd08329b18a9bd667562e2b)