### PR TITLE
Double Rustbucket special attack duration

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -5051,8 +5051,8 @@
           });
         }
       } else if (id === 'rustbucket') {
-        player.sentryTimer = 150;
-        player.sentrySuperTimer = isSuper ? 150 : 0;
+        player.sentryTimer = 300;
+        player.sentrySuperTimer = isSuper ? 300 : 0;
         if (isSuper) {
           state.effects.push({
             x: player.x,


### PR DESCRIPTION
### Motivation
- Make Rustbucket’s special and super-special attacks last twice as long to adjust character tuning and consistency between normal and super durations.

### Description
- Increased `player.sentryTimer` and `player.sentrySuperTimer` from `150` to `300` frames in `bayou-brawlers/index.html` (Rustbucket special handling).

### Testing
- No automated tests were run for this small tuning change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95f3d85f48329964aa99dd5a57cd1)