### PR TITLE
Increase Rustbucket special and super-special durations

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -5051,8 +5051,8 @@
           });
         }
       } else if (id === 'rustbucket') {
-        player.sentryTimer = 150;
-        player.sentrySuperTimer = isSuper ? 150 : 0;
+        player.sentryTimer = isSuper ? 600 : 300;
+        player.sentrySuperTimer = isSuper ? 600 : 0;
         if (isSuper) {
           state.effects.push({
             x: player.x,


### PR DESCRIPTION
### Motivation
- Make Rustbucket's special attack last twice as long and his super special attack last four times as long to extend sentry lifetimes.

### Description
- Updated `bayou-brawlers/index.html` in `castCharacterAbility` for the `rustbucket` branch to set `player.sentryTimer = isSuper ? 600 : 300` and `player.sentrySuperTimer = isSuper ? 600 : 0`.

### Testing
- Ran `git diff`, inspected the modified file snippet with `nl`/`sed`, and committed the change, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa4b5b3e54832995ad1c9ce84999f2)