### PR TITLE
Increase Rustbucket speed and durability

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1463,7 +1463,7 @@
         sprite: 'rustbucket',
         renderScale: 0.75,
         physicsProfileId: 'player-rustbucket',
-        stats: { speed: 3.2, power: 1.1, range: 42, durability: 110 },
+        stats: { speed: 3.9, power: 1.1, range: 42, durability: 130 },
         moves: {
           fast: 'Quick cleave combo',
           power: 'Heavy wrench uppercut',


### PR DESCRIPTION
### Motivation
- Make Rustbucket the fastest playable character by a slight margin and increase his durability to improve survivability.

### Description
- Update `bayou-brawlers/index.html` to set Rustbucket's `stats` from `{ speed: 3.2, power: 1.1, range: 42, durability: 110 }` to `{ speed: 3.9, power: 1.1, range: 42, durability: 130 }`.

### Testing
- No automated tests were run for this static configuration change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb528f79008329889212fd0c0f8d2d)