### PR TITLE
Rustbucket: bidirectional special and targeted super-special projectiles

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -4418,6 +4418,35 @@
       });
     }
 
+    function spawnProjectileTowardTarget(owner, target, speed, damage, friendly, color = '#f5d07a', options = null) {
+      if (!owner || !target) return;
+      const ownerId = owner?.charData?.id || null;
+      const originX = owner.x + owner.facing * 20;
+      const originY = owner.y - 10;
+      const enemyBody = getEnemyHitbox(target);
+      const targetX = enemyBody.x + enemyBody.width * 0.5;
+      const targetY = enemyBody.y + enemyBody.height * 0.5;
+      const dx = targetX - originX;
+      const dy = targetY - originY;
+      const dist = Math.hypot(dx, dy) || 1;
+      state.projectiles.push({
+        x: originX,
+        y: originY,
+        vx: (dx / dist) * speed,
+        vy: (dy / dist) * speed,
+        damage,
+        friendly,
+        life: 180,
+        color,
+        tracking: false,
+        turnRate: 0,
+        ownerId,
+        trailEvery: 0,
+        ricochetRemaining: ownerId === 'rustbucket' ? 1 : 0,
+        attackKind: options?.attackKind || null
+      });
+    }
+
     const RUSTBUCKET_RICOCHET_CHANCE = 0.25;
     const RUSTBUCKET_RICOCHET_MAX_BOUNCES = 8;
 
@@ -5257,9 +5286,24 @@
         player.perfectGlamourPlusTimer = 0;
       }
       if (player.sentryTimer > 0 && player.sentryTimer % 18 === 0) {
-        spawnProjectile(player, 11, hasLevel(player, 7) ? 9 : 7, true, '#ffe8aa', {
-          attackKind: player.sentrySuperTimer > 0 ? 'super-special' : 'special'
-        });
+        const isSuperSpecial = player.sentrySuperTimer > 0;
+        const projectileDamage = hasLevel(player, 7) ? 9 : 7;
+        if (isSuperSpecial) {
+          const livingTargets = state.enemies.filter(enemy => enemy.hp > 0 && canPlayerAffectEnemy(enemy));
+          livingTargets.forEach((enemy) => {
+            spawnProjectileTowardTarget(player, enemy, 11, projectileDamage, true, '#ffe8aa', {
+              attackKind: 'super-special'
+            });
+          });
+        } else {
+          spawnProjectile(player, 11, projectileDamage, true, '#ffe8aa', {
+            attackKind: 'special'
+          });
+          const reverseOwner = { ...player, facing: player.facing * -1 };
+          spawnProjectile(reverseOwner, 11, projectileDamage, true, '#ffe8aa', {
+            attackKind: 'special'
+          });
+        }
       }
       if (player.tempestTimer > 0) {
         player.tempestTimer -= 1;


### PR DESCRIPTION
### Motivation
- Make Rustbucket's sentry special more useful in close-quarters by firing both forward and backward. 
- Make the super special more effective by aiming projectiles directly at visible enemies instead of generic forward shots.

### Description
- Added a helper `spawnProjectileTowardTarget(owner, target, speed, damage, friendly, color, options)` that creates a projectile aimed at an enemy hitbox center. 
- Changed sentry firing logic so normal special now spawns one projectile forward and one projectile backward each cycle using `spawnProjectile` with a reversed `facing`. 
- Changed sentry super-special so each firing cycle spawns a targeted projectile at every valid on-screen enemy using the new `spawnProjectileTowardTarget`, preserving projectile metadata such as `attackKind` and Rustbucket ricochet defaults.

### Testing
- No automated tests were run because there is no automated test suite for this gameplay change; an in-browser/manual playtest is recommended to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf8e727908329a3ccdb7b62f98eae)