### PR TITLE
Require 3 super-pellets for Super Special and add 3-orb HUD

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -750,6 +750,25 @@
       box-shadow: 0 0 12px rgba(94,241,255,0.95), 0 0 24px rgba(122,149,255,0.8);
       animation: superPulse 0.9s ease-in-out infinite alternate;
     }
+    .super-orbs {
+      display: inline-flex;
+      gap: 4px;
+      margin-left: 4px;
+      align-items: center;
+    }
+    .super-orb {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      border: 1px solid rgba(162, 202, 255, 0.75);
+      background: rgba(10, 25, 40, 0.75);
+      box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.6);
+    }
+    .super-orb.filled {
+      border-color: rgba(170, 231, 255, 0.98);
+      background: radial-gradient(circle at 30% 30%, #b9edff 0%, #47beff 48%, #266eff 100%);
+      box-shadow: 0 0 8px rgba(86, 177, 255, 0.9), inset 0 0 5px rgba(210, 240, 255, 0.8);
+    }
     @keyframes superPulse {
       from { transform: scale(1); }
       to { transform: scale(1.03); }
@@ -893,6 +912,11 @@
       </div>
       <div class="chip" style="display:flex; gap:6px; align-items:center;">Power
         <div class="hp-bar"><div class="hp-fill" id="powerFill" style="background:linear-gradient(90deg,#5ef1ff,#7a95ff)"></div></div>
+        <div class="super-orbs" id="superOrbHud" aria-label="Super special charge">
+          <span class="super-orb" data-super-orb="0"></span>
+          <span class="super-orb" data-super-orb="1"></span>
+          <span class="super-orb" data-super-orb="2"></span>
+        </div>
       </div>
       <div class="chip">Ability: <span id="specialReady">Locked</span></div>
       <div class="chip character-sheet-chip">
@@ -1721,6 +1745,7 @@
     const BASE_MAX_POWER = 100;
     const SPECIAL_COST = BASE_MAX_POWER / 3;
     const SUPER_COST = SPECIAL_COST;
+    const SUPER_PELLETS_REQUIRED = 3;
     const XP_TABLE = [0, 45, 90, 150, 230, 320, 420, 530, 650, 780];
     const XP_BY_TIER = { small: 7, medium: 12, elite: 22.5, boss: 50 };
     const POWER_BY_TIER = { small: 5, medium: 8, elite: 12, boss: 15 };
@@ -2557,6 +2582,7 @@
         level: 1,
         xp: 0,
         power: 0,
+        superPellets: 0,
         maxPower: BASE_MAX_POWER,
         passiveCooldown: 0,
         basicDamageMultiplier: 1,
@@ -3871,7 +3897,17 @@
       else if (isSuperReady) ready.textContent = 'Super Ready';
       else if (player.power >= SPECIAL_COST) ready.textContent = hasLevel(player, 5) ? 'Special Ready' : 'Ability Ready';
       else ready.textContent = 'Charging';
+      updateSuperOrbHud(player);
       refreshCharacterSheetIfVisible();
+    }
+
+    function updateSuperOrbHud(player) {
+      const filled = clamp(Math.floor(player?.superPellets || 0), 0, SUPER_PELLETS_REQUIRED);
+      for (let i = 0; i < SUPER_PELLETS_REQUIRED; i += 1) {
+        const orb = document.querySelector(`[data-super-orb="${i}"]`);
+        if (!orb) continue;
+        orb.classList.toggle('filled', i < filled);
+      }
     }
 
     function setActionButtonRecharge(buttonInput, cooldown, cooldownMax) {
@@ -3937,6 +3973,7 @@
         }
       }
       if (Math.random() < 0.2) spawnPickup(enemy.x, enemy.y);
+      if (Math.random() < 0.33) spawnPickup(enemy.x + rand(-10, 10), enemy.y + rand(-8, 8), 'super-pellet');
       if (STAGED_ENEMY_TYPES.has(enemy.type) && enemy.stage > 1) {
         const nextStage = enemy.stage - 1;
         const childCount = 2;
@@ -4393,8 +4430,8 @@
       refreshCharacterSheetIfVisible();
     }
 
-    function spawnPickup(x, y) {
-      state.pickups.push({ x, y, timer: 600 });
+    function spawnPickup(x, y, type = 'gumbo') {
+      state.pickups.push({ x, y, timer: 600, type });
     }
 
     function spawnProjectile(owner, speed, damage, friendly, color = '#f5d07a', options = null) {
@@ -4777,13 +4814,18 @@
       }
 
       if (input.special && player.specialCooldown <= 0 && hasLevel(player, 3) && player.power >= SPECIAL_COST) {
-        const castSuper = hasLevel(player, 5) && player.power >= (player.maxPower || BASE_MAX_POWER);
+        const hasSuperPellets = (player.superPellets || 0) >= SUPER_PELLETS_REQUIRED;
+        const castSuper = hasLevel(player, 5) && player.power >= (player.maxPower || BASE_MAX_POWER) && hasSuperPellets;
         player.attackFacing = attackFacing;
         player.facing = attackFacing;
         setSharedAttackCooldown(player, castSuper ? 360 : 210);
         player.actionLock = getSpecialAnimationLockFrames(player, attackFacing);
         player.animationSignals.special = true;
         addPower(player, -(castSuper ? SUPER_COST : SPECIAL_COST));
+        if (castSuper) {
+          player.superPellets = 0;
+          updateSuperOrbHud(player);
+        }
         playPlayerSfx(player, 'attackSpecial');
         castCharacterAbility(player, castSuper);
       }
@@ -6271,9 +6313,26 @@
           height: 20
         };
         if (rectsOverlap(playerBody, pickupBody)) {
-          healPlayer(25);
-          addScore(40);
-          addPower(player, 10);
+          if (pickup.type === 'super-pellet') {
+            player.superPellets = clamp((player.superPellets || 0) + 1, 0, SUPER_PELLETS_REQUIRED);
+            addScore(60);
+            state.effects.push({
+              type: 'floating-text',
+              text: 'SUPER PELLET',
+              x: pickup.x,
+              y: pickup.y - 22,
+              vy: -0.35,
+              timer: 40,
+              maxTimer: 40,
+              color: 'rgba(122, 220, 255, 0.96)',
+              outline: 'rgba(18, 42, 74, 0.98)'
+            });
+            updateSuperOrbHud(player);
+          } else {
+            healPlayer(25);
+            addScore(40);
+            addPower(player, 10);
+          }
           pickup.timer = 0;
         }
       });
@@ -7724,7 +7783,23 @@
       state.pickups.forEach(pickup => {
         const x = pickup.x - state.cameraX;
         const y = pickup.y - state.cameraY - 12;
-        ctx.drawImage(assets.pickup, x - 10, y, 20, 20);
+        if (pickup.type === 'super-pellet') {
+          ctx.save();
+          ctx.globalCompositeOperation = 'lighter';
+          const pulse = 0.7 + (Math.sin((pickup.timer || 0) * 0.22) * 0.3);
+          const radius = 8 + pulse * 4;
+          const glow = ctx.createRadialGradient(x, y + 10, 1, x, y + 10, radius);
+          glow.addColorStop(0, 'rgba(190, 236, 255, 0.95)');
+          glow.addColorStop(0.45, 'rgba(98, 186, 255, 0.82)');
+          glow.addColorStop(1, 'rgba(66, 138, 255, 0)');
+          ctx.fillStyle = glow;
+          ctx.beginPath();
+          ctx.arc(x, y + 10, radius, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.restore();
+        } else {
+          ctx.drawImage(assets.pickup, x - 10, y, 20, 20);
+        }
       });
 
       const renderQueue = state.enemies

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3885,7 +3885,8 @@
       const currentMaxPower = player.maxPower || BASE_MAX_POWER;
       fill.style.width = `${(player.power / currentMaxPower) * 100}%`;
       const ready = document.getElementById('specialReady');
-      const isSuperReady = hasLevel(player, 5) && player.power >= currentMaxPower;
+      const hasSuperPellets = (player.superPellets || 0) >= SUPER_PELLETS_REQUIRED;
+      const isSuperReady = hasLevel(player, 5) && player.power >= currentMaxPower && hasSuperPellets;
       if (isSuperReady && !player.superReadyNotified) {
         showNotification('Super special charged');
         player.superReadyNotified = true;
@@ -3895,6 +3896,7 @@
       setSuperReadyGlow(isSuperReady);
       if (!hasLevel(player, 3)) ready.textContent = 'Locked';
       else if (isSuperReady) ready.textContent = 'Super Ready';
+      else if (hasLevel(player, 5) && player.power >= currentMaxPower && !hasSuperPellets) ready.textContent = 'Need 3 Pellets';
       else if (player.power >= SPECIAL_COST) ready.textContent = hasLevel(player, 5) ? 'Special Ready' : 'Ability Ready';
       else ready.textContent = 'Charging';
       updateSuperOrbHud(player);
@@ -5469,11 +5471,13 @@
             && (nearbyEnemies >= 2 || targetEnemy.isBoss || targetDistance <= (companion.range + 26));
 
           if (shouldSpecial) {
-            const castSuper = companion.power >= (companion.maxPower || BASE_MAX_POWER) * 0.92;
+            const castSuper = companion.power >= (companion.maxPower || BASE_MAX_POWER) * 0.92
+              && (companion.superPellets || 0) >= SUPER_PELLETS_REQUIRED;
             companion.specialCooldown = castSuper ? 300 : 170;
             companion.actionLock = Math.max(14, Math.floor(getSpecialAnimationLockFrames(companion, companion.facing) * 0.8));
             companion.animationSignals.special = true;
             addPower(companion, -(castSuper ? SUPER_COST : SPECIAL_COST));
+            if (castSuper) companion.superPellets = 0;
             playPlayerSfx(companion, 'attackSpecial');
             castCharacterAbility(companion, castSuper);
           } else if (companion.powerCooldown <= 0 && (targetDistance <= (companion.range + 18) || targetEnemy.isBoss || Math.random() < 0.45)) {


### PR DESCRIPTION
### Motivation
- Introduce a secondary resource for the super special so it isn’t usable purely from the power meter, matching the requested three-circle visual mechanic.
- Provide immediate visual feedback near the power bar so players can see how many super charges they’ve collected at a glance.
- Make super special use a meaningful pickup-driven decision by adding collectible glowing blue pellets that must be consumed to cast the super.

### Description
- Added HUD UI and CSS for three small orb indicators next to the Power bar and styles for empty vs filled glowing-blue orbs.
- Added `SUPER_PELLETS_REQUIRED = 3` and a `player.superPellets` field to track collected pellets per player.
- Extended pickup spawning to support a typed pickup (default gumbo + new `super-pellet`) and added a chance for enemies to drop `super-pellet` on death.
- Implemented `updateSuperOrbHud(player)` and hooked it into the existing power HUD update path to toggle orb visuals, changed pickup collection to increment `superPellets`, and updated the special-cast logic so super specials require full power and at least 3 pellets and then consume them when used.
- Added distinct in-world rendering for `super-pellet` pickups and a floating-text feedback when a pellet is collected.

### Testing
- Performed static/diff inspection and code review of the modified `bayou-brawlers/index.html` to confirm HUD markup, constants, new functions, pickup type handling, and cast gating were added and wired correctly.
- Applied the edits with an automated patching step and verified the updated file parses and the repository shows the expected changes (no automated unit tests were available for this file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fded32296c832999559aab6e71d63c)