### PR TITLE
Persist companions, summons, and charmed enemies between stages

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -6834,18 +6834,22 @@
 
     function setupLevel() {
       const level = levels[state.levelIndex];
+      const retainedCharmedEnemies = state.enemies.filter((enemy) => enemy && enemy.hp > 0 && isCharmed(enemy));
+      const retainedBrambleDrone = state.scarlettBrambleDrone && state.scarlettBrambleDrone.hp > 0
+        ? state.scarlettBrambleDrone
+        : null;
       const defaultLevelWidth = Number.isFinite(Number(level?.worldWidth))
         ? Number(level.worldWidth)
         : (2200 + state.levelIndex * 120);
       state.levelWidth = getLevelWorldWidth(level, defaultLevelWidth);
       state.bossActive = false;
       state.stageBossPhase = 0;
-      state.enemies = [];
+      state.enemies = retainedCharmedEnemies;
       state.projectiles = [];
       state.pickups = [];
       state.effects = [];
       state.hazards = [];
-      state.scarlettBrambleDrone = null;
+      state.scarlettBrambleDrone = retainedBrambleDrone;
       state.lockX = null;
       state.waveIndex = 0;
       state.nextWaveToSpawn = 0;
@@ -6861,6 +6865,23 @@
         state.companions.forEach((companion, index) => {
           companion.x = 80 - ((index + 1) * 26);
           companion.y = state.player ? state.player.y : clamp(companion.y, getBrawlLaneMinY(), BRAWL_LANE_MAX_Y);
+        });
+      }
+      if (state.scarlettBrambleDrone) {
+        state.scarlettBrambleDrone.x = clamp((state.player?.x || 80) + 18, 20, state.levelWidth - 20);
+        state.scarlettBrambleDrone.y = state.player
+          ? clamp(state.player.y - 4, getBrawlLaneMinY(), BRAWL_LANE_MAX_Y)
+          : clamp(state.scarlettBrambleDrone.y, getBrawlLaneMinY(), BRAWL_LANE_MAX_Y);
+      }
+      if (state.enemies.length > 0) {
+        state.enemies.forEach((enemy, index) => {
+          enemy.x = clamp((state.player?.x || 80) + 120 + (index * 34), 30, state.levelWidth - 30);
+          enemy.y = state.player
+            ? clamp(state.player.y + ((index % 2 === 0 ? -1 : 1) * 20), getBrawlLaneMinY(), BRAWL_LANE_MAX_Y)
+            : clamp(enemy.y, getBrawlLaneMinY(), BRAWL_LANE_MAX_Y);
+          enemy.waveBarrierSpawnSide = null;
+          enemy.waveBarrierCrossedToPlayerSide = true;
+          enemy.spawnFadeFrames = 0;
         });
       }
       updateCamera();


### PR DESCRIPTION
### Motivation
- Preserve ally-side entities (companions, summoned drone, and charmed enemies) across stage transitions so their in-flight state (HP, level, damage, statuses) is retained rather than wiped when a new stage starts.
- Prevent stale transient flags (wave barrier spawn/crossed state, spawn fade) and out-of-bounds positions that can cause odd behavior after a transition.

### Description
- Update `setupLevel()` in `bayou-brawlers/index.html` to collect `retainedCharmedEnemies` and a living `retainedBrambleDrone` and assign them into `state.enemies` and `state.scarlettBrambleDrone` instead of clearing those fields.
- Clear `state.projectiles`, `state.pickups`, `state.effects`, and `state.hazards` as before while preserving retained allies so ongoing statuses and HP persist into the next stage.
- Reposition retained allies near the player start position using `clamp(...)` to ensure valid world bounds and reset transient fields like `waveBarrierSpawnSide`, `waveBarrierCrossedToPlayerSide`, and `spawnFadeFrames` on retained charmed enemies.
- Leave existing companion continuity logic intact and continue to reposition companions relative to the player as before.

### Testing
- Ran the test suite with `npm test -- --runInBand`, and all tests passed (`3` test suites, `6` tests total).
- Verified the modified file is `bayou-brawlers/index.html` and that the game setup path `setupLevel()` now includes the retention and repositioning logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00cd1bd4a88329bebb90a49faa2408)