### PR TITLE
Add strength-driven push interactions to Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1760,16 +1760,31 @@
 
     const enemyPixelStrengthByType = {};
 
-    function measureOpaquePixelPercent(frameCanvas) {
-      if (!frameCanvas || !frameCanvas.width || !frameCanvas.height) return 0;
-      const ctx = frameCanvas.getContext('2d', { willReadFrequently: true });
-      if (!ctx) return 0;
-      const { data } = ctx.getImageData(0, 0, frameCanvas.width, frameCanvas.height);
+    function measureOpaquePixelPercent(image, frameRect) {
+      if (!image || !frameRect || !frameRect.width || !frameRect.height) return 0;
+      const scanCanvas = document.createElement('canvas');
+      scanCanvas.width = frameRect.width;
+      scanCanvas.height = frameRect.height;
+      const scanCtx = scanCanvas.getContext('2d', { willReadFrequently: true });
+      if (!scanCtx) return 0;
+      scanCtx.clearRect(0, 0, frameRect.width, frameRect.height);
+      scanCtx.drawImage(
+        image,
+        frameRect.x,
+        frameRect.y,
+        frameRect.width,
+        frameRect.height,
+        0,
+        0,
+        frameRect.width,
+        frameRect.height
+      );
+      const { data } = scanCtx.getImageData(0, 0, frameRect.width, frameRect.height);
       let opaque = 0;
       for (let i = 3; i < data.length; i += 4) {
         if (data[i] > 12) opaque += 1;
       }
-      return opaque / (frameCanvas.width * frameCanvas.height);
+      return opaque / (frameRect.width * frameRect.height);
     }
 
     function deriveEnemyPixelStrengths() {
@@ -1778,9 +1793,10 @@
       if (!regularEnemyTypes.length) return;
       const scored = regularEnemyTypes.map(([typeId]) => {
         const tracks = assets.enemyAnimations[typeId];
-        const idleLeftFrames = tracks?.idle?.left?.frames || tracks?.walk?.left?.frames || [];
-        const firstFrame = idleLeftFrames[0] || null;
-        return { typeId, score: measureOpaquePixelPercent(firstFrame) };
+        const idleLeftTrack = tracks?.idle?.left || tracks?.walk?.left || null;
+        const firstFrame = idleLeftTrack?.frames?.[0] || null;
+        const score = measureOpaquePixelPercent(idleLeftTrack?.img, firstFrame);
+        return { typeId, score };
       });
       scored.sort((a, b) => a.score - b.score);
       const minStrength = 30;

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1733,6 +1733,76 @@
     const STUN_BREAK_REQUIRED_INPUTS = 6;
     const STUN_BREAK_WINDOW_FRAMES = 120;
     const STUN_BREAK_IMMUNITY_FRAMES = 240;
+
+    const PLAYER_STRENGTH = {
+      'old-man-croc': 100,
+      possumatli: 95,
+      'shunky-rooster': 90,
+      'grimma-the-feared': 85,
+      rustbucket: 80,
+      'billy-boxby': 45,
+      'scarlett-glumpkin': 35,
+      'green-fairy': 25
+    };
+
+    const BOSS_STRENGTH = {
+      lodicrust: 99,
+      sweetykins: 98,
+      mrNibbles: 97,
+      'mud-monster': 96,
+      kingOfThieves: 95,
+      tinkeringTom: 94,
+      mirrorMaster: 93,
+      theSlais: 92,
+      origamiMaster: 91,
+      ladyWorthington: 90
+    };
+
+    const enemyPixelStrengthByType = {};
+
+    function measureOpaquePixelPercent(frameCanvas) {
+      if (!frameCanvas || !frameCanvas.width || !frameCanvas.height) return 0;
+      const ctx = frameCanvas.getContext('2d', { willReadFrequently: true });
+      if (!ctx) return 0;
+      const { data } = ctx.getImageData(0, 0, frameCanvas.width, frameCanvas.height);
+      let opaque = 0;
+      for (let i = 3; i < data.length; i += 4) {
+        if (data[i] > 12) opaque += 1;
+      }
+      return opaque / (frameCanvas.width * frameCanvas.height);
+    }
+
+    function deriveEnemyPixelStrengths() {
+      const regularEnemyTypes = Object.entries(enemyTypes)
+        .filter(([typeId, info]) => info && info.tier !== 'boss' && assets.enemyAnimations[typeId]);
+      if (!regularEnemyTypes.length) return;
+      const scored = regularEnemyTypes.map(([typeId]) => {
+        const tracks = assets.enemyAnimations[typeId];
+        const idleLeftFrames = tracks?.idle?.left?.frames || tracks?.walk?.left?.frames || [];
+        const firstFrame = idleLeftFrames[0] || null;
+        return { typeId, score: measureOpaquePixelPercent(firstFrame) };
+      });
+      scored.sort((a, b) => a.score - b.score);
+      const minStrength = 30;
+      const maxStrength = 84;
+      const span = Math.max(1, scored.length - 1);
+      scored.forEach((entry, idx) => {
+        enemyPixelStrengthByType[entry.typeId] = Math.round(minStrength + ((maxStrength - minStrength) * (idx / span)));
+      });
+    }
+
+    function getEntityStrength(entity) {
+      if (!entity) return 0;
+      if (entity.charData?.id) {
+        return PLAYER_STRENGTH[entity.charData.id] || 40;
+      }
+      const typeId = entity.type;
+      if (BOSS_STRENGTH[typeId]) return BOSS_STRENGTH[typeId];
+      if (entity.isBoss) return 96;
+      if (enemyPixelStrengthByType[typeId] !== undefined) return enemyPixelStrengthByType[typeId];
+      return 50;
+    }
+
     const PLAYER_STUN_TYPES = new Set(['brute', 'boss', 'mud-monster', 'sweetykins']);
     const ENEMY_DEATH_HOLD_FRAMES = 240;
     const ENEMY_DAMAGE_MULTIPLIER = 0.75;
@@ -3032,6 +3102,10 @@
 
     function resolveCharacterBodyCollision(mover, blocker, weight = 1) {
       if (!mover || !blocker || mover === blocker || mover.hp <= 0 || blocker.hp <= 0) return;
+      const moverStrength = getEntityStrength(mover);
+      const blockerStrength = getEntityStrength(blocker);
+      const totalStrength = Math.max(1, moverStrength + blockerStrength);
+      const moverShare = clamp(blockerStrength / totalStrength, 0, 1);
       const moverBody = getPhysicsBody(mover);
       const blockerBody = getPhysicsBody(blocker);
       if (!rectsOverlap(moverBody, blockerBody)) return;
@@ -3048,10 +3122,10 @@
 
       if (overlapX < overlapY) {
         const pushDir = Math.sign(dx) || (mover.uid < blocker.uid ? -1 : 1);
-        mover.x += pushDir * overlapX * weight;
+        mover.x += pushDir * overlapX * weight * moverShare;
       } else {
         const pushDir = Math.sign(dy) || (mover.uid < blocker.uid ? -1 : 1);
-        mover.y += pushDir * overlapY * weight;
+        mover.y += pushDir * overlapY * weight * moverShare;
       }
     }
 
@@ -3060,6 +3134,7 @@
       state.enemies.forEach((enemy) => {
         if (!enemy || enemy.hp <= 0 || enemy.attachTargetFrames > 0) return;
         resolveCharacterBodyCollision(player, enemy, 1);
+        resolveCharacterBodyCollision(enemy, player, 1);
       });
       state.companions.forEach((companion) => {
         if (!companion || companion.hp <= 0) return;
@@ -9965,6 +10040,7 @@
       });
 
       await Promise.all(promises);
+      deriveEnemyPixelStrengths();
     }
 
     async function init() {


### PR DESCRIPTION
### Motivation
- Add a strength system so stronger player characters can physically push weaker enemies (and vice-versa) per the requested strongest→weakest orders for players and bosses.
- Make non-boss enemy strength derive from artwork so smaller/less-opaque enemies are weaker and larger/more-opaque ones are stronger.
- Ensure collisions and pushing behave consistently in both directions so physical displacement is determined by relative strength instead of being uniform.

### Description
- Introduced `PLAYER_STRENGTH`, `BOSS_STRENGTH`, and `enemyPixelStrengthByType` and a `getEntityStrength` helper in `bayou-brawlers/index.html` to expose strengths for characters, bosses, and regular enemies respectively.
- Added `measureOpaquePixelPercent(frameCanvas)` and `deriveEnemyPixelStrengths()` to compute non-boss enemy strength from an animation frame's opaque pixel percentage and normalize values into a gameplay band.
- Modified `resolveCharacterBodyCollision` to scale displacement by relative strength (computing a mover share from `getEntityStrength`) so stronger entities push weaker ones farther.
- Updated `resolvePlayerCharacterCollisions` to call `resolveCharacterBodyCollision` in both directions for player↔enemy pairs and wired `deriveEnemyPixelStrengths()` into `loadAssets()` so pixel-derived strengths are ready after asset loading.

### Testing
- No automated tests were executed against these changes.
- Changes were verified locally by inspecting the diff and committing the updated `bayou-brawlers/index.html` file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a028b1797648329b252096e1a32ba31)