### PR TITLE
Allow backtracking to active enemy positions in Bayou Brawlers

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3436,8 +3436,14 @@
       });
 
       state.enemies.forEach(enemy => {
-        if (!enemy || enemy.hp > 0 || enemy.deathHoldFrames <= 0) return;
-        minFromLootOrBodies = Math.min(minFromLootOrBodies, enemy.x - 40);
+        if (!enemy) return;
+        if (enemy.hp > 0) {
+          minFromLootOrBodies = Math.min(minFromLootOrBodies, enemy.x - 40);
+          return;
+        }
+        if (enemy.deathHoldFrames > 0) {
+          minFromLootOrBodies = Math.min(minFromLootOrBodies, enemy.x - 40);
+        }
       });
 
       return clamp(minFromLootOrBodies, 40, state.levelWidth - 40);


### PR DESCRIPTION
### Motivation
- Ensure the player can reach any enemy position by including active enemies when computing how far the player is allowed to backtrack, preventing forward-progress boundaries from blocking access to enemies that moved behind them.

### Description
- Modify `getBacktrackPlayerMinX()` in `bayou-brawlers/index.html` to treat active enemies (`enemy.hp > 0`) the same as pickups and lingering enemy bodies when relaxing the minimum X backtrack bound, while keeping the existing behavior for defeated enemies with `deathHoldFrames > 0`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b3f200ec83299679be553c184653)