### PR TITLE
Prevent companions from pushing players

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3180,7 +3180,9 @@
         resolveCharacterBodyCollision(companion, player, 1);
       });
       if (state.scarlettBrambleDrone && state.scarlettBrambleDrone.hp > 0) {
-        resolveCharacterBodyCollision(player, state.scarlettBrambleDrone, 1);
+        // Scarlett's returning bramble drone is player-aligned too, so it must
+        // yield like a companion instead of nudging an idle player into a chase loop.
+        resolveCharacterBodyCollision(state.scarlettBrambleDrone, player, 1);
       }
     }
     function circleIntersectsRect(circleX, circleY, circleRadius, rect) {

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3175,7 +3175,9 @@
       });
       state.companions.forEach((companion) => {
         if (!companion || companion.hp <= 0) return;
-        resolveCharacterBodyCollision(player, companion, 1);
+        // Companions should yield to player characters instead of pushing them,
+        // even when the companion's character strength is higher.
+        resolveCharacterBodyCollision(companion, player, 1);
       });
       if (state.scarlettBrambleDrone && state.scarlettBrambleDrone.hp > 0) {
         resolveCharacterBodyCollision(player, state.scarlettBrambleDrone, 1);


### PR DESCRIPTION
### Motivation
- Ensure companion NPCs yield to the player character rather than moving the player when collisions occur, so companions never push players even if their computed strength is greater.

### Description
- In `bayou-brawlers/index.html` updated `resolvePlayerCharacterCollisions` to call `resolveCharacterBodyCollision(companion, player, 1)` for companion entries so companions act as the mover that yields to the player blocker instead of calling `resolveCharacterBodyCollision(player, companion, 1)`.

### Testing
- Extracted inline scripts from `bayou-brawlers/index.html` and ran `node --check /tmp/bayou-brawlers-scripts.js` to verify JavaScript syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26d04e57188329bc0b06fceaf8548d)