### PR TITLE
Prevent companions from pushing the player (Bayou Brawlers)

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3137,15 +3137,10 @@
     }
 
 
-    function resolveCharacterBodyCollision(mover, blocker, weight = 1) {
-      if (!mover || !blocker || mover === blocker || mover.hp <= 0 || blocker.hp <= 0) return;
-      const moverStrength = getEntityStrength(mover);
-      const blockerStrength = getEntityStrength(blocker);
-      const totalStrength = Math.max(1, moverStrength + blockerStrength);
-      const moverShare = clamp(blockerStrength / totalStrength, 0, 1);
+    function getBodyOverlapSeparation(mover, blocker) {
       const moverBody = getPhysicsBody(mover);
       const blockerBody = getPhysicsBody(blocker);
-      if (!rectsOverlap(moverBody, blockerBody)) return;
+      if (!rectsOverlap(moverBody, blockerBody)) return null;
 
       const moverCenterX = moverBody.x + moverBody.width * 0.5;
       const moverCenterY = moverBody.y + moverBody.height * 0.5;
@@ -3155,7 +3150,20 @@
       const dy = moverCenterY - blockerCenterY;
       const overlapX = (moverBody.width + blockerBody.width) * 0.5 - Math.abs(dx);
       const overlapY = (moverBody.height + blockerBody.height) * 0.5 - Math.abs(dy);
-      if (overlapX <= 0 || overlapY <= 0) return;
+      if (overlapX <= 0 || overlapY <= 0) return null;
+
+      return { dx, dy, overlapX, overlapY };
+    }
+
+    function resolveCharacterBodyCollision(mover, blocker, weight = 1) {
+      if (!mover || !blocker || mover === blocker || mover.hp <= 0 || blocker.hp <= 0) return;
+      const moverStrength = getEntityStrength(mover);
+      const blockerStrength = getEntityStrength(blocker);
+      const totalStrength = Math.max(1, moverStrength + blockerStrength);
+      const moverShare = clamp(blockerStrength / totalStrength, 0, 1);
+      const separation = getBodyOverlapSeparation(mover, blocker);
+      if (!separation) return;
+      const { dx, dy, overlapX, overlapY } = separation;
 
       if (overlapX < overlapY) {
         const pushDir = Math.sign(dx) || (mover.uid < blocker.uid ? -1 : 1);
@@ -3163,6 +3171,21 @@
       } else {
         const pushDir = Math.sign(dy) || (mover.uid < blocker.uid ? -1 : 1);
         mover.y += pushDir * overlapY * weight * moverShare;
+      }
+    }
+
+    function resolveFollowerAwayFromPlayer(follower, player, weight = 1) {
+      if (!follower || !player || follower === player || follower.hp <= 0 || player.hp <= 0) return;
+      const separation = getBodyOverlapSeparation(follower, player);
+      if (!separation) return;
+      const { dx, dy, overlapX, overlapY } = separation;
+
+      if (overlapX < overlapY) {
+        const pushDir = Math.sign(dx) || (follower.x >= player.x ? 1 : -1);
+        follower.x += pushDir * overlapX * weight;
+      } else {
+        const pushDir = Math.sign(dy) || (follower.y >= player.y ? 1 : -1);
+        follower.y += pushDir * overlapY * weight;
       }
     }
 
@@ -3175,10 +3198,10 @@
       });
       state.companions.forEach((companion) => {
         if (!companion || companion.hp <= 0) return;
-        resolveCharacterBodyCollision(player, companion, 1);
+        resolveFollowerAwayFromPlayer(companion, player, 1);
       });
       if (state.scarlettBrambleDrone && state.scarlettBrambleDrone.hp > 0) {
-        resolveCharacterBodyCollision(player, state.scarlettBrambleDrone, 1);
+        resolveFollowerAwayFromPlayer(state.scarlettBrambleDrone, player, 1);
       }
     }
     function circleIntersectsRect(circleX, circleY, circleRadius, rect) {
@@ -5922,6 +5945,9 @@
         companion.x = clamp(companion.x, companionHorizontalBounds.minX, companionHorizontalBounds.maxX);
         companion.y = clamp(companion.y, companionVerticalBounds.minY, companionVerticalBounds.maxY);
         clampCompanionToPlayerLeash(companion, player);
+        resolveFollowerAwayFromPlayer(companion, player, 1);
+        companion.x = clamp(companion.x, companionHorizontalBounds.minX, companionHorizontalBounds.maxX);
+        companion.y = clamp(companion.y, companionVerticalBounds.minY, companionVerticalBounds.maxY);
         companion.isMoving = Math.hypot(companion.x - prevX, companion.y - prevY) > MOVE_EPSILON;
         updatePlayerAnimation(companion, dt);
       });
@@ -7238,6 +7264,9 @@
 
       const horizontalBounds = getPlayerHorizontalBounds();
       const yBounds = getPlayerVerticalBounds(drone);
+      drone.x = clamp(drone.x, horizontalBounds.minX, horizontalBounds.maxX);
+      drone.y = clamp(drone.y, yBounds.minY, yBounds.maxY);
+      resolveFollowerAwayFromPlayer(drone, player, 1);
       drone.x = clamp(drone.x, horizontalBounds.minX, horizontalBounds.maxX);
       drone.y = clamp(drone.y, yBounds.minY, yBounds.maxY);
       updateEnemyAnimation(drone, dt);


### PR DESCRIPTION
### Motivation
- Companions (including Scarlett’s bramble drone) could nudge or push the player if their movement collided with the player, which should never happen. 
- The intent is to ensure followers never move the player while preserving existing enemy↔player collision behavior.

### Description
- Added reusable overlap math `getBodyOverlapSeparation(mover, blocker)` to compute dx/dy and overlap extents without applying movement. 
- Kept the existing strength-weighted resolver as `resolveCharacterBodyCollision(mover, blocker, weight)` for enemy↔player interactions. 
- Added `resolveFollowerAwayFromPlayer(follower, player, weight)` and switched companion/drone collision handling to call it so followers are pushed away instead of moving the player. 
- Applied follower-only separation after companion and Scarlett drone movement/clamping so followers cannot visually shove the player during their own update steps.

### Testing
- Ran a syntax check on the extracted game script with `node --check /tmp/bayou-brawlers-main.js`, which completed without errors. 
- Ran the test suite with `npm test -- --runInBand`, and all Jest suites passed (`3 passed`). 
- Ran `git diff --check` to validate whitespace/patch issues with no failures reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26f2f224088329afda5381158f8dcb)