### PR TITLE
Add seed-bomb visuals and delayed bloom for Bayou Briar attack

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -3491,7 +3491,7 @@
       const nearExistingPatch = state.hazards.some(h => h.kind === 'briar-support-patch'
         && Math.abs(h.x - x) < ((h.w + width) * 0.45)
         && Math.abs(h.y - y) < ((h.h + height) * 0.45));
-      if (nearExistingPatch) return;
+      if (nearExistingPatch) return false;
       state.hazards.push({
         kind: 'briar-support-patch',
         x,
@@ -3506,6 +3506,30 @@
         damageInterval: 42,
         palette: Math.random() < 0.5 ? 'yellow' : 'green',
         phase: Math.random() * Math.PI * 2
+      });
+      return true;
+    }
+
+    function throwBriarSeedBomb(enemy, targetX, targetY) {
+      const startX = enemy.x + (enemy.facing || 1) * 22;
+      const startY = enemy.y - 58;
+      const distance = Math.hypot(targetX - startX, targetY - startY);
+      const duration = clamp(Math.round(distance / 12), 24, 38);
+      state.effects.push({
+        type: 'briar-seed-bomb',
+        startX,
+        startY,
+        targetX,
+        targetY,
+        x: startX,
+        y: startY,
+        timer: duration,
+        maxTimer: duration,
+        arcHeight: clamp(distance * 0.26, 42, 96),
+        spin: rand(-0.24, 0.24),
+        rotation: Math.random() * Math.PI * 2,
+        seedSize: rand(5.5, 7.5),
+        trailPhase: Math.random() * Math.PI * 2
       });
     }
 
@@ -6202,10 +6226,10 @@
             const targetYBounds = getPlayerVerticalBounds(player);
             const targetX = clamp(predictedX + rand(-38, 38), state.cameraX + 40, state.cameraX + canvas.width - 40);
             const targetY = clamp(predictedY + rand(-30, 30), targetYBounds.minY + 4, targetYBounds.maxY + 4);
-            spawnBriarSupportPatch(targetX, targetY);
+            throwBriarSeedBomb(enemy, targetX, targetY);
             if (Math.random() < 0.45) {
               const offsetX = rand(54, 96) * (Math.sign(leadX) || -(player.facing || 1));
-              spawnBriarSupportPatch(clamp(targetX + offsetX, state.cameraX + 40, state.cameraX + canvas.width - 40), clamp(targetY + rand(-20, 20), targetYBounds.minY + 4, targetYBounds.maxY + 4));
+              throwBriarSeedBomb(enemy, clamp(targetX + offsetX, state.cameraX + 40, state.cameraX + canvas.width - 40), clamp(targetY + rand(-20, 20), targetYBounds.minY + 4, targetYBounds.maxY + 4));
             }
             enemy.cooldown = rand(60, 100);
           }
@@ -6955,6 +6979,33 @@
           effect.vy = (effect.vy || 0) * 0.9 + (effect.driftY || 0);
           effect.size += effect.growth || 0;
           effect.alpha = Math.max(0, (effect.alpha || 0) * 0.974);
+        }
+        if (effect.type === 'briar-seed-bomb') {
+          const maxTimer = Math.max(1, effect.maxTimer || 1);
+          const progress = clamp(1 - (effect.timer / maxTimer), 0, 1);
+          const arc = Math.sin(progress * Math.PI) * (effect.arcHeight || 60);
+          effect.x = (effect.startX || effect.x) + ((effect.targetX - (effect.startX || effect.x)) * progress);
+          effect.y = (effect.startY || effect.y) + ((effect.targetY - (effect.startY || effect.y)) * progress) - arc;
+          effect.rotation = (effect.rotation || 0) + (effect.spin || 0);
+          effect.trailPhase = (effect.trailPhase || 0) + 0.42;
+          if (effect.timer <= 1 && !effect.bloomed) {
+            effect.bloomed = true;
+            const bloomed = spawnBriarSupportPatch(effect.targetX, effect.targetY);
+            state.effects.push({
+              type: 'briar-seed-bloom',
+              x: effect.targetX,
+              y: effect.targetY,
+              timer: 24,
+              maxTimer: 24,
+              radius: bloomed ? rand(34, 48) : rand(18, 28),
+              petals: Array.from({ length: 9 }, (_, index) => ({
+                angle: (Math.PI * 2 * index / 9) + rand(-0.18, 0.18),
+                length: rand(16, 32),
+                width: rand(3, 6),
+                curl: rand(-0.28, 0.28)
+              }))
+            });
+          }
         }
         if (effect.type === 'rustbucket-shrapnel-burst') {
           const groundY = effect.groundY || BRAWL_LANE_MAX_Y - 4;
@@ -8664,6 +8715,96 @@
             ctx.lineTo(p3x, p3y);
             ctx.closePath();
             ctx.fill();
+          });
+          ctx.restore();
+        }
+        if (effect.type === 'briar-seed-bomb') {
+          const maxTimer = Math.max(1, effect.maxTimer || 1);
+          const progress = clamp(1 - (effect.timer / maxTimer), 0, 1);
+          const screenX = effect.x - state.cameraX;
+          const screenY = effect.y - state.cameraY;
+          const targetScreenX = effect.targetX - state.cameraX;
+          const targetScreenY = effect.targetY - state.cameraY;
+          const seedSize = effect.seedSize || 6;
+          const shadowAlpha = 0.18 + progress * 0.2;
+          ctx.save();
+          ctx.fillStyle = `rgba(28, 48, 24, ${shadowAlpha})`;
+          ctx.beginPath();
+          ctx.ellipse(targetScreenX, targetScreenY + 2, 13 + progress * 10, 4 + progress * 3, 0, 0, Math.PI * 2);
+          ctx.fill();
+
+          ctx.globalCompositeOperation = 'lighter';
+          for (let i = 0; i < 4; i += 1) {
+            const trailProgress = clamp(progress - i * 0.035, 0, 1);
+            const trailArc = Math.sin(trailProgress * Math.PI) * (effect.arcHeight || 60);
+            const trailX = (effect.startX || effect.x) + ((effect.targetX - (effect.startX || effect.x)) * trailProgress) - state.cameraX;
+            const trailY = (effect.startY || effect.y) + ((effect.targetY - (effect.startY || effect.y)) * trailProgress) - trailArc - state.cameraY;
+            const alpha = 0.24 * (1 - i / 4);
+            ctx.fillStyle = `rgba(136, 255, 125, ${alpha})`;
+            ctx.beginPath();
+            ctx.arc(trailX, trailY, Math.max(1.5, seedSize - i * 1.2), 0, Math.PI * 2);
+            ctx.fill();
+          }
+
+          const glow = ctx.createRadialGradient(screenX, screenY, 1, screenX, screenY, seedSize * 3.4);
+          glow.addColorStop(0, 'rgba(220, 255, 158, 0.95)');
+          glow.addColorStop(0.42, 'rgba(84, 255, 111, 0.68)');
+          glow.addColorStop(1, 'rgba(44, 185, 69, 0)');
+          ctx.fillStyle = glow;
+          ctx.beginPath();
+          ctx.arc(screenX, screenY, seedSize * 3.4, 0, Math.PI * 2);
+          ctx.fill();
+
+          ctx.globalCompositeOperation = 'source-over';
+          ctx.translate(screenX, screenY);
+          ctx.rotate(effect.rotation || 0);
+          ctx.fillStyle = 'rgba(83, 142, 45, 0.96)';
+          ctx.beginPath();
+          ctx.ellipse(0, 0, seedSize * 1.1, seedSize * 0.78, 0, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.strokeStyle = 'rgba(203, 255, 153, 0.9)';
+          ctx.lineWidth = 1.3;
+          ctx.beginPath();
+          ctx.arc(seedSize * 0.12, -seedSize * 0.1, seedSize * 0.62, 0.2, Math.PI * 1.35);
+          ctx.stroke();
+          ctx.restore();
+        }
+        if (effect.type === 'briar-seed-bloom') {
+          const maxTimer = Math.max(1, effect.maxTimer || 24);
+          const progress = clamp(1 - (effect.timer / maxTimer), 0, 1);
+          const lifePct = clamp(effect.timer / maxTimer, 0, 1);
+          const screenX = effect.x - state.cameraX;
+          const screenY = effect.y - state.cameraY;
+          const radius = (effect.radius || 38) * (0.45 + progress * 0.9);
+          ctx.save();
+          ctx.globalCompositeOperation = 'lighter';
+          const bloomGlow = ctx.createRadialGradient(screenX, screenY, 1, screenX, screenY, radius * 1.45);
+          bloomGlow.addColorStop(0, `rgba(222, 255, 152, ${0.62 * lifePct})`);
+          bloomGlow.addColorStop(0.52, `rgba(89, 245, 105, ${0.44 * lifePct})`);
+          bloomGlow.addColorStop(1, 'rgba(42, 180, 72, 0)');
+          ctx.fillStyle = bloomGlow;
+          ctx.beginPath();
+          ctx.ellipse(screenX, screenY, radius * 1.2, radius * 0.48, 0, 0, Math.PI * 2);
+          ctx.fill();
+
+          ctx.strokeStyle = `rgba(193, 255, 176, ${0.78 * lifePct})`;
+          ctx.lineWidth = 2;
+          ctx.beginPath();
+          ctx.ellipse(screenX, screenY, radius, radius * 0.38, 0, 0, Math.PI * 2);
+          ctx.stroke();
+
+          (effect.petals || []).forEach(petal => {
+            const petalLength = petal.length * (0.35 + progress * 0.85);
+            const petalX = screenX + Math.cos(petal.angle) * petalLength;
+            const petalY = screenY + Math.sin(petal.angle) * petalLength * 0.45;
+            ctx.save();
+            ctx.translate(petalX, petalY);
+            ctx.rotate(petal.angle + (petal.curl || 0) * progress);
+            ctx.fillStyle = `rgba(126, 255, 118, ${0.56 * lifePct})`;
+            ctx.beginPath();
+            ctx.ellipse(0, 0, petal.width * 1.8, petal.width * 0.72, 0, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
           });
           ctx.restore();
         }


### PR DESCRIPTION
### Motivation
- Make the Bayou Briar attack more readable by giving its support-patch spawn a visible telegraph (arcing seed bombs) instead of instant hazard placement. 
- Improve feedback so players can react to incoming briar hazards before they appear. 
- Keep existing hazard behavior but delay creation until after the visual bloom lands.

### Description
- Change `spawnBriarSupportPatch` to return a boolean indicating whether a patch was spawned and early-return `false` when a nearby patch blocks placement. 
- Add `throwBriarSeedBomb(enemy, targetX, targetY)` which enqueues a `briar-seed-bomb` effect with arc, travel duration, rotation and trail metadata. 
- Replace immediate `spawnBriarSupportPatch(...)` calls in the `bayouBriar` attack logic with `throwBriarSeedBomb(...)` so the hazard is created only after the seed bomb lands. 
- Add `updateEffects` handling for `briar-seed-bomb` (arc motion, bloom trigger that calls `spawnBriarSupportPatch`) and add drawing code for both `briar-seed-bomb` and `briar-seed-bloom` to render shadows, glowing trails, seed sprite and bloom visuals.

### Testing
- Verified inline script parsing with a `node` parse check which succeeded. 
- Ran unit tests via `npm test -- --runInBand` and all test suites passed. 
- Attempted to install Chromium via Playwright for automated visual verification, but the browser download failed in this environment (`ERR_SOCKET_CLOSED`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27043958b4832989f6adc7c73ca963)