### PR TITLE
Add Delving Daphodilus geyser explosions

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -8468,7 +8468,7 @@
           return;
         }
         if (hazard.kind === 'delving-geyser') {
-          const sprite = getHazardAnimationFrame(hazard, 'delvingGeyser', 14, false);
+          const sprite = getHazardAnimationFrame(hazard, 'geyser', 14, false);
           const agePct = clamp((hazard.animAge || 0) / Math.max(1, hazard.maxFrames || DELVING_GEYSER_DURATION_FRAMES), 0, 1);
           const pulse = 1 - agePct;
           ctx.save();
@@ -9985,7 +9985,6 @@
         mosquitoAttack: ['assets/BB_hazard_animation_mosquitos_attack.png', 6],
         mosquitoKilled: ['assets/BB_hazard_animation_mosquitos_killed.png', 6],
         geyser: ['assets/BB_hazard_animation_geyser.png', 6],
-        delvingGeyser: ['assets/BB_hazard_geyser.png', 6],
         branch1: ['assets/BB_hazard_branch001.png', 1],
         branch2: ['assets/BB_hazard_branch002.png', 1],
         branch3: ['assets/BB_hazard_branch003.png', 1],

--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1843,6 +1843,9 @@
     const BRANCH_TRIGGER_Y_RADIUS = 118;
     const GEYSER_TRIGGER_RADIUS = 118;
     const GEYSER_DAMAGE_RADIUS = 72;
+    const DELVING_GEYSER_DAMAGE_RADIUS = 66;
+    const DELVING_GEYSER_DURATION_FRAMES = 48;
+    const DELVING_GEYSER_DAMAGE_FRAME = 12;
     const MECHANIZED_MOMENTUM_MAX_STACKS = 12;
     const MECHANIZED_MOMENTUM_STACK_MULTIPLIER = 0.03;
     const MECHANIZED_MOMENTUM_DURATION_FRAMES = 120;
@@ -3482,6 +3485,23 @@
         h: height,
         frames: Number.POSITIVE_INFINITY
       });
+    }
+
+
+    function spawnDelvingGeyserExplosion(x, y) {
+      state.hazards.push({
+        kind: 'delving-geyser',
+        x,
+        y,
+        w: DELVING_GEYSER_DAMAGE_RADIUS * 2,
+        h: DELVING_GEYSER_DAMAGE_RADIUS,
+        frames: DELVING_GEYSER_DURATION_FRAMES,
+        maxFrames: DELVING_GEYSER_DURATION_FRAMES,
+        damageFrame: DELVING_GEYSER_DAMAGE_FRAME,
+        damagedPlayer: false,
+        animAge: 0
+      });
+      state.shake = Math.max(state.shake, 5);
     }
 
 
@@ -6158,6 +6178,7 @@
               if (Math.abs(enemy.x - player.x) < 40) {
                 enemy.x += enemy.facing >= 0 ? 40 : -40;
               }
+              spawnDelvingGeyserExplosion(enemy.x, enemy.y);
               setEnemyState(enemy, 'Emerge');
             }
           } else if (enemy.aiState === 'Emerge') {
@@ -6191,6 +6212,7 @@
               }
               const verticalBounds = getEnemyVerticalBounds(enemy);
               enemy.targetY = clamp(player.y + rand(-18, 18), verticalBounds.minY, verticalBounds.maxY);
+              spawnDelvingGeyserExplosion(enemy.x, enemy.y);
             } else if ((distance <= enemy.range || rectsOverlap(enemyBody, playerBody)) && enemy.cooldown <= 0 && enemy.windup <= 0) {
               enemy.windup = 10;
               enemy.attackAnimTimer = 14;
@@ -6586,7 +6608,7 @@
         const player = state.player;
         if (!player) return;
         const overlap = Math.abs(player.x - h.x) < h.w * 0.5 && Math.abs(player.y - h.y) < h.h * 0.5;
-        if (h.kind && h.kind.startsWith('swamp-')) {
+        if (h.kind && (h.kind.startsWith('swamp-') || h.kind === 'delving-geyser')) {
           h.animAge = (h.animAge || 0) + 1;
         }
         if (h.kind === 'swamp-alligator') {
@@ -6693,6 +6715,21 @@
               h.state = 'primed';
               h.cooldown = rand(190, 330);
             }
+          }
+        }
+
+        if (h.kind === 'delving-geyser') {
+          const elapsed = (h.maxFrames || DELVING_GEYSER_DURATION_FRAMES) - h.frames;
+          const dist = Math.hypot(player.x - h.x, player.y - h.y);
+          if (!h.damagedPlayer && elapsed >= (h.damageFrame || DELVING_GEYSER_DAMAGE_FRAME) && dist <= DELVING_GEYSER_DAMAGE_RADIUS) {
+            damagePlayer(SWAMP_HAZARD_ENEMY_HIT_DAMAGE, null);
+            const angle = Math.atan2(player.y - h.y, player.x - h.x) || (Math.random() * Math.PI * 2);
+            player.x = clamp(player.x + Math.cos(angle) * rand(30, 58), 24, getWaveBarrierPlayerMaxX() - 20);
+            player.y = clamp(player.y + Math.sin(angle) * rand(14, 32), getBrawlLaneMinY(), BRAWL_LANE_MAX_Y);
+            player.z = Math.max(player.z || 0, 10);
+            player.vz = Math.max(player.vz || 0, 3.8);
+            h.damagedPlayer = true;
+            state.shake = Math.max(state.shake, 10);
           }
         }
 
@@ -8430,6 +8467,20 @@
           }
           return;
         }
+        if (hazard.kind === 'delving-geyser') {
+          const sprite = getHazardAnimationFrame(hazard, 'delvingGeyser', 14, false);
+          const agePct = clamp((hazard.animAge || 0) / Math.max(1, hazard.maxFrames || DELVING_GEYSER_DURATION_FRAMES), 0, 1);
+          const pulse = 1 - agePct;
+          ctx.save();
+          ctx.globalCompositeOperation = 'lighter';
+          ctx.fillStyle = `rgba(108, 72, 44, ${0.26 * pulse})`;
+          ctx.beginPath();
+          ctx.ellipse(x, y + 4, 58 + pulse * 18, 19 + pulse * 8, 0, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.restore();
+          if (sprite) ctx.drawImage(sprite.img, sprite.frame.x, sprite.frame.y, sprite.frame.width, sprite.frame.height, x - 82, y - 132, 164, 164);
+          return;
+        }
         if (hazard.kind === 'mud-trail') {
           ctx.fillStyle = 'rgba(109, 74, 51, 0.34)';
           ctx.beginPath();
@@ -9934,6 +9985,7 @@
         mosquitoAttack: ['assets/BB_hazard_animation_mosquitos_attack.png', 6],
         mosquitoKilled: ['assets/BB_hazard_animation_mosquitos_killed.png', 6],
         geyser: ['assets/BB_hazard_animation_geyser.png', 6],
+        delvingGeyser: ['assets/BB_hazard_geyser.png', 6],
         branch1: ['assets/BB_hazard_branch001.png', 1],
         branch2: ['assets/BB_hazard_branch002.png', 1],
         branch3: ['assets/BB_hazard_branch003.png', 1],


### PR DESCRIPTION
### Motivation
- Make the Delving Daphodilus enemy produce mud geyser explosions both where it dives and where it erupts, to match design intent and add additional environmental hazard telegraphing and gameplay impact.

### Description
- Added new constants (`DELVING_GEYSER_DAMAGE_RADIUS`, `DELVING_GEYSER_DURATION_FRAMES`, `DELVING_GEYSER_DAMAGE_FRAME`) and a helper `spawnDelvingGeyserExplosion(x,y)` to create short-lived `delving-geyser` hazards in `bayou-brawlers/index.html`.
- Triggered `spawnDelvingGeyserExplosion` when a Daphodilus goes underground and when it repositions to emerge so explosions occur at both dive and arrival locations.
- Implemented update logic for `delving-geyser` hazards to apply a one-time hit/knock-up to the player during the explosion and to advance `animAge` alongside existing swamp hazards.
- Wired rendering for the new hazard to use the existing `assets/BB_hazard_geyser.png` animation by adding a `delvingGeyser` hazard asset key and a custom draw path that reuses the existing animation frames.

### Testing
- Ran `npm test -- --runInBand` and all test suites passed (3 test suites, 6 tests total).
- Verified game code lint/consistency via a diff/check during development with no flagged issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a277c7d138083299936c2a520f667f9)