### PR TITLE
Fix bayou geyser animation timing

### DIFF
--- a/bayou-brawlers/index.html
+++ b/bayou-brawlers/index.html
@@ -1844,6 +1844,7 @@
     const GEYSER_TRIGGER_RADIUS = 118;
     const GEYSER_DAMAGE_RADIUS = 72;
     const GEYSER_DAMAGE_AMOUNT = SWAMP_HAZARD_ENEMY_HIT_DAMAGE;
+    const GEYSER_ERUPT_DURATION_FRAMES = 54;
     const DELVING_GEYSER_DAMAGE_RADIUS = GEYSER_DAMAGE_RADIUS;
     const DELVING_GEYSER_DAMAGE_AMOUNT = GEYSER_DAMAGE_AMOUNT;
     const DELVING_GEYSER_DURATION_FRAMES = 48;
@@ -3447,6 +3448,15 @@
       let frameIndex = Math.floor((frameAge / 60) * fps);
       if (loop) frameIndex %= track.frames.length;
       else frameIndex = clamp(frameIndex, 0, track.frames.length - 1);
+      return { img: track.img, frame: track.frames[frameIndex] || track.frames[0] };
+    }
+
+    function getHazardAnimationFrameForDuration(hazard, assetKey, durationFrames) {
+      const track = assets.hazards[assetKey];
+      if (!track || !track.frames?.length) return null;
+      const frameAge = Math.max(0, hazard.animAge || 0);
+      const duration = Math.max(1, durationFrames || track.frames.length);
+      const frameIndex = clamp(Math.floor((frameAge / duration) * track.frames.length), 0, track.frames.length - 1);
       return { img: track.img, frame: track.frames[frameIndex] || track.frames[0] };
     }
 
@@ -6703,11 +6713,12 @@
           const dist = Math.hypot(player.x - h.x, player.y - h.y);
           if (h.state === 'primed' && h.cooldown <= 0 && dist <= GEYSER_TRIGGER_RADIUS) {
             h.state = 'erupting';
-            h.eruptTimer = 54;
+            h.eruptTimer = GEYSER_ERUPT_DURATION_FRAMES;
+            h.eruptDuration = GEYSER_ERUPT_DURATION_FRAMES;
             h.damagedPlayer = false;
             h.animAge = 0;
           } else if (h.state === 'erupting') {
-            const elapsed = 54 - h.eruptTimer;
+            const elapsed = (h.eruptDuration || GEYSER_ERUPT_DURATION_FRAMES) - h.eruptTimer;
             if (!h.damagedPlayer && elapsed >= h.damageFrame && dist <= GEYSER_DAMAGE_RADIUS) {
               damagePlayer(GEYSER_DAMAGE_AMOUNT, null);
               const angle = Math.random() * Math.PI * 2;
@@ -8457,7 +8468,7 @@
         if (hazard.kind === 'swamp-geyser') {
           const pulse = 0.5 + (Math.sin((hazard.animAge || 0) * 0.22) * 0.5);
           if (hazard.state === 'erupting') {
-            const sprite = getHazardAnimationFrame(hazard, 'geyser', 14, false);
+            const sprite = getHazardAnimationFrameForDuration(hazard, 'geyser', hazard.eruptDuration || GEYSER_ERUPT_DURATION_FRAMES);
             ctx.save();
             ctx.globalCompositeOperation = 'lighter';
             ctx.fillStyle = 'rgba(255, 215, 97, 0.28)';
@@ -8476,7 +8487,7 @@
           return;
         }
         if (hazard.kind === 'delving-geyser') {
-          const sprite = getHazardAnimationFrame(hazard, 'geyser', 14, false);
+          const sprite = getHazardAnimationFrameForDuration(hazard, 'geyser', hazard.maxFrames || DELVING_GEYSER_DURATION_FRAMES);
           const agePct = clamp((hazard.animAge || 0) / Math.max(1, hazard.maxFrames || DELVING_GEYSER_DURATION_FRAMES), 0, 1);
           const pulse = 1 - agePct;
           ctx.save();


### PR DESCRIPTION
### Motivation
- The geyser animation lingered on its last frame because frame selection used a fixed FPS mapping instead of the hazard's actual eruption lifetime.

### Description
- Added a `GEYSER_ERUPT_DURATION_FRAMES` constant and stored per-hazard `eruptDuration` for swamp geysers to represent the eruption lifetime.
- Added `getHazardAnimationFrameForDuration(hazard, assetKey, durationFrames)` which maps `hazard.animAge` to frames evenly across a supplied duration.
- Switched swamp geyser rendering to use the duration-based frame selector and updated delving geyser rendering to also use the duration-aware selector.
- All changes are in `bayou-brawlers/index.html` and ensure frames are distributed evenly over the hazard's active frames.

### Testing
- Ran unit tests with `npm test -- --runInBand` and all test suites passed.
- Executed a script that parsed and evaluated inline scripts in `bayou-brawlers/index.html` with `node` to validate no runtime parse errors and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2884430188832986076a8325f28f82)